### PR TITLE
docs(webdriverio): document 'Keys' object

### DIFF
--- a/packages/webdriverio/src/commands/browser/action.ts
+++ b/packages/webdriverio/src/commands/browser/action.ts
@@ -43,14 +43,15 @@ import { KeyAction, PointerAction, WheelAction } from '../../utils/actions/index
  * #### Special Characters
  *
  * If you like to use special characters like e.g. `Control`, `Page Up` or `Shift`, make sure to import the
- * [`Key`](https://github.com/webdriverio/webdriverio/blob/main/packages/webdriverio/src/constants.ts#L352-L417) object
- * from the `webdriverio` package like so:
+ * [`Key`](/docs/api/modules#key) object from the `webdriverio` package like so:
  *
  * ```ts
  * import { Key } from 'webdriverio'
  * ```
  *
- * The object allows you to access the unicode representation of the desired special character.
+ * The `Key` object provides constants for all special keys including `Key.Ctrl` (cross-platform), `Key.Enter`,
+ * `Key.Tab`, `Key.ArrowLeft`, arrow keys, function keys, and more. See the [Key API docs](/docs/api/modules#key)
+ * for a complete list.
  *
  * ### Pointer input source
  *

--- a/packages/webdriverio/src/commands/browser/keys.ts
+++ b/packages/webdriverio/src/commands/browser/keys.ts
@@ -5,16 +5,31 @@ import { checkUnicode } from '../../utils/index.js'
 /**
  *
  * Send a sequence of key strokes to the "active" element. You can make an input element active by just clicking
- * on it. To use characters like "Left arrow" or "Back space", import the `Key` object from the WebdriverIO package.
+ * on it. To use special characters like "ArrowLeft", "Enter", or "Backspace", import the `Key` object from the WebdriverIO package:
  *
- * Modifier like `Control`, `Shift`, `Alt` and `Command` will stay pressed throughout the sequence and will be released
+ * ```js
+ * import { Key } from 'webdriverio'
+ * ```
+ *
+ * The `Key` object provides constants for all special keys including:
+ * - Navigation: `Key.ArrowLeft`, `Key.ArrowUp`, `Key.ArrowRight`, `Key.ArrowDown`, `Key.PageUp`, `Key.PageDown`, `Key.Home`, `Key.End`
+ * - Editing: `Key.Enter`, `Key.Tab`, `Key.Backspace`, `Key.Delete`, `Key.Insert`
+ * - Modifiers: `Key.Ctrl` (cross-platform), `Key.Shift`, `Key.Alt`, `Key.Control`, `Key.Command`
+ * - Function keys: `Key.F1` through `Key.F12`
+ * - Numpad: `Key.Numpad0` through `Key.Numpad9`, `Key.Multiply`, `Key.Add`, `Key.Subtract`, `Key.Divide`
+ * - And more: `Key.Escape`, `Key.Space`, `Key.Clear`, `Key.Pause`, etc.
+ *
+ * See the [Key API docs](/docs/api/modules#key) for a complete list.
+ *
+ * Modifier keys like `Control`, `Shift`, `Alt` and `Command` will stay pressed throughout the sequence and will be released
  * at the end. Modifying a click requires you to use the WebDriver Actions API through the
  * [performActions](https://webdriver.io/docs/api/webdriver#performactions) method.
  *
- * :::info
+ * :::info Cross-Platform Modifier
  *
- * Control keys differ based on the operating system the browser is running on, e.g. MacOS: `Command` and Windows: `Control`.
- * WebdriverIO provides a cross browser modifier control key called `Ctrl` (see example below).
+ * The `Key.Ctrl` constant provides a convenient way to use the "control" modifier across different operating systems.
+ * On macOS, it maps to the `Command` key, while on Windows and Linux it maps to the `Control` key.
+ * This is useful for keyboard shortcuts like select-all (`[Key.Ctrl, 'a']`), copy, or paste.
  *
  * :::
  *

--- a/packages/webdriverio/src/commands/element/addValue.ts
+++ b/packages/webdriverio/src/commands/element/addValue.ts
@@ -10,7 +10,7 @@ const VALID_TYPES = ['string', 'number']
  * :::info
  *
  * If you like to use special characters, e.g. to copy and paste a value from one input to another, use the
- * [`keys`](/docs/api/browser/keys) command.
+ * [`keys`](/docs/api/browser/keys) command with the [`Key`](/docs/api/modules#key) object.
  *
  * :::
  *

--- a/packages/webdriverio/src/commands/element/setValue.ts
+++ b/packages/webdriverio/src/commands/element/setValue.ts
@@ -7,7 +7,7 @@ import type { InputOptions } from '../../types.js'
  * :::info
  *
  * If you like to use special characters, e.g. to copy and paste a value from one input to another, use the
- * [`keys`](/docs/api/browser/keys) command.
+ * [`keys`](/docs/api/browser/keys) command with the [`Key`](/docs/api/modules#key) object.
  *
  * :::
  *

--- a/website/docs/api/Modules.md
+++ b/website/docs/api/Modules.md
@@ -181,7 +181,7 @@ The following special keys are available via the `Key` object:
 | `Key.Shift` | Shift key |
 | `Key.Alt` | Alt key |
 | `Key.Command` | Command key (Mac) |
-| `Key.NULL` | Null key |
+| `Key.NULL` | Null/release key — releases all currently held modifier keys |
 
 **Navigation Keys:**
 

--- a/website/docs/api/Modules.md
+++ b/website/docs/api/Modules.md
@@ -149,6 +149,102 @@ console.log(await matrix.getTitle())
 // returns ['Google', 'JSON']
 ```
 
+#### `Key`
+
+An object containing special character constants for use with the [`browser.keys`](/docs/api/browser/keys) command. These constants represent special keys that can be sent to the browser, such as `Enter`, `Tab`, `Escape`, arrow keys, function keys, and more.
+
+##### Example
+
+```js
+import { Key } from 'webdriverio'
+
+// Press Enter key
+await browser.keys(Key.Enter)
+
+// Use Ctrl+A to select all (works cross-platform)
+await browser.keys([Key.Ctrl, 'a'])
+
+// Navigate with arrow keys
+await browser.keys([Key.ArrowDown, Key.ArrowDown, Key.Enter])
+```
+
+##### Available Keys
+
+The following special keys are available via the `Key` object:
+
+**Modifier Keys:**
+
+| Constant | Description |
+|----------|-------------|
+| `Key.Ctrl` | Cross-platform control key (Command on Mac, Control on Windows/Linux) |
+| `Key.Control` | Control key |
+| `Key.Shift` | Shift key |
+| `Key.Alt` | Alt key |
+| `Key.Command` | Command key (Mac) |
+| `Key.NULL` | Null key |
+
+**Navigation Keys:**
+
+| Constant | Description |
+|----------|-------------|
+| `Key.Cancel` | Cancel key |
+| `Key.Help` | Help key |
+| `Key.Backspace` | Backspace key |
+| `Key.Tab` | Tab key |
+| `Key.Clear` | Clear key |
+| `Key.Return` | Return key |
+| `Key.Enter` | Enter key |
+| `Key.Pause` | Pause key |
+| `Key.Escape` | Escape key |
+| `Key.Space` | Space key |
+| `Key.PageUp` | Page Up key |
+| `Key.PageDown` | Page Down key |
+| `Key.End` | End key |
+| `Key.Home` | Home key |
+| `Key.ArrowLeft` | Left Arrow key |
+| `Key.ArrowUp` | Up Arrow key |
+| `Key.ArrowRight` | Right Arrow key |
+| `Key.ArrowDown` | Down Arrow key |
+| `Key.Insert` | Insert key |
+| `Key.Delete` | Delete key |
+
+**Character Keys:**
+
+| Constant | Description |
+|----------|-------------|
+| `Key.Semicolon` | Semicolon key |
+| `Key.Equals` | Equals key |
+
+**Numpad Keys:**
+
+| Constant | Description |
+|----------|-------------|
+| `Key.Numpad0` - `Key.Numpad9` | Numpad 0-9 |
+| `Key.Multiply` | Numpad Multiply |
+| `Key.Add` | Numpad Add |
+| `Key.Separator` | Numpad Separator |
+| `Key.Subtract` | Numpad Subtract |
+| `Key.Decimal` | Numpad Decimal |
+| `Key.Divide` | Numpad Divide |
+
+**Function Keys:**
+
+| Constant | Description |
+|----------|-------------|
+| `Key.F1` - `Key.F12` | Function keys F1 through F12 |
+
+**Other Keys:**
+
+| Constant | Description |
+|----------|-------------|
+| `Key.ZenkakuHankaku` | Zenkaku/Hankaku key (Japanese) |
+
+:::info Cross-Platform Modifier Keys
+
+The `Key.Ctrl` constant provides a convenient way to use the "control" modifier across different operating systems. On macOS, it maps to the `Command` key, while on Windows and Linux it maps to the `Control` key. This is useful when writing tests that need to work across multiple platforms, e.g., for select-all (`Ctrl+A`), copy (`Ctrl+C`), or paste (`Ctrl+V`) operations.
+
+:::
+
 ## `@wdio/cli`
 
 Instead of calling the `wdio` command, you can also include the test runner as module and run it in an arbitrary environment. For that, you'll need to require the `@wdio/cli` package as module, like this:


### PR DESCRIPTION
This PR adds comprehensive documentation for the `Key` object exported by the `webdriverio` package. The `Key` object provides special character constants for use with `browser.keys()`, but was previously undocumented, making it difficult for users to discover and use these constants effectively.

### Changes

- **Added `Key` documentation to `website/docs/api/Modules.md`**:
  - Import example showing `import { Key } from 'webdriverio'`
  - Practical usage examples (Enter key, Ctrl+A select-all, arrow navigation)
  - Complete reference tables organized by key category:
    - Modifier Keys (Ctrl, Shift, Alt, Control, Command, NULL)
    - Navigation Keys (Arrow keys, Page Up/Down, Home, End, etc.)
    - Character Keys (Semicolon, Equals)
    - Numpad Keys (Numpad0-9, arithmetic operators)
    - Function Keys (F1-F12)
    - Other Keys (ZenkakuHankaku)
  - Callout explaining the cross-platform `Key.Ctrl` constant behavior

- **Enhanced JSDoc in `packages/webdriverio/src/commands/browser/keys.ts`**:
  - Added import instruction and example
  - Listed all key categories with examples
  - Added link to full Key API documentation
  - Documented the cross-platform `Key.Ctrl` modifier behavior

### Motivation

Users frequently need to send special keys like Enter, Tab, or arrow keys in their tests. While the `keys` command supported these via the `Key` object, there was no centralized documentation listing all available constants. This led to users having to look at the source code or use trial and error.

The special `Key.Ctrl` constant (which maps to Command on macOS and Control on Windows/Linux) was especially under-documented, despite being very useful for cross-platform keyboard shortcuts.
