### PR TITLE
fix(webdriverio): convert html/:root CSS selectors to XPath for Firefox <150 BiDi (#15233)

### DIFF
--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -297,6 +297,17 @@ export function transformClassicToBidiSelector(using: string, value: string): re
 }
 
 /**
+ * Returns true when the connected Firefox browser is older than v150, which has a BiDi bug
+ * where browsingContext.locateNodes returns empty nodes for CSS root selectors (issue #15233).
+ */
+function isFirefoxBidiRootSelectorBug(browser: WebdriverIO.Browser): boolean {
+    if (!browser.isFirefox) { return false }
+    const version = browser.capabilities?.browserVersion ?? ''
+    const major = parseInt(version.match(/(\d+)/)?.[1] ?? '0', 10)
+    return !isNaN(major) && major > 0 && major < 150
+}
+
+/**
  * Parallel look up of a selector within multiple shadow roots
  * @param this WebdriverIO Browser or Element instance
  * @param selector selector to look up
@@ -316,7 +327,7 @@ export async function findDeepElement(
         context,
         (this as WebdriverIO.Element).elementId
     )
-    const { using, value } = findStrategy(selector as string, this.isW3C, this.isMobile)
+    let { using, value } = findStrategy(selector as string, this.isW3C, this.isMobile)
 
     /**
      * if we are using a relative xpath selector and we have a parent element
@@ -325,6 +336,19 @@ export async function findDeepElement(
      */
     if (using === 'xpath' && (value.startsWith('./') || value.startsWith('..')) && (this as WebdriverIO.Element).elementId) {
         return this.findElementFromElement((this as WebdriverIO.Element).elementId, using, value)
+    }
+
+    /**
+     * Firefox < 150 BiDi has a bug where browsingContext.locateNodes returns empty nodes for
+     * CSS root selectors ('html', ':root'). Convert to absolute XPath only for unscoped
+     * top-level lookups; scoped contexts (shadow roots, element-scoped) must not use //html
+     * as that would escape the scope. Fixed in Firefox 150+. (issue #15233)
+     */
+    const isScopedContext = shadowRoots.length > 0 || Boolean((this as WebdriverIO.Element).elementId)
+    if (using === 'css selector' && (value === 'html' || value === ':root') &&
+        !isScopedContext && isFirefoxBidiRootSelectorBug(browser)) {
+        using = 'xpath'
+        value = '//html'
     }
 
     const locator = transformClassicToBidiSelector(using, value)
@@ -432,7 +456,7 @@ export async function findDeepElements(
         context,
         (this as WebdriverIO.Element).elementId
     )
-    const { using, value } = findStrategy(selector as string, this.isW3C, this.isMobile)
+    let { using, value } = findStrategy(selector as string, this.isW3C, this.isMobile)
 
     /**
      * if we are using a relative xpath selector and we have a parent element
@@ -441,6 +465,19 @@ export async function findDeepElements(
      */
     if (using === 'xpath' && (value.startsWith('./') || value.startsWith('..')) && (this as WebdriverIO.Element).elementId) {
         return this.findElementsFromElement((this as WebdriverIO.Element).elementId, using, value)
+    }
+
+    /**
+     * Firefox < 150 BiDi has a bug where browsingContext.locateNodes returns empty nodes for
+     * CSS root selectors ('html', ':root'). Convert to absolute XPath only for unscoped
+     * top-level lookups; scoped contexts (shadow roots, element-scoped) must not use //html
+     * as that would escape the scope. Fixed in Firefox 150+. (issue #15233)
+     */
+    const isScopedContext = shadowRoots.length > 0 || Boolean((this as WebdriverIO.Element).elementId)
+    if (using === 'css selector' && (value === 'html' || value === ':root') &&
+        !isScopedContext && isFirefoxBidiRootSelectorBug(browser)) {
+        using = 'xpath'
+        value = '//html'
     }
 
     const locator = transformClassicToBidiSelector(using, value)

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -303,8 +303,27 @@ export function transformClassicToBidiSelector(using: string, value: string): re
 function isFirefoxBidiRootSelectorBug(browser: WebdriverIO.Browser): boolean {
     if (!browser.isFirefox) { return false }
     const version = browser.capabilities?.browserVersion ?? ''
-    const major = parseInt(version.match(/(\d+)/)?.[1] ?? '0', 10)
+    const major = parseInt(version.match(/\d+/)?.[0] ?? '0', 10)
     return !isNaN(major) && major > 0 && major < 150
+}
+
+/**
+ * Applies the Firefox < 150 BiDi root selector workaround: converts CSS 'html' / ':root'
+ * to the absolute XPath '/html' for unscoped top-level lookups only.
+ * '/html' is anchored to the document root, making it semantically equivalent to ':root'.
+ * '//html' is intentionally avoided as it matches html elements at any depth.
+ */
+function applyFirefoxRootSelectorWorkaround(
+    using: string,
+    value: string,
+    isScopedContext: boolean,
+    browser: WebdriverIO.Browser
+): { using: string, value: string } {
+    if (using === 'css selector' && (value === 'html' || value === ':root') &&
+        !isScopedContext && isFirefoxBidiRootSelectorBug(browser)) {
+        return { using: 'xpath', value: '/html' }
+    }
+    return { using, value }
 }
 
 /**
@@ -338,18 +357,8 @@ export async function findDeepElement(
         return this.findElementFromElement((this as WebdriverIO.Element).elementId, using, value)
     }
 
-    /**
-     * Firefox < 150 BiDi has a bug where browsingContext.locateNodes returns empty nodes for
-     * CSS root selectors ('html', ':root'). Convert to absolute XPath only for unscoped
-     * top-level lookups; scoped contexts (shadow roots, element-scoped) must not use //html
-     * as that would escape the scope. Fixed in Firefox 150+. (issue #15233)
-     */
     const isScopedContext = shadowRoots.length > 0 || Boolean((this as WebdriverIO.Element).elementId)
