### PR TITLE
fix(docs): fix MDX compilation errors in docs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ website/community/Resources.md
 website/docs/desktop-testing/electron/
 website/docs/desktop-testing/tauri/
 scripts/bidi/cddl
+temp_extract/
 browserstack.err
 e2e/tailwind.config.js
 packages/webdriverio/.chrome

--- a/packages/wdio-protocols/src/protocols/webdriverBidi.ts
+++ b/packages/wdio-protocols/src/protocols/webdriverBidi.ts
@@ -263,7 +263,7 @@ const protocol = {
                 {
                     "name": "params",
                     "type": "`remote.BrowserSetClientWindowStateParameters`",
-                    "description": "<pre>\\{<br />  clientWindow: BrowserClientWindow;<br />}\\}</pre>",
+                    "description": "<pre>\\{<br />  clientWindow: BrowserClientWindow;<br />\\};</pre>",
                     "required": true
                 }
             ],
@@ -583,7 +583,7 @@ const protocol = {
                 {
                     "name": "params",
                     "type": "`remote.EmulationSetGeolocationOverrideParameters`",
-                    "description": "<pre>\\{<br />  coordinates: EmulationGeolocationCoordinates &#124; null;<br />} &#124; {<br />  error: EmulationGeolocationPositionError;<br />}) & {<br />  contexts?: BrowsingContextBrowsingContext[];<br />  userContexts?: BrowserUserContext[];<br />}\\}</pre>",
+                    "description": "<pre>\\{<br />  coordinates: EmulationGeolocationCoordinates &#124; null;<br />\\} &#124; \\{<br />  error: EmulationGeolocationPositionError;<br />\\}) & \\{<br />  contexts?: BrowsingContextBrowsingContext[];<br />  userContexts?: BrowserUserContext[];<br />\\};</pre>",
                     "required": true
                 }
             ],
@@ -863,7 +863,7 @@ const protocol = {
                 {
                     "name": "params",
                     "type": "`remote.NetworkContinueWithAuthParameters`",
-                    "description": "<pre>\\{<br />  request: NetworkRequest;<br />}\\}</pre>",
+                    "description": "<pre>\\{<br />  request: NetworkRequest;<br />\\};</pre>",
                     "required": true
                 }
             ],

