### PR TITLE
fix(wdio-browserstack-service): skip performO11ySync execute call in …

### DIFF
--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -1920,7 +1920,7 @@ export function getMochaTestHierarchy(test: Frameworks.Test) {
 }
 
 export const performO11ySync = async (browser: WebdriverIO.Browser) => {
-    if (isBrowserstackSession(browser)) {
+    if (isBrowserstackSession(browser) && !browser.isBidi) {
         await browser.execute(`browserstack_executor: ${JSON.stringify({
             action: 'annotate',
             arguments: {

--- a/packages/wdio-browserstack-service/tests/util.test.ts
+++ b/packages/wdio-browserstack-service/tests/util.test.ts
@@ -54,6 +54,7 @@ import {
     getAppA11yResults,
     isMultiRemoteCaps,
     getTestPlanId,
+    performO11ySync,
 } from '../src/util.js'
 import * as bstackLogger from '../src/bstackLogger.js'
 import PerformanceTester from '../src/instrumentation/performance/performance-tester.js'
@@ -2257,5 +2258,48 @@ describe('getAppA11yResultsSummary', () => {
         const result = await utils.getA11yResultsSummary(false, {} as WebdriverIO.Browser, true, true)
         delete process.env.BSTACK_A11Y_JWT
         expect(result).toEqual({ })
+    })
+})
+
+describe('performO11ySync', () => {
+    it('calls browser.execute with browserstack_executor when classic WebDriver session', async () => {
+        const mockExecute = vi.fn().mockResolvedValue(null)
+        const browser = {
+            isBidi: false,
+            options: { hostname: 'hub.browserstack.com' },
+            execute: mockExecute,
+        } as unknown as WebdriverIO.Browser
+
+        await performO11ySync(browser)
+
+        expect(mockExecute).toHaveBeenCalledOnce()
+        expect(mockExecute.mock.calls[0][0]).toContain('browserstack_executor')
+        expect(mockExecute.mock.calls[0][0]).toContain('ObservabilitySync')
+    })
+
+    it('skips browser.execute when session is BiDi to avoid new Function() validation failure', async () => {
+        const mockExecute = vi.fn().mockResolvedValue(null)
+        const browser = {
+            isBidi: true,
+            options: { hostname: 'hub.browserstack.com' },
+            execute: mockExecute,
+        } as unknown as WebdriverIO.Browser
+
+        await performO11ySync(browser)
+
+        expect(mockExecute).not.toHaveBeenCalled()
+    })
+
+    it('skips browser.execute when not a BrowserStack session', async () => {
+        const mockExecute = vi.fn().mockResolvedValue(null)
+        const browser = {
+            isBidi: false,
+            options: { hostname: 'localhost' },
+            execute: mockExecute,
+        } as unknown as WebdriverIO.Browser
+
+        await performO11ySync(browser)
+
+        expect(mockExecute).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
…BiDi sessions

In BiDi mode, webdriverio validates scripts via `new Function()` before dispatching. The `browserstack_executor: {...}` string used by `performO11ySync` is not valid JavaScript (it's a BrowserStack-specific protocol intercepted at the WebDriver protocol layer), so it throws a SyntaxError.

Guard the `browser.execute()` call with `!browser.isBidi` to skip it when BiDi is active. The observability sync is a non-critical annotation; skipping it for BiDi sessions is preferable to crashing the test run.

Fixes #15207

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

`performO11ySync` calls `browser.execute()` with `browserstack_executor: {...}` — a BrowserStack-specific protocol string that is intercepted at the WebDriver layer, not executed as JavaScript. In BiDi mode, WebdriverIO validates scripts via `new Function()` before dispatching them, which throws a `SyntaxError: Unexpected token ':'` because the string is not valid JavaScript. This crashes every test immediately on session start when `testObservability` is enabled with a BiDi session.                       
                                                                                                                                                    
Fix: guard the `browser.execute()` call with `!browser.isBidi`. The observability sync is a non-critical debug-level timing annotation; all actual test result reporting (pass/fail, logs) goes through separate REST API calls and is unaffected.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

`performO11ySync` is called `onBeforeTest` and sends `{"action":"annotate","arguments":{"data":"ObservabilitySync:<timestamp>","level":"debug"}}` via `browser.execute()`. All other BrowserStack executor calls in the service (`service.ts`, `insights-handler.ts`) already use `browser.executeScript()`, which bypasses the BiDi validation path — only this one call used `browser.execute()`.

### Reviewers: @webdriverio/project-committers