-    if (using === 'css selector' && (value === 'html' || value === ':root') &&
-        !isScopedContext && isFirefoxBidiRootSelectorBug(browser)) {
-        using = 'xpath'
-        value = '//html'
-    }
+    ;({ using, value } = applyFirefoxRootSelectorWorkaround(using, value, isScopedContext, browser))
 
     const locator = transformClassicToBidiSelector(using, value)
 
@@ -467,18 +476,8 @@ export async function findDeepElements(
         return this.findElementsFromElement((this as WebdriverIO.Element).elementId, using, value)
     }
 
-    /**
-     * Firefox < 150 BiDi has a bug where browsingContext.locateNodes returns empty nodes for
-     * CSS root selectors ('html', ':root'). Convert to absolute XPath only for unscoped
-     * top-level lookups; scoped contexts (shadow roots, element-scoped) must not use //html
-     * as that would escape the scope. Fixed in Firefox 150+. (issue #15233)
-     */
     const isScopedContext = shadowRoots.length > 0 || Boolean((this as WebdriverIO.Element).elementId)
-    if (using === 'css selector' && (value === 'html' || value === ':root') &&
-        !isScopedContext && isFirefoxBidiRootSelectorBug(browser)) {
-        using = 'xpath'
-        value = '//html'
-    }
+    ;({ using, value } = applyFirefoxRootSelectorWorkaround(using, value, isScopedContext, browser))
 
     const locator = transformClassicToBidiSelector(using, value)
 

--- a/packages/webdriverio/tests/utils/findDeepElement.test.ts
+++ b/packages/webdriverio/tests/utils/findDeepElement.test.ts
@@ -395,3 +395,141 @@ describe('findDeepElements - isConnected validation', () => {
         expect(element.findElementsFromElement).not.toHaveBeenCalled()
     })
 })
