### PR TITLE
feat(create-wdio): migrate to @wdio/electron-service and add Tauri service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ tests/.retry_succeeded
 website/docs/Contribute.md
 website/community/Resources.md
 website/docs/desktop-testing/electron/
+website/docs/desktop-testing/tauri/
 scripts/bidi/cddl
 browserstack.err
 e2e/tailwind.config.js

--- a/packages/create-wdio/src/cli/utils.ts
+++ b/packages/create-wdio/src/cli/utils.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import fs from 'node:fs/promises'
 import inquirer from 'inquirer'
-import { configHelperSuccessMessage, CONFIG_HELPER_SERENITY_BANNER, SUPPORTED_CONFIG_FILE_EXTENSION, CONFIG_HELPER_INTRO, isNuxtProject, SUPPORTED_PACKAGES } from '../constants.js'
+import { buildTauriBanner, configHelperSuccessMessage, CONFIG_HELPER_SERENITY_BANNER, SUPPORTED_CONFIG_FILE_EXTENSION, CONFIG_HELPER_INTRO, getResolvedPurpose, isNuxtProject, SUPPORTED_PACKAGES } from '../constants.js'
 import type { ParsedAnswers } from '../types.js'
 import { createPackageJSON, setupTypeScript, npmInstall, createWDIOConfig, createWDIOScript, runAppiumInstaller, convertPackageHashToObject, getAnswers, getPathForFileGeneration, getProjectProps, getProjectRoot, getSerenityPackages } from '../utils.js'
 