--- a/packages/webdriver/src/bidi/handler.ts
+++ b/packages/webdriver/src/bidi/handler.ts
@@ -69,7 +69,7 @@ export class BidiHandler extends BidiCore {
      * @param params `remote.SessionSubscribeParameters` {@link https://w3c.github.io/webdriver-bidi/#command-session-subscribe | command parameter}
      * @returns `Promise<local.SessionSubscribeResult>`
      **/
-    async sessionSubscribe(params: remote.SessionSubscribeParameters | remote.SessionSubscriptionRequest): Promise<local.SessionSubscribeResult> {
+    async sessionSubscribe(params: remote.SessionSubscribeParameters): Promise<local.SessionSubscribeResult> {
         const result = await this.send({
             method: 'session.subscribe',
             params

--- a/packages/webdriver/src/bidi/localTypes.ts
+++ b/packages/webdriver/src/bidi/localTypes.ts
@@ -15,13 +15,13 @@
 
 export type Message = CommandResponse | ErrorResponse | Event
 
-export interface CommandResponse extends Extensible {
+export type CommandResponse = Extensible & {
     type: 'success';
     id: JsUint;
     result: ResultData;
 }
 
-export interface ErrorResponse extends Extensible {
+export type ErrorResponse = Extensible & {
     type: 'error';
     id: JsUint | null;
     error: ErrorCode;
@@ -30,14 +30,14 @@ export interface ErrorResponse extends Extensible {
 }
 
 export type ResultData = BrowserResult | BrowsingContextResult | EmulationResult | InputResult | NetworkResult | ScriptResult | SessionResult | StorageResult | WebExtensionResult
-export interface EmptyResult extends Extensible {}
+export type EmptyResult = Extensible
 
 export type Event = EventData & Extensible & {
     type: 'event';
 }
 
-export type Extensible = Record<string, unknown>
 export type EventData = BrowsingContextEvent | InputEvent | LogEvent | NetworkEvent | ScriptEvent
+export type Extensible = Record<string, unknown>
 export type JsInt = number
 export type JsUint = number
 export type ErrorCode = 'invalid argument' | 'invalid selector' | 'invalid session id' | 'invalid web extension' | 'move target out of bounds' | 'no such alert' | 'no such network collector' | 'no such element' | 'no such frame' | 'no such handle' | 'no such history entry' | 'no such intercept' | 'no such network data' | 'no such node' | 'no such request' | 'no such script' | 'no such storage partition' | 'no such user context' | 'no such web extension' | 'session not created' | 'unable to capture screen' | 'unable to close browser' | 'unable to set cookie' | 'unable to set file input' | 'unavailable network data' | 'underspecified storage partition' | 'unknown command' | 'unknown error' | 'unsupported operation'
@@ -48,7 +48,7 @@ export interface SessionCapabilitiesRequest {
     firstMatch?: SessionCapabilityRequest[];
 }
 
-export interface SessionCapabilityRequest extends Extensible {
+export type SessionCapabilityRequest = Extensible & {
     acceptInsecureCerts?: boolean;
     browserName?: string;
     browserVersion?: string;
@@ -59,20 +59,16 @@ export interface SessionCapabilityRequest extends Extensible {
 
 export type SessionProxyConfiguration = SessionAutodetectProxyConfiguration | SessionDirectProxyConfiguration | SessionManualProxyConfiguration | SessionPacProxyConfiguration | SessionSystemProxyConfiguration
 
-export interface SessionAutodetectProxyConfiguration extends Extensible {
+export type SessionAutodetectProxyConfiguration = Extensible & {
     proxyType: 'autodetect';
 }
 
-export interface SessionDirectProxyConfiguration extends Extensible {
+export type SessionDirectProxyConfiguration = Extensible & {
     proxyType: 'direct';
 }
 
-export interface SessionManualProxyConfiguration extends SessionSocksProxyConfiguration, Extensible {
+export type SessionManualProxyConfiguration = SessionSocksProxyConfiguration & Extensible & {
     proxyType: 'manual';
-    /**
-     * @deprecated no longer supported by browsers, will be removed in v10. See https://github.com/w3c/webdriver-bidi/commit/c580471251eaefe812526b0c894faf9dc201716d
-     */
-    ftpProxy?: string;
     httpProxy?: string;
     sslProxy?: string;
     noProxy?: string[];
@@ -83,12 +79,12 @@ export interface SessionSocksProxyConfiguration {
     socksVersion: number;
 }
 
-export interface SessionPacProxyConfiguration extends Extensible {
+export type SessionPacProxyConfiguration = Extensible & {
     proxyType: 'pac';
     proxyAutoconfigUrl: string;
 }
 
-export interface SessionSystemProxyConfiguration extends Extensible {
+export type SessionSystemProxyConfiguration = Extensible & {
     proxyType: 'system';
 }
 
@@ -224,7 +220,7 @@ export interface BrowsingContextBaseNavigationInfo {
     userContext?: BrowserUserContext;
 }
 
-export interface BrowsingContextNavigationInfo extends BrowsingContextBaseNavigationInfo {}
+export type BrowsingContextNavigationInfo = BrowsingContextBaseNavigationInfo
 export type BrowsingContextUserPromptType = 'alert' | 'beforeunload' | 'confirm' | 'prompt'
 export type BrowsingContextActivateResult = EmptyResult
 
@@ -258,10 +254,10 @@ export interface BrowsingContextPrintResult {
     data: string;
 }
 
-export interface BrowsingContextTraverseHistoryResult {}
 export type BrowsingContextReloadResult = BrowsingContextNavigateResult
 export type BrowsingContextSetBypassCspResult = EmptyResult
 export type BrowsingContextSetViewportResult = EmptyResult
+export type BrowsingContextTraverseHistoryResult = EmptyResult
 
 export interface BrowsingContextContextCreated {
     method: 'browsingContext.contextCreated';
@@ -310,7 +306,7 @@ export interface BrowsingContextDownloadWillBegin {
     params: BrowsingContextDownloadWillBeginParams;
 }
 
-export interface BrowsingContextDownloadWillBeginParams extends BrowsingContextBaseNavigationInfo {
+export type BrowsingContextDownloadWillBeginParams = BrowsingContextBaseNavigationInfo & {
     suggestedFilename: string;
 }
 
@@ -419,7 +415,7 @@ export type NetworkCollector = string
 export type NetworkCollectorType = 'blob'
 export type NetworkSameSite = 'strict' | 'lax' | 'none' | 'default'
 
-export interface NetworkCookie extends Extensible {
+export type NetworkCookie = Extensible & {
     name: string;
     value: NetworkBytesValue;
     domain: string;
@@ -526,7 +522,7 @@ export interface NetworkAuthRequired {
     params: NetworkAuthRequiredParameters;
 }
 
-export interface NetworkAuthRequiredParameters extends NetworkBaseParameters {
+export type NetworkAuthRequiredParameters = NetworkBaseParameters & {
     response: NetworkResponseData;
 }
 
@@ -535,7 +531,7 @@ export interface NetworkBeforeRequestSent {
     params: NetworkBeforeRequestSentParameters;
 }
 
-export interface NetworkBeforeRequestSentParameters extends NetworkBaseParameters {
+export type NetworkBeforeRequestSentParameters = NetworkBaseParameters & {
     initiator?: NetworkInitiator;
 }
 
@@ -544,7 +540,7 @@ export interface NetworkFetchError {
     params: NetworkFetchErrorParameters;
 }
 
-export interface NetworkFetchErrorParameters extends NetworkBaseParameters {
+export type NetworkFetchErrorParameters = NetworkBaseParameters & {
     errorText: string;
 }
 
@@ -553,7 +549,7 @@ export interface NetworkResponseCompleted {
     params: NetworkResponseCompletedParameters;
 }
 
-export interface NetworkResponseCompletedParameters extends NetworkBaseParameters {
+export type NetworkResponseCompletedParameters = NetworkBaseParameters & {
     response: NetworkResponseData;
 }
 
@@ -562,7 +558,7 @@ export interface NetworkResponseStarted {
     params: NetworkResponseStartedParameters;
 }
 
-export interface NetworkResponseStartedParameters extends NetworkBaseParameters {
+export type NetworkResponseStartedParameters = NetworkBaseParameters & {
     response: NetworkResponseData;
 }
 
@@ -605,18 +601,13 @@ export interface ScriptExceptionDetails {
 
 export type ScriptHandle = string
 export type ScriptInternalId = string
-export type ScriptLocalValue = ScriptRemoteReference | ScriptPrimitiveProtocolValue | ScriptChannelValue | ScriptArrayLocalValue | ScriptDateLocalValueMap | ScriptDateLocalValue | ScriptMapLocalValue | ScriptObjectLocalValue | ScriptRegExpLocalValueMap | ScriptRegExpLocalValue | ScriptSetLocalValue
+export type ScriptLocalValue = ScriptRemoteReference | ScriptPrimitiveProtocolValue | ScriptChannelValue | ScriptArrayLocalValue | ScriptDateLocalValue | ScriptMapLocalValue | ScriptObjectLocalValue | ScriptRegExpLocalValue | ScriptSetLocalValue
 export type ScriptListLocalValue = ScriptLocalValue[]
 
 export interface ScriptArrayLocalValue {
     type: 'array';
     value: ScriptListLocalValue;
 }
-
-/**
- * @deprecated in v9. Will be removed in v10 since the new cddl library will no longer generate this layer and rely on on ScriptDateLocalValue
- */
-export interface ScriptDateLocalValueMap extends ScriptDateLocalValue {}
 
 export interface ScriptDateLocalValue {
     type: 'date';
@@ -639,11 +630,6 @@ export interface ScriptRegExpValue {
     pattern: string;
     flags?: string;
 }
-
-/**
- * @deprecated in v9. Will be removed in v10 since the new cddl library will no longer generate this layer and rely on on ScriptDateLocalValue
- */
-export interface ScriptRegExpLocalValueMap extends ScriptRegExpLocalValue {}
 
 export interface ScriptRegExpLocalValue {
     type: 'regexp';
@@ -696,51 +682,51 @@ export interface ScriptBaseRealmInfo {
     origin: string;
 }
 
-export interface ScriptWindowRealmInfo extends ScriptBaseRealmInfo {
+export type ScriptWindowRealmInfo = ScriptBaseRealmInfo & {
     type: 'window';
     context: BrowsingContextBrowsingContext;
     userContext?: BrowserUserContext;
     sandbox?: string;
 }
 
-export interface ScriptDedicatedWorkerRealmInfo extends ScriptBaseRealmInfo {
+export type ScriptDedicatedWorkerRealmInfo = ScriptBaseRealmInfo & {
     type: 'dedicated-worker';
     owners: ScriptRealm[];
 }
 
-export interface ScriptSharedWorkerRealmInfo extends ScriptBaseRealmInfo {
+export type ScriptSharedWorkerRealmInfo = ScriptBaseRealmInfo & {
     type: 'shared-worker';
 }
 
-export interface ScriptServiceWorkerRealmInfo extends ScriptBaseRealmInfo {
+export type ScriptServiceWorkerRealmInfo = ScriptBaseRealmInfo & {
     type: 'service-worker';
 }
 
-export interface ScriptWorkerRealmInfo extends ScriptBaseRealmInfo {
+export type ScriptWorkerRealmInfo = ScriptBaseRealmInfo & {
     type: 'worker';
 }
 
-export interface ScriptPaintWorkletRealmInfo extends ScriptBaseRealmInfo {
+export type ScriptPaintWorkletRealmInfo = ScriptBaseRealmInfo & {
     type: 'paint-worklet';
 }
 
-export interface ScriptAudioWorkletRealmInfo extends ScriptBaseRealmInfo {
+export type ScriptAudioWorkletRealmInfo = ScriptBaseRealmInfo & {
     type: 'audio-worklet';
 }
 
-export interface ScriptWorkletRealmInfo extends ScriptBaseRealmInfo {
+export type ScriptWorkletRealmInfo = ScriptBaseRealmInfo & {
     type: 'worklet';
 }
 
 export type ScriptRealmType = 'window' | 'dedicated-worker' | 'shared-worker' | 'service-worker' | 'worker' | 'paint-worklet' | 'audio-worklet' | 'worklet'
 export type ScriptRemoteReference = ScriptSharedReference | ScriptRemoteObjectReference
 
-export interface ScriptSharedReference extends Extensible {
+export type ScriptSharedReference = Extensible & {
     sharedId: ScriptSharedId;
     handle?: ScriptHandle;
 }
 
-export interface ScriptRemoteObjectReference extends Extensible {
+export type ScriptRemoteObjectReference = Extensible & {
     handle: ScriptHandle;
     sharedId?: ScriptSharedId;
 }
@@ -775,12 +761,12 @@ export interface ScriptFunctionRemoteValue {
     internalId?: ScriptInternalId;
 }
 
-export interface ScriptRegExpRemoteValue extends ScriptRegExpLocalValue {
+export type ScriptRegExpRemoteValue = ScriptRegExpLocalValue & {
     handle?: ScriptHandle;
     internalId?: ScriptInternalId;
 }
 
-export interface ScriptDateRemoteValue extends ScriptDateLocalValue {
+export type ScriptDateRemoteValue = ScriptDateLocalValue & {
     handle?: ScriptHandle;
     internalId?: ScriptInternalId;
 }
@@ -965,7 +951,7 @@ export interface ScriptRealmDestroyedParameters {
 
 export type StorageResult = StorageDeleteCookiesResult | StorageGetCookiesResult | StorageSetCookieResult
 
-export interface StoragePartitionKey extends Extensible {
+export type StoragePartitionKey = Extensible & {
     userContext?: string;
     sourceOrigin?: string;
 }
@@ -983,7 +969,7 @@ export interface StorageDeleteCookiesResult {
     partitionKey: StoragePartitionKey;
 }
 
-export interface LogEvent extends LogEntryAdded {}
+export type LogEvent = LogEntryAdded
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 export type LogEntry = LogGenericLogEntry | LogConsoleLogEntry | LogJavascriptLogEntry
 
@@ -995,17 +981,17 @@ export interface LogBaseLogEntry {
     stackTrace?: ScriptStackTrace;
 }
 
-export interface LogGenericLogEntry extends LogBaseLogEntry {
+export type LogGenericLogEntry = LogBaseLogEntry & {
     type: string;
 }
 
-export interface LogConsoleLogEntry extends LogBaseLogEntry {
+export type LogConsoleLogEntry = LogBaseLogEntry & {
     type: 'console';
     method: string;
     args: ScriptRemoteValue[];
 }
 
-export interface LogJavascriptLogEntry extends LogBaseLogEntry {
+export type LogJavascriptLogEntry = LogBaseLogEntry & {
     type: 'javascript';
 }
 
@@ -1014,8 +1000,8 @@ export interface LogEntryAdded {
     params: LogEntry;
 }
 
-export interface InputEvent extends InputFileDialogOpened {}
 export type InputResult = InputPerformActionsResult | InputReleaseActionsResult | InputSetFilesResult
+export type InputEvent = InputFileDialogOpened
 export type InputPerformActionsResult = EmptyResult
 export type InputReleaseActionsResult = EmptyResult
 export type InputSetFilesResult = EmptyResult

--- a/packages/webdriver/src/bidi/remoteTypes.ts
+++ b/packages/webdriver/src/bidi/remoteTypes.ts
@@ -17,9 +17,9 @@ export type Command = CommandData & Extensible & {
     id: JsUint;
 }
 
-export type Extensible = Record<string, unknown>
 export type CommandData = BrowserCommand | BrowsingContextCommand | EmulationCommand | InputCommand | NetworkCommand | ScriptCommand | SessionCommand | StorageCommand | WebExtensionCommand
-export interface EmptyParams {}
+export type EmptyParams = Extensible
+export type Extensible = Record<string, unknown>
 export type JsInt = number
 export type JsUint = number
 export type SessionCommand = SessionEnd | SessionNew | SessionStatus | SessionSubscribe | SessionUnsubscribe
@@ -29,7 +29,7 @@ export interface SessionCapabilitiesRequest {
     firstMatch?: SessionCapabilityRequest[];
 }
 
-export interface SessionCapabilityRequest extends Extensible {
+export type SessionCapabilityRequest = Extensible & {
     acceptInsecureCerts?: boolean;
     browserName?: string;
     browserVersion?: string;
@@ -40,20 +40,16 @@ export interface SessionCapabilityRequest extends Extensible {
 
 export type SessionProxyConfiguration = SessionAutodetectProxyConfiguration | SessionDirectProxyConfiguration | SessionManualProxyConfiguration | SessionPacProxyConfiguration | SessionSystemProxyConfiguration
 
-export interface SessionAutodetectProxyConfiguration extends Extensible {
+export type SessionAutodetectProxyConfiguration = Extensible & {
     proxyType: 'autodetect';
 }
 
-export interface SessionDirectProxyConfiguration extends Extensible {
+export type SessionDirectProxyConfiguration = Extensible & {
     proxyType: 'direct';
 }
 
-export interface SessionManualProxyConfiguration extends SessionSocksProxyConfiguration, Extensible {
+export type SessionManualProxyConfiguration = SessionSocksProxyConfiguration & Extensible & {
     proxyType: 'manual';
-    /**
-     * @deprecated no longer supported by browsers, will be removed in v10. See https://github.com/w3c/webdriver-bidi/commit/c580471251eaefe812526b0c894faf9dc201716d
-     */
-    ftpProxy?: string;
     httpProxy?: string;
     sslProxy?: string;
     noProxy?: string[];
@@ -64,12 +60,12 @@ export interface SessionSocksProxyConfiguration {
     socksVersion: number;
 }
 
-export interface SessionPacProxyConfiguration extends Extensible {
+export type SessionPacProxyConfiguration = Extensible & {
     proxyType: 'pac';
     proxyAutoconfigUrl: string;
 }
 
-export interface SessionSystemProxyConfiguration extends Extensible {
+export type SessionSystemProxyConfiguration = Extensible & {
     proxyType: 'system';
 }
 
@@ -85,11 +81,6 @@ export interface SessionUserPromptHandler {
 export type SessionUserPromptHandlerType = 'accept' | 'dismiss' | 'ignore'
 export type SessionSubscription = string
 
-/**
- * @deprecated Use SessionSubscribeParameters instead, will be removed in v10.
- */
-export interface SessionSubscriptionRequest extends SessionSubscribeParameters {}
-
 export interface SessionSubscribeParameters {
     events: string[];
     contexts?: BrowsingContextBrowsingContext[];
@@ -102,10 +93,6 @@ export interface SessionUnsubscribeByIdRequest {
 
 export interface SessionUnsubscribeByAttributesRequest {
     events: string[];
-    /**
-     * @deprecated should no longer be used, will be removed in v10, see https://github.com/w3c/webdriver-bidi/issues/829 & https://github.com/w3c/webdriver-bidi/pull/998
-     */
-    contexts?: BrowsingContextBrowsingContext[];
 }
 
 export interface SessionStatus {
@@ -129,7 +116,7 @@ export interface SessionEnd {
 
 export interface SessionSubscribe {
     method: 'session.subscribe';
-    params: SessionSubscribeParameters | SessionSubscriptionRequest;
+    params: SessionSubscribeParameters;
 }
 
 export interface SessionUnsubscribe {
@@ -694,7 +681,7 @@ export type NetworkCollector = string
 export type NetworkCollectorType = 'blob'
 export type NetworkSameSite = 'strict' | 'lax' | 'none' | 'default'
 
-export interface NetworkCookie extends Extensible {
+export type NetworkCookie = Extensible & {
     name: string;
     value: NetworkBytesValue;
     domain: string;
@@ -947,18 +934,13 @@ export interface ScriptExceptionDetails {
 
 export type ScriptHandle = string
 export type ScriptInternalId = string
-export type ScriptLocalValue = ScriptRemoteReference | ScriptPrimitiveProtocolValue | ScriptChannelValue | ScriptArrayLocalValue | ScriptDateLocalValueMap | ScriptDateLocalValue | ScriptMapLocalValue | ScriptObjectLocalValue | ScriptRegExpLocalValueMap | ScriptRegExpLocalValue | ScriptSetLocalValue
+export type ScriptLocalValue = ScriptRemoteReference | ScriptPrimitiveProtocolValue | ScriptChannelValue | ScriptArrayLocalValue | ScriptDateLocalValue | ScriptMapLocalValue | ScriptObjectLocalValue | ScriptRegExpLocalValue | ScriptSetLocalValue
 export type ScriptListLocalValue = ScriptLocalValue[]
 
 export interface ScriptArrayLocalValue {
     type: 'array';
     value: ScriptListLocalValue;
 }
-
-/**
- * @deprecated in v9. Will be removed in v10 since the new cddl library will no longer generate this layer and rely on on ScriptDateLocalValue
- */
-export interface ScriptDateLocalValueMap extends ScriptDateLocalValue {}
 
 export interface ScriptDateLocalValue {
     type: 'date';
@@ -981,11 +963,6 @@ export interface ScriptRegExpValue {
     pattern: string;
     flags?: string;
 }
-
-/**
- * @deprecated in v9. Will be removed in v10 since the new cddl library will no longer generate this layer and rely on on ScriptDateLocalValue
- */
-export interface ScriptRegExpLocalValueMap extends ScriptRegExpLocalValue {}
 
 export interface ScriptRegExpLocalValue {
     type: 'regexp';
@@ -1034,12 +1011,12 @@ export interface ScriptBigIntValue {
 export type ScriptRealmType = 'window' | 'dedicated-worker' | 'shared-worker' | 'service-worker' | 'worker' | 'paint-worklet' | 'audio-worklet' | 'worklet'
 export type ScriptRemoteReference = ScriptSharedReference | ScriptRemoteObjectReference
 
-export interface ScriptSharedReference extends Extensible {
+export type ScriptSharedReference = Extensible & {
     sharedId: ScriptSharedId;
     handle?: ScriptHandle;
 }
 
-export interface ScriptRemoteObjectReference extends Extensible {
+export type ScriptRemoteObjectReference = Extensible & {
     handle: ScriptHandle;
     sharedId?: ScriptSharedId;
 }
@@ -1074,12 +1051,12 @@ export interface ScriptFunctionRemoteValue {
     internalId?: ScriptInternalId;
 }
 
-export interface ScriptRegExpRemoteValue extends ScriptRegExpLocalValue {
+export type ScriptRegExpRemoteValue = ScriptRegExpLocalValue & {
     handle?: ScriptHandle;
     internalId?: ScriptInternalId;
 }
 
-export interface ScriptDateRemoteValue extends ScriptDateLocalValue {
+export type ScriptDateRemoteValue = ScriptDateLocalValue & {
     handle?: ScriptHandle;
     internalId?: ScriptInternalId;
 }
@@ -1303,7 +1280,7 @@ export interface ScriptRemovePreloadScriptParameters {
 
 export type StorageCommand = StorageDeleteCookies | StorageGetCookies | StorageSetCookie
 
-export interface StoragePartitionKey extends Extensible {
+export type StoragePartitionKey = Extensible & {
     userContext?: string;
     sourceOrigin?: string;
 }
@@ -1313,7 +1290,7 @@ export interface StorageGetCookies {
     params: StorageGetCookiesParameters;
 }
 
-export interface StorageCookieFilter extends Extensible {
+export type StorageCookieFilter = Extensible & {
     name?: string;
     value?: NetworkBytesValue;
     domain?: string;
@@ -1330,7 +1307,7 @@ export interface StorageBrowsingContextPartitionDescriptor {
     context: BrowsingContextBrowsingContext;
 }
 
-export interface StorageStorageKeyPartitionDescriptor extends Extensible {
+export type StorageStorageKeyPartitionDescriptor = Extensible & {
     type: 'storageKey';
     userContext?: string;
     sourceOrigin?: string;
@@ -1348,7 +1325,7 @@ export interface StorageSetCookie {
     params: StorageSetCookieParameters;
 }
 
-export interface StoragePartialCookie extends Extensible {
+export type StoragePartialCookie = Extensible & {
     name: string;
     value: NetworkBytesValue;
     domain: string;
@@ -1455,12 +1432,12 @@ export interface InputPointerUpAction {
     button: JsUint;
 }
 
-export interface InputPointerDownAction extends InputPointerCommonProperties {
+export type InputPointerDownAction = InputPointerCommonProperties & {
     type: 'pointerDown';
     button: JsUint;
 }
 
-export interface InputPointerMoveAction extends InputPointerCommonProperties {
+export type InputPointerMoveAction = InputPointerCommonProperties & {
     type: 'pointerMove';
     x: number;
     y: number;

--- a/scripts/bidi/index.ts
+++ b/scripts/bidi/index.ts
@@ -129,6 +129,8 @@ for (const assignment of astRemote) {
             .replaceAll('\n', '<br />')
             .replaceAll('*', '\\*')
             .replaceAll('|', '&#124;')
+            .replaceAll('{', '\\{')
+            .replaceAll('}', '\\}')
 
     const commandReturnAST = astLocal.find((a) => a.Name === (responseType?.Name || 'EmptyResult'))
     const commandReturnTS = commandReturnAST ? transform([commandReturnAST]) : ''
@@ -147,7 +149,7 @@ for (const assignment of astRemote) {
                 type: `\`${paramType}\``,
 
                 description: paramExample
-                    ? `<pre>\\${paramExample.slice(0, -1)}\\}</pre>`
+                    ? `<pre>${paramExample}</pre>`
                     : '<pre>\\{\\}</pre>',
                 required: true
             }],

--- a/scripts/docs-generation/electronDocs.ts
+++ b/scripts/docs-generation/electronDocs.ts
@@ -43,12 +43,24 @@ export async function generateElectronDocs () {
         // Drop the source's first H1 heading (Docusaurus uses front-matter title)
         const stripped = raw.replace(/^#[^\n]*\n+/, '')
 
+        const sourceFileDir = path.posix.dirname(remotePath)
+        const resolveRelativePath = (relativePath: string) => {
+            const resolved = path.posix.normalize(`${sourceFileDir}/${relativePath}`)
+            return `https://raw.githubusercontent.com/${GITHUB_REPO}/${DOCS_SHA}/${resolved}`
+        }
+
         const transformed = rewriteLinks(stripped)
-            // Rewrite repo-relative image paths (e.g. ../assets/foo.png) to absolute raw URLs
+            // Rewrite repo-relative image paths in markdown syntax to absolute raw GitHub URLs
             .replace(
-                /(\]|src=")(\.\.\/)+(assets\/[\w./-]+)/g,
-                (_match, prefix: string, _dots: string, assetPath: string) =>
-                    `${prefix}https://raw.githubusercontent.com/${GITHUB_REPO}/${DOCS_SHA}/${DOCS_SOURCE_DIR}/${assetPath}`
+                /!\[([^\]]*)\]\(((?:\.\.\/)+[^\s)"']+)((?:\s+'[^']*')?)\)/g,
+                (_match, alt: string, relativePath: string, title: string) =>
+                    `![${alt}](${resolveRelativePath(relativePath)}${title})`
+            )
+            // Rewrite repo-relative image paths in HTML src attributes to absolute raw GitHub URLs
+            .replace(
+                /(src=")((?:\.\.\/)+[^\s"]+)/g,
+                (_match, prefix: string, relativePath: string) =>
+                    `${prefix}${resolveRelativePath(relativePath)}`
             )
 
         await fs.writeFile(newDocsPath, `---

--- a/scripts/docs-generation/tauriDocs.ts
+++ b/scripts/docs-generation/tauriDocs.ts
@@ -45,12 +45,32 @@ export async function generateTauriDocs () {
 
         const stripped = raw.replace(/^#[^\n]*\n+/, '')
 
+        const sourceFileDir = path.posix.dirname(remotePath)
+        const resolveRelativePath = (relativePath: string) => {
+            const resolved = path.posix.normalize(`${sourceFileDir}/${relativePath}`)
+            return `https://raw.githubusercontent.com/${GITHUB_REPO}/${DOCS_SHA}/${resolved}`
+        }
+
+        let inCodeBlock = false
         const transformed = rewriteLinks(stripped)
+            // Rewrite repo-relative image paths in markdown syntax to absolute raw GitHub URLs
             .replace(
-                /(\]|src=")(\.\.\/)+(assets\/[\w./-]+)/g,
-                (_match, prefix: string, _dots: string, assetPath: string) =>
-                    `${prefix}https://raw.githubusercontent.com/${GITHUB_REPO}/${DOCS_SHA}/${DOCS_SOURCE_DIR}/${assetPath}`
+                /!\[([^\]]*)\]\(((?:\.\.\/)+[^\s)"']+)((?:\s+'[^']*')?)\)/g,
+                (_match, alt: string, relativePath: string, title: string) =>
+                    `![${alt}](${resolveRelativePath(relativePath)}${title})`
             )
+            // Rewrite repo-relative image paths in HTML src attributes to absolute raw GitHub URLs
+            .replace(
+                /(src=")((?:\.\.\/)+[^\s"]+)/g,
+                (_match, prefix: string, relativePath: string) =>
+                    `${prefix}${resolveRelativePath(relativePath)}`
+            )
+            // Escape TypeScript generic angle brackets in plain text to prevent MDX parse errors
+            .split('\n').map((line) => {
+                if (/^```/.test(line)) { inCodeBlock = !inCodeBlock }
+                if (inCodeBlock) { return line }
+                return line.replace(/<([A-Z][a-zA-Z0-9]+)>/g, '\\<$1>')
+            }).join('\n')
 
         await fs.writeFile(newDocsPath, `---
 id: ${id}


### PR DESCRIPTION
## Proposed changes

The docs build has been broken since the latest bidi spec update. Running `pnpm run docs` fails with 3 MDX compilation errors (also happens locally, see https://github.com/webdriverio/webdriverio/actions/runs/25857338074/job/75978354499).

- `_webdriverBidi.md`: the bidi generator only escapes the outer `{`/`}` of parameter descriptions, for union/intersection types like `emulation.setGeolocationOverride` the inner braces stay raw and acorn can't parse them. Fixed `scripts/bidi/index.ts` and patched the already-generated `webdriverBidi.ts`
- `electron/api.md`: the image path rewrite regex looked for `]../` but markdown image syntax is `](../`, so relative images were never rewritten to absolute GitHub raw URLs
- `tauri/api.md`: `Partial<TauriServiceOptions>` in plain text gets parsed by MDX as an unclosed JSX tag — added a post-processing step to escape `<PascalCase>` patterns outside code blocks
- Added `temp_extract/` to `.gitignore` since the cleanup in `downloadDocsTranslations` can silently fail and leave it behind

Also includes the bidi type/handler changes from the spec update that triggered this.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
