### PR TITLE
fix(browserstack-service): restore boolean product map types

### DIFF
--- a/packages/wdio-browserstack-service/src/testHub/utils.ts
+++ b/packages/wdio-browserstack-service/src/testHub/utils.ts
@@ -13,10 +13,10 @@ export interface Errors {
     errors: ErrorType[]
 }
 
-export const getProductMap = (config: BrowserStackConfig): { [key: string]: boolean | undefined } => {
+export const getProductMap = (config: BrowserStackConfig): { [key: string]: boolean } => {
     return {
         observability: config.testObservability.enabled,
-        accessibility: config.accessibility,
+        accessibility: config.accessibility === true,
         percy: config.percy,
         automate: config.automate,
         app_automate: config.appAutomate

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -364,7 +364,7 @@ export const processLaunchBuildResponse = (response: LaunchResponse, options: Br
     processAccessibilityResponse(response, options)
 }
 
-export const launchTestSession = PerformanceTester.measureWrapper(PERFORMANCE_SDK_EVENTS.TESTHUB_EVENTS.START, o11yErrorHandler(async function launchTestSession(options: BrowserstackConfig & Options.Testrunner, config: Options.Testrunner, bsConfig: UserConfig, bStackConfig: BrowserStackConfig, accessibilityAutomation: boolean | null) {
+export const launchTestSession = PerformanceTester.measureWrapper(PERFORMANCE_SDK_EVENTS.TESTHUB_EVENTS.START, o11yErrorHandler(async function launchTestSession(options: BrowserstackConfig & Options.Testrunner, config: Options.Testrunner, bsConfig: UserConfig, bStackConfig: BrowserStackConfig, accessibilityAutomation?: boolean) {
     const launchBuildUsage = UsageStats.getInstance().launchBuildUsage
     launchBuildUsage.triggered()
 

--- a/packages/wdio-browserstack-service/tests/testHub/utils.test.ts
+++ b/packages/wdio-browserstack-service/tests/testHub/utils.test.ts
@@ -31,6 +31,11 @@ describe('getProductMap', () => {
         }
         expect(productMap).toEqual(expectedProductMap)
     })
+
+    it('should coerce unset accessibility to false', () => {
+        const productMap = utils.getProductMap({ ...config, accessibility: undefined } as any)
+        expect(productMap.accessibility).toBe(false)
+    })
 })
 
 describe('shouldProcessEventForTesthub', () => {

--- a/packages/wdio-browserstack-service/tests/testHub/utils.test.ts
+++ b/packages/wdio-browserstack-service/tests/testHub/utils.test.ts
@@ -36,6 +36,11 @@ describe('getProductMap', () => {
         const productMap = utils.getProductMap({ ...config, accessibility: undefined } as any)
         expect(productMap.accessibility).toBe(false)
     })
+
+    it('should preserve explicit accessibility: true', () => {
+        const productMap = utils.getProductMap({ ...config, accessibility: true } as any)
+        expect(productMap.accessibility).toBe(true)
+    })
 })
 
 describe('shouldProcessEventForTesthub', () => {


### PR DESCRIPTION
PR #15215 loosened getProductMap's return to `{ [key: string]: boolean | undefined }`, which broke the public `Capabilities.buildProductMap` and `EventProperties.productMap` contracts (both `{ [key: string]: boolean }`). It also left launchTestSession declaring `accessibilityAutomation: boolean | null` while the launcher now passes `boolean | undefined`, producing 9 TS errors during `npm run setup`.

Coerce `config.accessibility` (`boolean | undefined`) to `boolean` via `=== true` in getProductMap, and align launchTestSession's parameter to `?: boolean`. Preserves the PR's "omit unset accessibility" intent for the build-start payload without leaking `undefined`/`null` into typed boolean capabilities.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