+
+// Firefox < 150 BiDi root selector workaround (issue #15233)
+describe('findDeepElement - Firefox root selector workaround', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockGetCurrentContext.mockResolvedValue('ctx-1')
+        mockGetShadowElementsByContextId.mockReturnValue([])
+    })
+
+    it('should convert "html" CSS selector to XPath for Firefox < 150 (unscoped)', async () => {
+        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
+
+        await findDeepElement.call(browser, 'html')
+
+        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
+            expect.objectContaining({ locator: { type: 'xpath', value: '//html' } })
+        )
+    })
+
+    it('should convert ":root" CSS selector to XPath for Firefox < 150 (unscoped)', async () => {
+        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
+
+        await findDeepElement.call(browser, ':root')
+
+        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
+            expect.objectContaining({ locator: { type: 'xpath', value: '//html' } })
+        )
+    })
+
+    it('should NOT convert for Firefox >= 150', async () => {
+        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '150.0' } })
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
+
+        await findDeepElement.call(browser, 'html')
+
+        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
+            expect.objectContaining({ locator: { type: 'css', value: 'html' } })
+        )
+    })
+
+    it('should NOT convert in element-scoped context (Firefox < 150)', async () => {
+        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
+        const element: any = {
+            isW3C: true, isMobile: false, isFirefox: true,
+            elementId: 'parent-id', __browser: browser,
+            findElementFromElement: vi.fn().mockResolvedValue({ [ELEMENT_KEY]: 'found' }),
+        }
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
+
+        await findDeepElement.call(element, 'html')
+
+        // scoped context: must NOT receive an absolute //html locator
+        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
+            expect.objectContaining({ locator: { type: 'css', value: 'html' } })
+        )
+    })
+
+    it('should NOT convert other CSS selectors', async () => {
+        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'body-node' }] })
+
+        await findDeepElement.call(browser, 'body')
+
+        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
+            expect.objectContaining({ locator: { type: 'css', value: 'body' } })
+        )
+    })
+})
+
+describe('findDeepElements - Firefox root selector workaround', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockGetCurrentContext.mockResolvedValue('ctx-1')
+        mockGetShadowElementsByContextId.mockReturnValue([])
+    })
+
+    it('should convert "html" CSS selector to XPath for Firefox < 150 (unscoped)', async () => {
+        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
+
+        await findDeepElements.call(browser, 'html')
+
+        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
+            expect.objectContaining({ locator: { type: 'xpath', value: '//html' } })
+        )
+    })
+
+    it('should convert ":root" CSS selector to XPath for Firefox < 150 (unscoped)', async () => {
+        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
+
+        await findDeepElements.call(browser, ':root')
+
+        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
+            expect.objectContaining({ locator: { type: 'xpath', value: '//html' } })
+        )
+    })
+
+    it('should NOT convert for Firefox >= 150', async () => {
+        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '150.0' } })
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
+
+        await findDeepElements.call(browser, 'html')
+
+        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
+            expect.objectContaining({ locator: { type: 'css', value: 'html' } })
+        )
+    })
+
+    it('should NOT convert in element-scoped context (Firefox < 150)', async () => {
+        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
+        const element: any = {
+            isW3C: true, isMobile: false, isFirefox: true,
+            elementId: 'parent-id', __browser: browser,
+            findElementsFromElement: vi.fn().mockResolvedValue([]),
+        }
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
+
+        await findDeepElements.call(element, 'html')
+
+        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
+            expect.objectContaining({ locator: { type: 'css', value: 'html' } })
+        )
+    })
+
+    it('should NOT convert other CSS selectors', async () => {
+        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'div-node' }] })
+
+        await findDeepElements.call(browser, 'div')
+
+        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
+            expect.objectContaining({ locator: { type: 'css', value: 'div' } })
+        )
+    })
+})

--- a/packages/webdriverio/tests/utils/findDeepElement.test.ts
+++ b/packages/webdriverio/tests/utils/findDeepElement.test.ts
@@ -397,76 +397,28 @@ describe('findDeepElements - isConnected validation', () => {
 })
 
 // Firefox < 150 BiDi root selector workaround (issue #15233)
-describe('findDeepElement - Firefox root selector workaround', () => {
-    beforeEach(() => {
-        vi.clearAllMocks()
-        mockGetCurrentContext.mockResolvedValue('ctx-1')
-        mockGetShadowElementsByContextId.mockReturnValue([])
-    })
-
-    it('should convert "html" CSS selector to XPath for Firefox < 150 (unscoped)', async () => {
-        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
-        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
-
-        await findDeepElement.call(browser, 'html')
-
-        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
-            expect.objectContaining({ locator: { type: 'xpath', value: '//html' } })
-        )
-    })
-
-    it('should convert ":root" CSS selector to XPath for Firefox < 150 (unscoped)', async () => {
-        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
-        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
-
-        await findDeepElement.call(browser, ':root')
-
-        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
-            expect.objectContaining({ locator: { type: 'xpath', value: '//html' } })
-        )
-    })
-
-    it('should NOT convert for Firefox >= 150', async () => {
-        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '150.0' } })
-        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
-
-        await findDeepElement.call(browser, 'html')
-
-        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
-            expect.objectContaining({ locator: { type: 'css', value: 'html' } })
-        )
-    })
-
-    it('should NOT convert in element-scoped context (Firefox < 150)', async () => {
-        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
-        const element: any = {
+describe.each([
+    {
+        name: 'findDeepElement',
+        fn: findDeepElement,
+        scopedElementStub: (browser: any) => ({
             isW3C: true, isMobile: false, isFirefox: true,
             elementId: 'parent-id', __browser: browser,
             findElementFromElement: vi.fn().mockResolvedValue({ [ELEMENT_KEY]: 'found' }),
-        }
-        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
-
-        await findDeepElement.call(element, 'html')
-
-        // scoped context: must NOT receive an absolute //html locator
-        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
-            expect.objectContaining({ locator: { type: 'css', value: 'html' } })
-        )
-    })
-
-    it('should NOT convert other CSS selectors', async () => {
-        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
-        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'body-node' }] })
-
-        await findDeepElement.call(browser, 'body')
-
-        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
-            expect.objectContaining({ locator: { type: 'css', value: 'body' } })
-        )
-    })
-})
-
-describe('findDeepElements - Firefox root selector workaround', () => {
+        }),
+        otherSelector: 'body',
+    },
+    {
+        name: 'findDeepElements',
+        fn: findDeepElements,
+        scopedElementStub: (browser: any) => ({
+            isW3C: true, isMobile: false, isFirefox: true,
+            elementId: 'parent-id', __browser: browser,
+            findElementsFromElement: vi.fn().mockResolvedValue([]),
+        }),
+        otherSelector: 'div',
+    },
+])('$name - Firefox root selector workaround', ({ fn, scopedElementStub, otherSelector }) => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockGetCurrentContext.mockResolvedValue('ctx-1')
@@ -477,10 +429,10 @@ describe('findDeepElements - Firefox root selector workaround', () => {
         const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
         browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
 
-        await findDeepElements.call(browser, 'html')
+        await fn.call(browser, 'html')
 
         expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
-            expect.objectContaining({ locator: { type: 'xpath', value: '//html' } })
+            expect.objectContaining({ locator: expect.objectContaining({ type: 'xpath', value: '/html' }) })
         )
     })
 
