### PR TITLE
fix(wdio-protocols): correct typo "agains" → "against" in metrics description

### DIFF
--- a/packages/wdio-protocols/src/protocols/saucelabs.ts
+++ b/packages/wdio-protocols/src/protocols/saucelabs.ts
@@ -190,7 +190,7 @@ export default {
                     name: 'metrics',
                     type: 'string[]',
                     description:
-                        'Name of metrics you want to assert agains the baseline.',
+                        'Name of metrics you want to assert against the baseline.',
                     required: false,
                 },
             ],


### PR DESCRIPTION
Single-line typo fix on the `assert` metrics description string in `packages/wdio-protocols/src/protocols/saucelabs.ts:193`. User-visible (`--help` text). No behavior change.