@@ -17,11 +17,21 @@ export async function runConfigCommand(parsedAnswers: ParsedAnswers, npmTag: str
     /**
      * print success message
      */
+    const extraInfoParts: string[] = []
+    if (parsedAnswers.serenityAdapter) {
+        extraInfoParts.push(CONFIG_HELPER_SERENITY_BANNER)
+    }
+    if (parsedAnswers.purpose === 'tauri') {
+        extraInfoParts.push(buildTauriBanner(
+            parsedAnswers.rawAnswers.tauriDriverProvider,
+            parsedAnswers.rawAnswers.tauriUseFrontendPlugin
+        ))
+    }
     console.log(
         configHelperSuccessMessage({
             projectRootDir: parsedAnswers.projectRootDir,
             runScript: parsedAnswers.serenityAdapter ? 'serenity' : 'wdio',
-            extraInfo: parsedAnswers.serenityAdapter ? CONFIG_HELPER_SERENITY_BANNER : ''
+            extraInfo: extraInfoParts.join('\n')
         }),
     )
 
@@ -132,7 +142,7 @@ export const parseAnswers = async function (yes: boolean): Promise<ParsedAnswers
         runner: runnerPackage.short as 'local' | 'browser',
         preset: presetPackage.short,
         framework: frameworkPackage.short,
-        purpose: runnerPackage.purpose,
+        purpose: getResolvedPurpose(answers),
         serenityAdapter: frameworkPackage.package === '@serenity-js/webdriverio' && frameworkPackage.purpose,
         reporters: reporterPackages.map(({ short }) => short),
         plugins: pluginPackages.map(({ short }) => short),

--- a/packages/create-wdio/src/constants.ts
+++ b/packages/create-wdio/src/constants.ts
@@ -112,8 +112,7 @@ export const SUPPORTED_PACKAGES = {
     runner: [
         { name: 'E2E Testing - of Web or Mobile Applications', value: '@wdio/local-runner$--$local$--$e2e' },
         { name: 'Component or Unit Testing - in the browser\n    > https://webdriver.io/docs/component-testing', value: '@wdio/browser-runner$--$browser$--$component' },
-        { name: 'Desktop Testing - of Electron Applications\n    > https://webdriver.io/docs/desktop-testing/electron', value: '@wdio/local-runner$--$local$--$electron' },
-        { name: 'Desktop Testing - of MacOS Applications\n    > https://webdriver.io/docs/desktop-testing/macos', value: '@wdio/local-runner$--$local$--$macos' },
+        { name: 'Desktop Testing - of Electron, Tauri, or macOS Applications\n    > https://webdriver.io/docs/desktop-testing', value: '@wdio/local-runner$--$local$--$desktop' },
         { name: 'VS Code Extension Testing\n    > https://webdriver.io/docs/vscode-extension-testing', value: '@wdio/local-runner$--$local$--$vscode' },
         { name: 'Roku Testing - of OTT apps running on RokuOS\n    > https://webdriver.io/docs/wdio-roku-service', value: '@wdio/local-runner$--$local$--$roku' }
     ],
@@ -164,7 +163,9 @@ export const SUPPORTED_PACKAGES = {
         { name: 'browserstack', value: '@wdio/browserstack-service$--$browserstack' },
         { name: 'lighthouse', value: '@wdio/lighthouse-service$--$lighthouse' },
         { name: 'vscode', value: 'wdio-vscode-service$--$vscode' },
-        { name: 'electron', value: 'wdio-electron-service$--$electron' },
+        { name: 'electron', value: '@wdio/electron-service$--$electron' },
+        { name: 'tauri', value: '@wdio/tauri-service$--$tauri' },
+        { name: 'tauri-plugin', value: '@wdio/tauri-plugin$--$tauri-plugin' },
         { name: 'appium', value: '@wdio/appium-service$--$appium' },
         // external
         { name: 'camera', value: 'wdio-camera-service$--$camera' },
@@ -239,6 +240,66 @@ export function usesSerenity (answers: Questionnair) {
     return answers.framework.includes('serenity-js')
 }
 
+/**
+ * Build the post-install instructions for Tauri users. The npm side is auto-installed,
+ * but the Rust side (Cargo.toml + plugin registration) needs manual edits.
+ */
+export function buildTauriBanner (
+    driverProvider: TauriDriverProviderChoice | undefined,
+    useFrontendPlugin: boolean | undefined
+) {
+    const lines = [
+        '',
+        '🦀 Tauri requires a couple of Rust-side additions before tests can run:',
+        ''
+    ]
+
+    if (driverProvider === TauriDriverProviderChoice.Embedded) {
+        lines.push(
+            '  1. Add the embedded WebDriver crate to `src-tauri/Cargo.toml`:',
+            '',
+            '       [dependencies]',
+            '       tauri-plugin-wdio-webdriver = "1"',
+            '',
+            '  2. Register the plugin in `src-tauri/src/lib.rs`:',
+            '',
+            '       tauri::Builder::default()',
+            '           .plugin(tauri_plugin_wdio_webdriver::init())',
+            '           // ...',
+            ''
+        )
+    } else if (driverProvider === TauriDriverProviderChoice.Official) {
+        lines.push(
+            '  1. Install the official tauri-driver via Cargo:',
+            '',
+            '       cargo install tauri-driver --locked',
+            '',
+            '  2. On Linux, set `WEBKIT_DISABLE_DMABUF_RENDERER=1` in your shell when running tests.',
+            ''
+        )
+    } else if (driverProvider === TauriDriverProviderChoice.CrabNebula) {
+        lines.push(
+            '  1. Follow the CrabNebula tauri-driver setup guide:',
+            '       🔗 https://crabnebula.dev/docs/tauri-driver',
+            ''
+        )
+    }
+
+    if (useFrontendPlugin) {
+        lines.push(
+            '  Frontend plugin (@wdio/tauri-plugin) was added to your npm dependencies.',
+            '  See https://webdriver.io/docs/desktop-testing/tauri/plugin-setup for wiring instructions.',
+            ''
+        )
+    }
+
+    lines.push(
+        'Full Tauri setup docs:',
+        '  🔗 https://webdriver.io/docs/desktop-testing/tauri'
+    )
+    return lines.join('\n')
+}
+
 enum ProtocolOptions {
     HTTPS = 'https',
     HTTP = 'http'
@@ -263,6 +324,18 @@ export enum ElectronBuildToolChoice {
     SomethingElse = 'Something else'
 }
 
+export enum DesktopFrameworkChoice {
+    Electron = 'Electron (https://www.electronjs.org/)',
+    Tauri = 'Tauri (https://tauri.app/)',
+    MacOS = 'Native macOS app'
+}
+
+export enum TauriDriverProviderChoice {
+    Official = 'Official tauri-driver (cross-platform, Cargo-installed)',
+    CrabNebula = 'CrabNebula tauri-driver (managed cloud / drop-in)',
+    Embedded = 'Embedded driver via tauri-plugin-wdio-webdriver crate'
+}
+
 export const SUPPORTED_BROWSER_RUNNER_PRESETS = [
     { name: 'Lit (https://lit.dev/)', value: '$--$' },
     { name: 'Vue.js (https://vuejs.org/)', value: '@vitejs/plugin-vue$--$vue' },
@@ -278,7 +351,20 @@ function isBrowserRunner (answers: Questionnair) {
     return answers.runner === SUPPORTED_PACKAGES.runner[1].value
 }
 function getTestingPurpose (answers: Questionnair) {
-    return convertPackageHashToObject(answers.runner).purpose as 'e2e' | 'electron' | 'component' | 'vscode' | 'macos' | 'roku'
+    return convertPackageHashToObject(answers.runner).purpose as 'e2e' | 'electron' | 'tauri' | 'component' | 'vscode' | 'macos' | 'desktop' | 'roku'
+}
+export function getResolvedPurpose (answers: Questionnair) {
+    const raw = getTestingPurpose(answers)
+    if (raw !== 'desktop') {
+        return raw
+    }
+    switch (answers.desktopFramework) {
+    case DesktopFrameworkChoice.Tauri: return 'tauri'
+    case DesktopFrameworkChoice.MacOS: return 'macos'
+    case DesktopFrameworkChoice.Electron:
+    default:
+        return 'electron'
+    }
 }
 
 export const TESTING_LIBRARY_PACKAGES: Record<string, string> = {
@@ -351,15 +437,38 @@ export const QUESTIONNAIRE = [{
     )
 }, {
     type: 'list',
+    name: 'desktopFramework',
+    message: 'What type of desktop application are you testing?',
+    choices: Object.values(DesktopFrameworkChoice),
+    when: /* istanbul ignore next */ (answers: Questionnair) => getTestingPurpose(answers) === 'desktop'
+}, {
+    type: 'list',
     name: 'electronBuildTool',
     message: 'Which tool are you using to build your Electron app?',
     choices: Object.values(ElectronBuildToolChoice),
-    when: /* instanbul ignore next */ (answers: Questionnair) => getTestingPurpose(answers) === 'electron'
+    when: /* instanbul ignore next */ (answers: Questionnair) => getResolvedPurpose(answers) === 'electron'
 }, {
     type: 'input',
     name: 'electronAppBinaryPath',
     message: 'What is the path to the binary of your built Electron app?',
-    when: /* istanbul ignore next */ (answers: Questionnair) => getTestingPurpose(answers) === 'electron' && (answers.electronBuildTool === ElectronBuildToolChoice.SomethingElse)
+    when: /* istanbul ignore next */ (answers: Questionnair) => getResolvedPurpose(answers) === 'electron' && (answers.electronBuildTool === ElectronBuildToolChoice.SomethingElse)
+}, {
+    type: 'list',
+    name: 'tauriDriverProvider',
+    message: 'Which WebDriver provider would you like to use for Tauri?',
+    choices: Object.values(TauriDriverProviderChoice),
+    when: /* istanbul ignore next */ (answers: Questionnair) => getResolvedPurpose(answers) === 'tauri'
+}, {
+    type: 'confirm',
+    name: 'tauriUseFrontendPlugin',
+    message: 'Install @wdio/tauri-plugin for richer in-webview integration (browser.tauri.execute, mocking)?',
+    default: true,
+    when: /* istanbul ignore next */ (answers: Questionnair) => getResolvedPurpose(answers) === 'tauri'
+}, {
+    type: 'input',
+    name: 'tauriAppBinaryPath',
+    message: 'Path to your built Tauri binary (leave blank to use the default `cargo tauri build` output)?',
+    when: /* istanbul ignore next */ (answers: Questionnair) => getResolvedPurpose(answers) === 'tauri'
 }, {
     type: 'list',
     name: 'backend',
@@ -521,9 +630,9 @@ export const QUESTIONNAIRE = [{
             return SUPPORTED_PACKAGES.framework.slice(0, 1)
         }
         /**
-         * Serenity tests don't come with proper ElectronJS example files
+         * Serenity tests don't come with proper Electron or Tauri example files
          */
-        if (getTestingPurpose(answers) === 'electron') {
+        if (['electron', 'tauri'].includes(getResolvedPurpose(answers))) {
             return SUPPORTED_PACKAGES.framework.filter(
                 ({ value }) => !value.startsWith('@serenity-js')
             )
@@ -554,7 +663,7 @@ export const QUESTIONNAIRE = [{
         /**
          * we only have examples for Mocha and Jasmine
          */
-        if (['vscode', 'electron', 'macos'].includes(getTestingPurpose(answers)) && answers.framework.includes('cucumber')) {
+        if (['vscode', 'electron', 'tauri', 'macos'].includes(getResolvedPurpose(answers)) && answers.framework.includes('cucumber')) {
             return false
         }
         return true
@@ -595,7 +704,7 @@ export const QUESTIONNAIRE = [{
          * and also not needed when running VS Code tests since the service comes with
          * its own page object implementation, nor when running Electron or MacOS tests
          */
-        !['vscode', 'electron', 'macos'].includes(getTestingPurpose(answers)) &&
+        !['vscode', 'electron', 'tauri', 'macos'].includes(getResolvedPurpose(answers)) &&
         /**
          * Serenity/JS generates Lean Page Objects by default, so there's no need to ask about it
          * See https://serenity-js.org/handbook/web-testing/page-objects-pattern/
@@ -658,17 +767,23 @@ export const QUESTIONNAIRE = [{
         if (answers.e2eEnvironment === 'mobile') {
             services.push('appium')
         }
-        if (getTestingPurpose(answers) === 'e2e' && isNuxtProject) {
+        if (getResolvedPurpose(answers) === 'e2e' && isNuxtProject) {
             services.push('nuxt')
         }
 
-        if (getTestingPurpose(answers) === 'vscode') {
+        if (getResolvedPurpose(answers) === 'vscode') {
             return [SUPPORTED_PACKAGES.service.find(({ name }) => name === 'vscode')]
-        } else if (getTestingPurpose(answers) === 'electron') {
+        } else if (getResolvedPurpose(answers) === 'electron') {
             return [SUPPORTED_PACKAGES.service.find(({ name }) => name === 'electron')]
-        } else if (getTestingPurpose(answers) === 'macos') {
+        } else if (getResolvedPurpose(answers) === 'tauri') {
+            const tauriEntries = [SUPPORTED_PACKAGES.service.find(({ name }) => name === 'tauri')]
+            if (answers.tauriUseFrontendPlugin) {
+                tauriEntries.push(SUPPORTED_PACKAGES.service.find(({ name }) => name === 'tauri-plugin'))
+            }
+            return tauriEntries
+        } else if (getResolvedPurpose(answers) === 'macos') {
             return [SUPPORTED_PACKAGES.service.find(({ name }) => name === 'appium')]
-        } else if (getTestingPurpose(answers) === 'roku') {
+        } else if (getResolvedPurpose(answers) === 'roku') {
             return [SUPPORTED_PACKAGES.service.find(({ name }) => name === 'roku')]
         }
         return prioServiceOrderFor(services)
@@ -680,14 +795,19 @@ export const QUESTIONNAIRE = [{
         } else if (answers.backend === BackendChoice.Saucelabs) {
             defaultServices.push('sauce')
         }
-        if (answers.e2eEnvironment === 'mobile' || getTestingPurpose(answers) === 'macos') {
+        if (answers.e2eEnvironment === 'mobile' || getResolvedPurpose(answers) === 'macos') {
             defaultServices.push('appium')
         }
-        if (getTestingPurpose(answers) === 'vscode') {
+        if (getResolvedPurpose(answers) === 'vscode') {
             defaultServices.push('vscode')
-        } else if (getTestingPurpose(answers) === 'electron') {
+        } else if (getResolvedPurpose(answers) === 'electron') {
             defaultServices.push('electron')
-        } else if (getTestingPurpose(answers) === 'roku') {
+        } else if (getResolvedPurpose(answers) === 'tauri') {
+            defaultServices.push('tauri')
+            if (answers.tauriUseFrontendPlugin) {
+                defaultServices.push('tauri-plugin')
+            }
+        } else if (getResolvedPurpose(answers) === 'roku') {
             defaultServices.push('roku')
         }
         if (isNuxtProject) {
@@ -724,7 +844,6 @@ export const QUESTIONNAIRE = [{
 }]
 
 export const COMMUNITY_PACKAGES_WITH_TS_SUPPORT = [
-    'wdio-electron-service',
     'wdio-vscode-service',
     'wdio-nuxt-service',
     'wdio-vite-service',

--- a/packages/create-wdio/src/templates/snippets/services.ejs
+++ b/packages/create-wdio/src/templates/snippets/services.ejs
@@ -1,6 +1,18 @@
 services: [<%- answers.services.map((service) => {
     if (service === 'electron') {
         return /*js*/`'electron'`
+    } else if (service === 'tauri') {
+        const binaryLine = answers.rawAnswers.tauriAppBinaryPath
+            ? `\n            appBinaryPath: '${answers.rawAnswers.tauriAppBinaryPath}',`
+            : ''
+        return /*js*/`[
+        'tauri',
+        {${binaryLine}
+            // see https://webdriver.io/docs/desktop-testing/tauri/configuration for all options
+        }
+    ]`
+    } else if (service === 'tauri-plugin') {
+        return /*js*/`'tauri-plugin'`
     } else if (service === 'sauce' && answers.useSauceConnect) {
         return /*js*/`[
         'sauce',

--- a/packages/create-wdio/src/templates/snippets/services.ejs
+++ b/packages/create-wdio/src/templates/snippets/services.ejs
@@ -2,12 +2,19 @@ services: [<%- answers.services.map((service) => {
     if (service === 'electron') {
         return /*js*/`'electron'`
     } else if (service === 'tauri') {
+        const providerMap: Record<string, string> = {
+            'Official tauri-driver (cross-platform, Cargo-installed)': 'official',
+            'CrabNebula tauri-driver (managed cloud / drop-in)': 'crabnebula',
+            'Embedded driver via tauri-plugin-wdio-webdriver crate': 'embedded',
+        }
+        const provider = providerMap[answers.rawAnswers.tauriDriverProvider as string] ?? 'official'
         const binaryLine = answers.rawAnswers.tauriAppBinaryPath
-            ? `\n            appBinaryPath: '${answers.rawAnswers.tauriAppBinaryPath}',`
+            ? `\n            appBinaryPath: ${JSON.stringify(answers.rawAnswers.tauriAppBinaryPath)},`
             : ''
         return /*js*/`[
         'tauri',
-        {${binaryLine}
+        {
+            driverProvider: '${provider}',${binaryLine}
             // see https://webdriver.io/docs/desktop-testing/tauri/configuration for all options
         }
     ]`

--- a/packages/create-wdio/src/templates/snippets/services.ejs
+++ b/packages/create-wdio/src/templates/snippets/services.ejs
@@ -2,12 +2,12 @@ services: [<%- answers.services.map((service) => {
     if (service === 'electron') {
         return /*js*/`'electron'`
     } else if (service === 'tauri') {
-        const providerMap: Record<string, string> = {
+        const providerMap = {
             'Official tauri-driver (cross-platform, Cargo-installed)': 'official',
             'CrabNebula tauri-driver (managed cloud / drop-in)': 'crabnebula',
             'Embedded driver via tauri-plugin-wdio-webdriver crate': 'embedded',
         }
-        const provider = providerMap[answers.rawAnswers.tauriDriverProvider as string] ?? 'official'
+        const provider = providerMap[answers.rawAnswers.tauriDriverProvider] ?? 'official'
         const binaryLine = answers.rawAnswers.tauriAppBinaryPath
             ? `\n            appBinaryPath: ${JSON.stringify(answers.rawAnswers.tauriAppBinaryPath)},`
             : ''

--- a/packages/create-wdio/src/templates/wdio.conf.tpl.ejs
+++ b/packages/create-wdio/src/templates/wdio.conf.tpl.ejs
@@ -1,6 +1,10 @@
 <%
 if (answers.isUsingTypeScript && answers.purpose === 'electron') {
-    %>/// <reference types="wdio-electron-service" />
+    %>/// <reference types="@wdio/electron-service" />
+<% }
+
+if (answers.isUsingTypeScript && answers.purpose === 'tauri') {
+    %>/// <reference types="@wdio/tauri-service" />
 <% }
 
 if (answers.isUsingTypeScript && answers.serenityAdapter) {

--- a/packages/create-wdio/src/types.ts
+++ b/packages/create-wdio/src/types.ts
@@ -1,4 +1,4 @@
-import type { BackendChoice, RegionOptions, ElectronBuildToolChoice,  } from './constants.js'
+import type { BackendChoice, RegionOptions, ElectronBuildToolChoice, DesktopFrameworkChoice, TauriDriverProviderChoice } from './constants.js'
 import type { PackageJson as typeFestPackageJson } from 'type-fest'
 import type { Package as normalizePackage } from 'normalize-package-data'
 export type NormalizedPackageJson = PackageJson & normalizePackage
@@ -18,6 +18,10 @@ export interface Questionnair {
     electronAppBinaryPath?: string
     electronBuildTool?: ElectronBuildToolChoice
     electronBuilderConfigPath?: string
+    desktopFramework?: DesktopFrameworkChoice
+    tauriDriverProvider?: TauriDriverProviderChoice
+    tauriUseFrontendPlugin?: boolean
+    tauriAppBinaryPath?: string
     backend?: BackendChoice
     hostname?: string
     port?: string

--- a/packages/create-wdio/tests/__snapshots__/utils.test.ts.snap
+++ b/packages/create-wdio/tests/__snapshots__/utils.test.ts.snap
@@ -53,7 +53,7 @@ exports[`setupTypeScript 1`] = `
             "@wdio/globals/types",
             "expect-webdriverio",
             "foo",
-            "wdio-electron-service"
+            "@wdio/electron-service"
         ],
         "skipLibCheck": true,
         "noEmit": true,

--- a/packages/create-wdio/tests/constants.test.ts
+++ b/packages/create-wdio/tests/constants.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 
 import { convertPackageHashToObject } from '../src/utils.js'
-import { SUPPORTED_PACKAGES } from '../src/constants.js'
+import { buildTauriBanner, getResolvedPurpose, SUPPORTED_PACKAGES, DesktopFrameworkChoice, TauriDriverProviderChoice } from '../src/constants.js'
 
 const supportedInstallations = [
     ...SUPPORTED_PACKAGES.runner.map(({ value }) => convertPackageHashToObject(value)),
@@ -16,6 +16,61 @@ describe('constants', () => {
         it('should provide all a short name', () => {
             const pluginsWithoutShorts = supportedInstallations.filter((plugin) => !plugin.short)
             expect(pluginsWithoutShorts).toHaveLength(0)
+        })
+    })
+
+    describe('desktop testing runner', () => {
+        const runnerEntry = SUPPORTED_PACKAGES.runner.find(
+            ({ value }) => convertPackageHashToObject(value).purpose === 'desktop'
+        )
+        const desktopAnswers = (framework?: DesktopFrameworkChoice) => ({
+            runner: runnerEntry!.value,
+            desktopFramework: framework
+        }) as any
+
+        it('exposes a single Desktop Testing entry', () => {
+            expect(runnerEntry).toBeTruthy()
+            const desktopRunners = SUPPORTED_PACKAGES.runner.filter(
+                ({ value }) => ['electron', 'macos'].includes(convertPackageHashToObject(value).purpose)
+            )
+            expect(desktopRunners).toHaveLength(0)
+        })
+
+        it('uses the new scoped @wdio/electron-service package', () => {
+            const electron = SUPPORTED_PACKAGES.service.find(({ name }) => name === 'electron')!
+            expect(convertPackageHashToObject(electron.value).package).toBe('@wdio/electron-service')
+        })
+
+        it('exposes @wdio/tauri-service and @wdio/tauri-plugin', () => {
+            const tauri = SUPPORTED_PACKAGES.service.find(({ name }) => name === 'tauri')!
+            const tauriPlugin = SUPPORTED_PACKAGES.service.find(({ name }) => name === 'tauri-plugin')!
+            expect(convertPackageHashToObject(tauri.value).package).toBe('@wdio/tauri-service')
+            expect(convertPackageHashToObject(tauriPlugin.value).package).toBe('@wdio/tauri-plugin')
+        })
+
+        it('resolves the desktop sub-question into a concrete purpose', () => {
+            expect(getResolvedPurpose(desktopAnswers(DesktopFrameworkChoice.Electron))).toBe('electron')
+            expect(getResolvedPurpose(desktopAnswers(DesktopFrameworkChoice.Tauri))).toBe('tauri')
+            expect(getResolvedPurpose(desktopAnswers(DesktopFrameworkChoice.MacOS))).toBe('macos')
+            expect(getResolvedPurpose(desktopAnswers())).toBe('electron')
+        })
+    })
+
+    describe('buildTauriBanner', () => {
+        it('emits Cargo crate instructions for the embedded driver', () => {
+            const banner = buildTauriBanner(TauriDriverProviderChoice.Embedded, false)
+            expect(banner).toContain('tauri-plugin-wdio-webdriver = "1"')
+            expect(banner).toContain('Register the plugin')
+        })
+
+        it('emits cargo install instructions for the official driver', () => {
+            const banner = buildTauriBanner(TauriDriverProviderChoice.Official, false)
+            expect(banner).toContain('cargo install tauri-driver')
+        })
+
+        it('appends frontend-plugin guidance when selected', () => {
+            const banner = buildTauriBanner(TauriDriverProviderChoice.Embedded, true)
+            expect(banner).toContain('@wdio/tauri-plugin')
         })
     })
 })

--- a/packages/create-wdio/tests/utils.test.ts
+++ b/packages/create-wdio/tests/utils.test.ts
@@ -624,7 +624,7 @@ test('setupTypeScript', async () => {
             framework: 'foo',
             services: [
                 'wdio-foobar-service$--$foobar',
-                'wdio-electron-service$--$electron'
+                '@wdio/electron-service$--$electron'
             ]
         },
         packagesToInstall: [],
@@ -642,7 +642,7 @@ test('setupTypeScript does not create tsconfig.json if TypeScript was not select
             framework: 'foo',
             services: [
                 'wdio-foobar-service$--$foobar',
-                'wdio-electron-service$--$electron'
+                '@wdio/electron-service$--$electron'
             ]
         },
         packagesToInstall: [],
@@ -661,7 +661,7 @@ test('setupTypeScript does not create tsconfig.json if there is already one', as
             framework: 'foo',
             services: [
                 'wdio-foobar-service$--$foobar',
-                'wdio-electron-service$--$electron'
+                '@wdio/electron-service$--$electron'
             ]
         },
         packagesToInstall: [],

--- a/packages/wdio-xvfb/README.md
+++ b/packages/wdio-xvfb/README.md
@@ -15,7 +15,7 @@ npm install @wdio/xvfb
 **Most users don't need to use this package directly.** It's automatically integrated into:
 
 - **`@wdio/local-runner`** - Automatically ensures xvfb is available for headless browser testing
-- **`wdio-electron-service`** - Provides headless Electron testing capabilities
+- **`@wdio/electron-service`** - Provides headless Electron testing capabilities
 
 Simply run your WebDriverIO tests normally, and xvfb will be managed automatically when needed.
 

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -36,10 +36,18 @@
     "npmUrl": "https://www.npmjs.com/package/wdio-intercept-service"
   },
   {
-    "packageName": "wdio-electron-service",
+    "packageName": "@wdio/electron-service",
     "title": "Electron",
-    "githubUrl": "https://github.com/webdriverio-community/wdio-electron-service",
-    "npmUrl": "https://www.npmjs.com/package/wdio-electron-service"
+    "location": "packages/electron-service/README.md",
+    "githubUrl": "https://github.com/webdriverio/desktop-mobile",
+    "npmUrl": "https://www.npmjs.com/package/@wdio/electron-service"
+  },
+  {
+    "packageName": "@wdio/tauri-service",
+    "title": "Tauri",
+    "location": "packages/tauri-service/README.md",
+    "githubUrl": "https://github.com/webdriverio/desktop-mobile",
+    "npmUrl": "https://www.npmjs.com/package/@wdio/tauri-service"
   },
   {
     "packageName": "wdio-gmail-service",

--- a/scripts/docs-generation/docsUtils.ts
+++ b/scripts/docs-generation/docsUtils.ts
@@ -1,0 +1,25 @@
+export interface PageProps {
+    sourcePath: string
+    title: string
+}
+
+/**
+ * Build a regex/replace function that turns the monorepo's relative markdown
+ * links (e.g. `./configuration.md`, `./api.md#mocking`) into Docusaurus URLs.
+ */
+export function buildLinkRewriter(allDocs: Record<string, PageProps>, publishedUrlPrefix: string) {
+    const filenameToId = new Map<string, string>()
+    for (const [id, { sourcePath }] of Object.entries(allDocs)) {
+        filenameToId.set(sourcePath, id)
+    }
+    return (content: string): string => content.replace(
+        /\.\/([\w-]+\.md)(#[\w-]+)?/g,
+        (match, filename: string, anchor: string | undefined) => {
+            const id = filenameToId.get(filename)
+            if (!id) {
+                return match
+            }
+            return `${publishedUrlPrefix}/${id}${anchor ?? ''}`
+        }
+    )
+}

--- a/scripts/docs-generation/electronDocs.ts
+++ b/scripts/docs-generation/electronDocs.ts
@@ -2,13 +2,9 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import url from 'node:url'
 import { downloadFromGitHub } from '../utils/index.js'
+import { buildLinkRewriter, type PageProps } from './docsUtils.js'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
-
-interface PageProps {
-    sourcePath: string
-    title: string
-}
 
 /**
  * Source files in `packages/electron-service/docs/` of the wdio-desktop-mobile
@@ -32,33 +28,12 @@ const DOCS_SOURCE_DIR = 'packages/electron-service/docs'
 const WEBSITE_DOCS_PATH = ['website', 'docs', 'desktop-testing', 'electron']
 const PUBLISHED_URL_PREFIX = '/docs/desktop-testing/electron'
 
-/**
- * Build a regex/replace map that turns the new repo's relative markdown links
- * (e.g. `./configuration.md`, `./electron-apis.md#mocking`) into Docusaurus URLs.
- */
-function buildLinkRewriter() {
-    const filenameToId = new Map<string, string>()
-    for (const [id, { sourcePath }] of Object.entries(allDocs)) {
-        filenameToId.set(sourcePath, id)
-    }
-    return (content: string): string => content.replace(
-        /\.\/([\w-]+\.md)(#[\w-]+)?/g,
-        (match, filename: string, anchor: string | undefined) => {
-            const id = filenameToId.get(filename)
-            if (!id) {
-                return match
-            }
-            return `${PUBLISHED_URL_PREFIX}/${id}${anchor ?? ''}`
-        }
-    )
-}
-
 export async function generateElectronDocs () {
     const basePath = path.join(__dirname, '..', '..')
     const electronDocsPath = path.join(basePath, ...WEBSITE_DOCS_PATH)
     await fs.mkdir(electronDocsPath, { recursive: true })
 
-    const rewriteLinks = buildLinkRewriter()
+    const rewriteLinks = buildLinkRewriter(allDocs, PUBLISHED_URL_PREFIX)
 
     for (const [id, { sourcePath, title }] of Object.entries(allDocs)) {
         const newDocsPath = path.join(electronDocsPath, `${id}.md`)

--- a/scripts/docs-generation/generateDocs.ts
+++ b/scripts/docs-generation/generateDocs.ts
@@ -9,6 +9,7 @@ import { generateWdioDocs } from './wdioDocs.js'
 import { generateReportersAndServicesDocs } from './packagesDocs.js'
 import { generate3rdPartyDocs } from './3rdPartyDocs.js'
 import { generateElectronDocs } from './electronDocs.js'
+import { generateTauriDocs } from './tauriDocs.js'
 import { generateEventDocs } from './eventDocs.js'
 import { copyContributingDocs } from './copyContributingDocs.js'
 import { downloadAwesomeResources } from './downloadAwesomeResources.js'
@@ -44,8 +45,9 @@ try {
     await generate3rdPartyDocs(sidebars)
     print('Generate Event Docs')
     await generateEventDocs()
-    print('Copy over Electron Service Resources')
+    print('Generate Desktop Service Docs (Electron + Tauri)')
     await generateElectronDocs()
+    await generateTauriDocs()
     print('Copy over Contributing Guidelines')
     await copyContributingDocs()
     print('Copy over Awesome Resources')

--- a/scripts/docs-generation/tauriDocs.ts
+++ b/scripts/docs-generation/tauriDocs.ts
@@ -11,31 +11,30 @@ interface PageProps {
 }
 
 /**
- * Source files in `packages/electron-service/docs/` of the wdio-desktop-mobile
+ * Source files in `packages/tauri-service/docs/` of the wdio-desktop-mobile
  * monorepo, keyed by the docusaurus `id` they should be published under.
  */
 const allDocs: Record<string, PageProps> = {
+    'quick-start': { sourcePath: 'quick-start.md', title: 'Quick Start' },
     configuration: { sourcePath: 'configuration.md', title: 'Configuration' },
-    api: { sourcePath: 'electron-apis.md', title: 'Accessing Electron APIs' },
-    'api-reference': { sourcePath: 'api-reference.md', title: 'API Reference' },
-    'standalone': { sourcePath: 'standalone-mode.md', title: 'Standalone Mode' },
-    'window-management': { sourcePath: 'window-management.md', title: 'Window Management' },
+    api: { sourcePath: 'api-reference.md', title: 'API Reference' },
+    'plugin-setup': { sourcePath: 'plugin-setup.md', title: 'Plugin Setup' },
+    'platform-support': { sourcePath: 'platform-support.md', title: 'Platform Support' },
+    'usage-examples': { sourcePath: 'usage-examples.md', title: 'Usage Examples' },
+    'log-forwarding': { sourcePath: 'log-forwarding.md', title: 'Log Forwarding' },
+    'edge-webdriver-windows': { sourcePath: 'edge-webdriver-windows.md', title: 'Edge WebDriver on Windows' },
     'deeplink-testing': { sourcePath: 'deeplink-testing.md', title: 'Deeplink Testing' },
-    debugging: { sourcePath: 'debugging.md', title: 'Debugging' },
-    'common-issues': { sourcePath: 'common-issues.md', title: 'Common Issues' }
+    'crabnebula-setup': { sourcePath: 'crabnebula-setup.md', title: 'CrabNebula Setup' },
+    troubleshooting: { sourcePath: 'troubleshooting.md', title: 'Troubleshooting' }
 }
 
 const GITHUB_REPO = 'webdriverio/desktop-mobile'
 const GITHUB_URL = `https://raw.githubusercontent.com/${GITHUB_REPO}`
 const DOCS_SHA = '37081c940a4528df3bf1994d9a5391d33a8775d5'
-const DOCS_SOURCE_DIR = 'packages/electron-service/docs'
-const WEBSITE_DOCS_PATH = ['website', 'docs', 'desktop-testing', 'electron']
-const PUBLISHED_URL_PREFIX = '/docs/desktop-testing/electron'
+const DOCS_SOURCE_DIR = 'packages/tauri-service/docs'
+const WEBSITE_DOCS_PATH = ['website', 'docs', 'desktop-testing', 'tauri']
+const PUBLISHED_URL_PREFIX = '/docs/desktop-testing/tauri'
 
-/**
- * Build a regex/replace map that turns the new repo's relative markdown links
- * (e.g. `./configuration.md`, `./electron-apis.md#mocking`) into Docusaurus URLs.
- */
 function buildLinkRewriter() {
     const filenameToId = new Map<string, string>()
     for (const [id, { sourcePath }] of Object.entries(allDocs)) {
@@ -53,23 +52,21 @@ function buildLinkRewriter() {
     )
 }
 
-export async function generateElectronDocs () {
+export async function generateTauriDocs () {
     const basePath = path.join(__dirname, '..', '..')
-    const electronDocsPath = path.join(basePath, ...WEBSITE_DOCS_PATH)
-    await fs.mkdir(electronDocsPath, { recursive: true })
+    const tauriDocsPath = path.join(basePath, ...WEBSITE_DOCS_PATH)
+    await fs.mkdir(tauriDocsPath, { recursive: true })
 
     const rewriteLinks = buildLinkRewriter()
 
     for (const [id, { sourcePath, title }] of Object.entries(allDocs)) {
-        const newDocsPath = path.join(electronDocsPath, `${id}.md`)
+        const newDocsPath = path.join(tauriDocsPath, `${id}.md`)
         const remotePath = `${DOCS_SOURCE_DIR}/${sourcePath}`
         const raw = await downloadFromGitHub(GITHUB_URL, DOCS_SHA, remotePath)
 
-        // Drop the source's first H1 heading (Docusaurus uses front-matter title)
         const stripped = raw.replace(/^#[^\n]*\n+/, '')
 
         const transformed = rewriteLinks(stripped)
-            // Rewrite repo-relative image paths (e.g. ../assets/foo.png) to absolute raw URLs
             .replace(
                 /(\]|src=")(\.\.\/)+(assets\/[\w./-]+)/g,
                 (_match, prefix: string, _dots: string, assetPath: string) =>

--- a/scripts/docs-generation/tauriDocs.ts
+++ b/scripts/docs-generation/tauriDocs.ts
@@ -2,13 +2,9 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import url from 'node:url'
 import { downloadFromGitHub } from '../utils/index.js'
+import { buildLinkRewriter, type PageProps } from './docsUtils.js'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
-
-interface PageProps {
-    sourcePath: string
-    title: string
-}
 
 /**
  * Source files in `packages/tauri-service/docs/` of the wdio-desktop-mobile
@@ -35,29 +31,12 @@ const DOCS_SOURCE_DIR = 'packages/tauri-service/docs'
 const WEBSITE_DOCS_PATH = ['website', 'docs', 'desktop-testing', 'tauri']
 const PUBLISHED_URL_PREFIX = '/docs/desktop-testing/tauri'
 
-function buildLinkRewriter() {
-    const filenameToId = new Map<string, string>()
-    for (const [id, { sourcePath }] of Object.entries(allDocs)) {
-        filenameToId.set(sourcePath, id)
-    }
-    return (content: string): string => content.replace(
-        /\.\/([\w-]+\.md)(#[\w-]+)?/g,
-        (match, filename: string, anchor: string | undefined) => {
-            const id = filenameToId.get(filename)
-            if (!id) {
-                return match
-            }
-            return `${PUBLISHED_URL_PREFIX}/${id}${anchor ?? ''}`
-        }
-    )
-}
-
 export async function generateTauriDocs () {
     const basePath = path.join(__dirname, '..', '..')
     const tauriDocsPath = path.join(basePath, ...WEBSITE_DOCS_PATH)
     await fs.mkdir(tauriDocsPath, { recursive: true })
 
-    const rewriteLinks = buildLinkRewriter()
+    const rewriteLinks = buildLinkRewriter(allDocs, PUBLISHED_URL_PREFIX)
 
     for (const [id, { sourcePath, title }] of Object.entries(allDocs)) {
         const newDocsPath = path.join(tauriDocsPath, `${id}.md`)

--- a/website/_sidebars.json
+++ b/website/_sidebars.json
@@ -139,8 +139,33 @@
           "items": [
             "desktop-testing/electron/configuration",
             "desktop-testing/electron/api",
-            "desktop-testing/electron/mocking",
-            "desktop-testing/electron/standalone"
+            "desktop-testing/electron/api-reference",
+            "desktop-testing/electron/window-management",
+            "desktop-testing/electron/deeplink-testing",
+            "desktop-testing/electron/standalone",
+            "desktop-testing/electron/debugging",
+            "desktop-testing/electron/common-issues"
+          ]
+        },
+        {
+          "type": "category",
+          "label": "Tauri",
+          "link": {
+            "type": "doc",
+            "id": "desktop-testing/tauri"
+          },
+          "items": [
+            "desktop-testing/tauri/quick-start",
+            "desktop-testing/tauri/configuration",
+            "desktop-testing/tauri/api",
+            "desktop-testing/tauri/plugin-setup",
+            "desktop-testing/tauri/platform-support",
+            "desktop-testing/tauri/usage-examples",
+            "desktop-testing/tauri/log-forwarding",
+            "desktop-testing/tauri/edge-webdriver-windows",
+            "desktop-testing/tauri/deeplink-testing",
+            "desktop-testing/tauri/crabnebula-setup",
+            "desktop-testing/tauri/troubleshooting"
           ]
         }
       ]

--- a/website/docs/desktop-testing/Electron.md
+++ b/website/docs/desktop-testing/Electron.md
@@ -29,7 +29,7 @@ To initiate a new WebdriverIO project, run:
 npm create wdio@latest ./
 ```
 
-An installation wizard will guide you through the process. Ensure you select _"Desktop Testing - of Electron Applications"_ when it asks you what type of testing you'd like to do. Afterwards provide the path to your compiled Electron application, e.g. `./dist`, then just keep the defaults or modify based on your preference.
+An installation wizard will guide you through the process. When asked what type of testing you'd like to do, select _"Desktop Testing - of Electron, Tauri, or macOS Applications"_, then choose _Electron_ at the framework prompt. Afterwards provide the path to your compiled Electron application, e.g. `./dist`, then just keep the defaults or modify based on your preference.
 
 The configuration wizard will install all required packages and create a `wdio.conf.js` or `wdio.conf.ts` with the necessary configuration to test your application. If you agree to autogenerate some test files you can run your first test via `npm run wdio`.
 
@@ -38,7 +38,7 @@ The configuration wizard will install all required packages and create a `wdio.c
 If you are already using WebdriverIO in your project you can skip the installation wizard and just add the following dependencies:
 
 ```sh
-npm install --save-dev wdio-electron-service
+npm install --save-dev @wdio/electron-service
 ```
 
 Then you can use the following configuration:

--- a/website/docs/desktop-testing/Tauri.md
+++ b/website/docs/desktop-testing/Tauri.md
@@ -1,0 +1,68 @@
+---
+id: tauri
+title: Tauri
+---
+
+[Tauri](https://tauri.app/) is a framework for building lightweight, secure cross-platform desktop applications using a Rust backend and the operating system's native webview. WebdriverIO's Tauri service automates the discovery, launch, and driving of Tauri apps on Windows (WebView2), macOS (WKWebView), and Linux (WebKitGTK) so the same test suite works everywhere.
+
+The advantages of using WebdriverIO for testing Tauri applications are:
+
+- 🚗 auto-provisioning of the WebDriver layer — choose `tauri-driver`, the CrabNebula driver, or the in-app embedded plugin
+- 📦 cross-platform binary detection (Edge WebView2 driver bundled on Windows)
+- 🧩 optional `@wdio/tauri-plugin` for richer in-webview integration (`browser.tauri.execute`, mocking)
+- 🔗 deeplink + protocol handler testing
+- 🪵 forwarding of Rust + frontend logs into the WebdriverIO test reporter
+
+## Getting Started
+
+To initiate a new WebdriverIO project, run:
+
+```sh
+npm create wdio@latest ./
+```
+
+When the wizard asks what type of testing you'd like to do, select _"Desktop Testing - of Electron, Tauri, or macOS Applications"_, then choose _Tauri_ at the framework prompt. The wizard will then ask which WebDriver provider you want to use (official `tauri-driver`, CrabNebula, or the embedded plugin) and whether you'd like the optional `@wdio/tauri-plugin` for richer integration.
+
+The wizard installs the npm packages automatically and prints any required Cargo additions to stdout for you to paste into your `src-tauri/Cargo.toml`.
+
+## Manual Setup
+
+If you already have a WebdriverIO project, install the service:
+
+```sh
+npm install --save-dev @wdio/tauri-service
+# optional: richer in-webview integration
+npm install --save-dev @wdio/tauri-plugin
+```
+
+For the embedded WebDriver plugin (recommended — runs the W3C server inside your app, no external `tauri-driver` needed), add the Cargo crate to `src-tauri/Cargo.toml`:
+
+```toml
+[dependencies]
+tauri-plugin-wdio-webdriver = "1"
+```
+
+…and register it in `src-tauri/src/lib.rs`:
+
+```rust
+tauri::Builder::default()
+    .plugin(tauri_plugin_wdio_webdriver::init())
+    // ...
+```
+
+Then add the service to your config:
+
+```ts
+// wdio.conf.ts
+export const config: WebdriverIO.Config = {
+    // ...
+    services: [['tauri', {
+        appBinaryPath: './src-tauri/target/release/my-tauri-app',
+        driverProvider: 'embedded'
+    }]]
+}
+```
+
+That's it 🎉
+
+Learn more about [configuring the Tauri Service](/docs/desktop-testing/tauri/configuration), [the Tauri plugin setup](/docs/desktop-testing/tauri/plugin-setup), [platform-specific notes](/docs/desktop-testing/tauri/platform-support), and [common usage patterns](/docs/desktop-testing/tauri/usage-examples).


### PR DESCRIPTION
## Proposed changes

We recently released `@wdio/electron-service` (replacing the previous community service `wdio-electron-service`) and `@wdio/tauri-service` (new) so we need to update WDIO documentation and the project creation wizard accordingly.

https://github.com/webdriverio/desktop-mobile
https://github.com/webdriverio-community/wdio-electron-service

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
- Collapse two separate desktop runner entries (Electron, macOS) into a
  single "Desktop Testing" runner with a follow-up "What type of desktop
  application are you testing?" sub-question (Electron / Tauri / Native macOS)
- Hard cutover from community `wdio-electron-service` to first-party
  `@wdio/electron-service`; remove `wdio-electron-service` from
  COMMUNITY_PACKAGES_WITH_TS_SUPPORT (scoped @wdio/* pkgs need no shim)
- Add `@wdio/tauri-service` and `@wdio/tauri-plugin` entries to SUPPORTED_PACKAGES
- Add DesktopFrameworkChoice and TauriDriverProviderChoice enums
- Add getResolvedPurpose() to map raw 'desktop' purpose → electron/tauri/macos;
  thread resolved purpose through parseAnswers() so templates see the right value
- Add Tauri wizard questions: driver provider, optional frontend plugin, binary path
- Add buildTauriBanner() that prints Cargo.toml / Rust registration instructions
  based on the chosen driver provider
- Update EJS templates for tauri reference types, services config snippet
- Update tests and snapshot for all of the above

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