@@ -488,10 +440,10 @@ describe('findDeepElements - Firefox root selector workaround', () => {
         const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
         browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
 
-        await findDeepElements.call(browser, ':root')
+        await fn.call(browser, ':root')
 
         expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
-            expect.objectContaining({ locator: { type: 'xpath', value: '//html' } })
+            expect.objectContaining({ locator: expect.objectContaining({ type: 'xpath', value: '/html' }) })
         )
     })
 
@@ -499,37 +451,45 @@ describe('findDeepElements - Firefox root selector workaround', () => {
         const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '150.0' } })
         browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
 
-        await findDeepElements.call(browser, 'html')
+        await fn.call(browser, 'html')
 
         expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
-            expect.objectContaining({ locator: { type: 'css', value: 'html' } })
+            expect.objectContaining({ locator: expect.objectContaining({ type: 'css', value: 'html' }) })
         )
     })
 
     it('should NOT convert in element-scoped context (Firefox < 150)', async () => {
         const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
-        const element: any = {
-            isW3C: true, isMobile: false, isFirefox: true,
-            elementId: 'parent-id', __browser: browser,
-            findElementsFromElement: vi.fn().mockResolvedValue([]),
-        }
+        const element: any = scopedElementStub(browser)
         browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'html-node' }] })
 
-        await findDeepElements.call(element, 'html')
+        await fn.call(element, 'html')
 
         expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
-            expect.objectContaining({ locator: { type: 'css', value: 'html' } })
+            expect.objectContaining({ locator: expect.objectContaining({ type: 'css', value: 'html' }) })
+        )
+    })
+
+    it('should NOT convert in shadow-root scoped context (Firefox < 150)', async () => {
+        mockGetShadowElementsByContextId.mockReturnValue(['shadow-root-id'])
+        const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [] })
+
+        await fn.call(browser, 'html')
+
+        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
+            expect.objectContaining({ locator: expect.objectContaining({ type: 'css', value: 'html' }) })
         )
     })
 
     it('should NOT convert other CSS selectors', async () => {
         const browser = createMockBrowser({ isFirefox: true, capabilities: { browserVersion: '149.0.2' } })
-        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'div-node' }] })
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [{ sharedId: 'other-node' }] })
 
-        await findDeepElements.call(browser, 'div')
+        await fn.call(browser, otherSelector)
 
         expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
-            expect.objectContaining({ locator: { type: 'css', value: 'div' } })
+            expect.objectContaining({ locator: expect.objectContaining({ type: 'css', value: otherSelector }) })
         )
     })
 })


### PR DESCRIPTION
## Proposed changes
Fixes [#15233](https://github.com/webdriverio/webdriverio/issues/15233).
In Firefox < 150.0, browsingContext.locateNodes returns empty nodes when given a CSS locator of html or :root, so html and $(':root') silently find nothing. The fix detects this browser+version combination and converts those two selectors to the equivalent XPath //html before the BiDi call ,matching what the user's workaround ($('//html')) already does manually. The conversion is gated on isFirefox && major < 150 and only applies to unscoped top-level lookups; scoped contexts (shadow roots, element-scoped) are left untouched since an absolute //html XPath would escape the scope boundary. Validated against real Firefox 149.0.2.
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
