### PR TITLE
fix(bidi): make generate:bidi safe to run against latest spec

### DIFF
--- a/packages/wdio-browserstack-service/src/testHub/utils.ts
+++ b/packages/wdio-browserstack-service/src/testHub/utils.ts
@@ -13,10 +13,10 @@ export interface Errors {
     errors: ErrorType[]
 }
 
-export const getProductMap = (config: BrowserStackConfig): { [key: string]: boolean | undefined } => {
+export const getProductMap = (config: BrowserStackConfig): { [key: string]: boolean } => {
     return {
         observability: config.testObservability.enabled,
-        accessibility: config.accessibility,
+        accessibility: config.accessibility === true,
         percy: config.percy,
         automate: config.automate,
         app_automate: config.appAutomate

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -364,7 +364,7 @@ export const processLaunchBuildResponse = (response: LaunchResponse, options: Br
     processAccessibilityResponse(response, options)
 }
 
-export const launchTestSession = PerformanceTester.measureWrapper(PERFORMANCE_SDK_EVENTS.TESTHUB_EVENTS.START, o11yErrorHandler(async function launchTestSession(options: BrowserstackConfig & Options.Testrunner, config: Options.Testrunner, bsConfig: UserConfig, bStackConfig: BrowserStackConfig, accessibilityAutomation: boolean | null) {
+export const launchTestSession = PerformanceTester.measureWrapper(PERFORMANCE_SDK_EVENTS.TESTHUB_EVENTS.START, o11yErrorHandler(async function launchTestSession(options: BrowserstackConfig & Options.Testrunner, config: Options.Testrunner, bsConfig: UserConfig, bStackConfig: BrowserStackConfig, accessibilityAutomation?: boolean) {
     const launchBuildUsage = UsageStats.getInstance().launchBuildUsage
     launchBuildUsage.triggered()
 

--- a/packages/wdio-browserstack-service/tests/testHub/utils.test.ts
+++ b/packages/wdio-browserstack-service/tests/testHub/utils.test.ts
@@ -31,6 +31,11 @@ describe('getProductMap', () => {
         }
         expect(productMap).toEqual(expectedProductMap)
     })
+
+    it('should coerce unset accessibility to false', () => {
+        const productMap = utils.getProductMap({ ...config, accessibility: undefined } as any)
+        expect(productMap.accessibility).toBe(false)
+    })
 })
 
 describe('shouldProcessEventForTesthub', () => {

--- a/packages/wdio-protocols/src/protocols/webdriverBidi.ts
+++ b/packages/wdio-protocols/src/protocols/webdriverBidi.ts
@@ -534,6 +534,46 @@ const protocol = {
             }
         }
     },
+    "browsingContext.startScreencast": {
+        "socket": {
+            "command": "browsingContextStartScreencast",
+            "description": "WebDriver Bidi command to send command method \"browsingContext.startScreencast\" with parameters.",
+            "ref": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-startScreencast",
+            "parameters": [
+                {
+                    "name": "params",
+                    "type": "`remote.BrowsingContextStartScreencastParameters`",
+                    "description": "<pre>\\{<br />  context: BrowsingContextBrowsingContext;<br />  mimeType?: string;<br />  streamOptions?: BrowsingContextMediaStreamOptions;<br />\\}</pre>",
+                    "required": true
+                }
+            ],
+            "returns": {
+                "type": "Object",
+                "name": "local.BrowsingContextStartScreencastResult",
+                "description": "Command return value with the following interface:\n   ```ts\n   {\n     screencast: BrowsingContextScreencast;\n     path: string;\n   }\n   ```"
+            }
+        }
+    },
+    "browsingContext.stopScreencast": {
+        "socket": {
+            "command": "browsingContextStopScreencast",
+            "description": "WebDriver Bidi command to send command method \"browsingContext.stopScreencast\" with parameters.",
+            "ref": "https://w3c.github.io/webdriver-bidi/#command-browsingContext-stopScreencast",
+            "parameters": [
+                {
+                    "name": "params",
+                    "type": "`remote.BrowsingContextStopScreencastParameters`",
+                    "description": "<pre>\\{<br />  screencast: BrowsingContextScreencast;<br />\\}</pre>",
+                    "required": true
+                }
+            ],
+            "returns": {
+                "type": "Object",
+                "name": "local.BrowsingContextStopScreencastResult",
+                "description": "Command return value with the following interface:\n   ```ts\n   {\n     path: string;\n     error?: string;\n   }\n   ```"
+            }
+        }
+    },
     "browsingContext.traverseHistory": {
         "socket": {
             "command": "browsingContextTraverseHistory",

--- a/packages/webdriver/src/bidi/handler.ts
+++ b/packages/webdriver/src/bidi/handler.ts
@@ -379,6 +379,36 @@ export class BidiHandler extends BidiCore {
     }
 
     /**
+     * WebDriver Bidi command to send command method "browsingContext.startScreencast" with parameters.
+     * @url https://w3c.github.io/webdriver-bidi/#command-browsingContext-startScreencast
+     * @param params `remote.BrowsingContextStartScreencastParameters` {@link https://w3c.github.io/webdriver-bidi/#command-browsingContext-startScreencast | command parameter}
+     * @returns `Promise<local.BrowsingContextStartScreencastResult>`
+     **/
+    async browsingContextStartScreencast(params: remote.BrowsingContextStartScreencastParameters): Promise<local.BrowsingContextStartScreencastResult> {
+        const result = await this.send({
+            method: 'browsingContext.startScreencast',
+            params
+        })
+
+        return result.result as local.BrowsingContextStartScreencastResult
+    }
+
+    /**
+     * WebDriver Bidi command to send command method "browsingContext.stopScreencast" with parameters.
+     * @url https://w3c.github.io/webdriver-bidi/#command-browsingContext-stopScreencast
+     * @param params `remote.BrowsingContextStopScreencastParameters` {@link https://w3c.github.io/webdriver-bidi/#command-browsingContext-stopScreencast | command parameter}
+     * @returns `Promise<local.BrowsingContextStopScreencastResult>`
+     **/
+    async browsingContextStopScreencast(params: remote.BrowsingContextStopScreencastParameters): Promise<local.BrowsingContextStopScreencastResult> {
+        const result = await this.send({
+            method: 'browsingContext.stopScreencast',
+            params
+        })
+
+        return result.result as local.BrowsingContextStopScreencastResult
+    }
+
+    /**
      * WebDriver Bidi command to send command method "browsingContext.traverseHistory" with parameters.
      * @url https://w3c.github.io/webdriver-bidi/#command-browsingContext-traverseHistory
      * @param params `remote.BrowsingContextTraverseHistoryParameters` {@link https://w3c.github.io/webdriver-bidi/#command-browsingContext-traverseHistory | command parameter}

--- a/packages/webdriver/src/bidi/localTypes.ts
+++ b/packages/webdriver/src/bidi/localTypes.ts
@@ -40,7 +40,7 @@ export type EventData = BrowsingContextEvent | InputEvent | LogEvent | NetworkEv
 export type Extensible = Record<string, unknown>
 export type JsInt = number
 export type JsUint = number
-export type ErrorCode = 'invalid argument' | 'invalid selector' | 'invalid session id' | 'invalid web extension' | 'move target out of bounds' | 'no such alert' | 'no such network collector' | 'no such element' | 'no such frame' | 'no such handle' | 'no such history entry' | 'no such intercept' | 'no such network data' | 'no such node' | 'no such request' | 'no such script' | 'no such storage partition' | 'no such user context' | 'no such web extension' | 'session not created' | 'unable to capture screen' | 'unable to close browser' | 'unable to set cookie' | 'unable to set file input' | 'unavailable network data' | 'underspecified storage partition' | 'unknown command' | 'unknown error' | 'unsupported operation'
+export type ErrorCode = 'invalid argument' | 'invalid selector' | 'invalid session id' | 'invalid web extension' | 'move target out of bounds' | 'no such alert' | 'no such network collector' | 'no such element' | 'no such frame' | 'no such handle' | 'no such history entry' | 'no such intercept' | 'no such network data' | 'no such node' | 'no such request' | 'no such screencast' | 'no such script' | 'no such storage partition' | 'no such user context' | 'no such web extension' | 'session not created' | 'unable to capture screen' | 'unable to close browser' | 'unable to set cookie' | 'unable to set file input' | 'unavailable network data' | 'underspecified storage partition' | 'unknown command' | 'unknown error' | 'unsupported operation'
 export type SessionResult = SessionEndResult | SessionNewResult | SessionStatusResult | SessionSubscribeResult | SessionUnsubscribeResult
 
 export interface SessionCapabilitiesRequest {
@@ -160,7 +160,7 @@ export interface BrowserGetUserContextsResult {
 export type BrowserRemoveUserContextResult = EmptyResult
 export type BrowserSetClientWindowStateResult = BrowserClientWindowInfo
 export type BrowserSetDownloadBehaviorResult = EmptyResult
-export type BrowsingContextResult = BrowsingContextActivateResult | BrowsingContextCaptureScreenshotResult | BrowsingContextCloseResult | BrowsingContextCreateResult | BrowsingContextGetTreeResult | BrowsingContextHandleUserPromptResult | BrowsingContextLocateNodesResult | BrowsingContextNavigateResult | BrowsingContextPrintResult | BrowsingContextReloadResult | BrowsingContextSetBypassCspResult | BrowsingContextSetViewportResult | BrowsingContextTraverseHistoryResult
+export type BrowsingContextResult = BrowsingContextActivateResult | BrowsingContextCaptureScreenshotResult | BrowsingContextCloseResult | BrowsingContextCreateResult | BrowsingContextGetTreeResult | BrowsingContextHandleUserPromptResult | BrowsingContextLocateNodesResult | BrowsingContextNavigateResult | BrowsingContextPrintResult | BrowsingContextReloadResult | BrowsingContextSetBypassCspResult | BrowsingContextSetViewportResult | BrowsingContextStartScreencastResult | BrowsingContextStopScreencastResult | BrowsingContextTraverseHistoryResult
 export type BrowsingContextEvent = BrowsingContextContextCreated | BrowsingContextContextDestroyed | BrowsingContextDomContentLoaded | BrowsingContextDownloadEnd | BrowsingContextDownloadWillBegin | BrowsingContextFragmentNavigated | BrowsingContextHistoryUpdated | BrowsingContextLoad | BrowsingContextNavigationAborted | BrowsingContextNavigationCommitted | BrowsingContextNavigationFailed | BrowsingContextNavigationStarted | BrowsingContextUserPromptClosed | BrowsingContextUserPromptOpened
 export type BrowsingContextBrowsingContext = string
 export type BrowsingContextInfoList = BrowsingContextInfo[]
@@ -211,6 +211,7 @@ export interface BrowsingContextXPathLocator {
 }
 
 export type BrowsingContextNavigation = string
+export type BrowsingContextDownload = string
 
 export interface BrowsingContextBaseNavigationInfo {
     context: BrowsingContextBrowsingContext;
@@ -257,6 +258,19 @@ export interface BrowsingContextPrintResult {
 export type BrowsingContextReloadResult = BrowsingContextNavigateResult
 export type BrowsingContextSetBypassCspResult = EmptyResult
 export type BrowsingContextSetViewportResult = EmptyResult
+
+export interface BrowsingContextStartScreencastResult {
+    screencast: BrowsingContextScreencast;
+    path: string;
+}
+
+export type BrowsingContextScreencast = string
+
+export interface BrowsingContextStopScreencastResult {
+    path: string;
+    error?: string;
+}
+
 export type BrowsingContextTraverseHistoryResult = EmptyResult
 
 export interface BrowsingContextContextCreated {
@@ -307,6 +321,7 @@ export interface BrowsingContextDownloadWillBegin {
 }
 
 export type BrowsingContextDownloadWillBeginParams = BrowsingContextBaseNavigationInfo & {
+    download: BrowsingContextDownload;
     suggestedFilename: string;
 }
 
@@ -319,10 +334,12 @@ export type BrowsingContextDownloadEndParams = (BrowsingContextDownloadCanceledP
 
 export type BrowsingContextDownloadCanceledParams = BrowsingContextBaseNavigationInfo & {
     status: 'canceled';
+    download: BrowsingContextDownload;
 }
 
 export type BrowsingContextDownloadCompleteParams = BrowsingContextBaseNavigationInfo & {
     status: 'complete';
+    download: BrowsingContextDownload;
     filepath: string | null;
 }
 

--- a/packages/webdriver/src/bidi/remoteTypes.ts
+++ b/packages/webdriver/src/bidi/remoteTypes.ts
@@ -221,7 +221,7 @@ export interface BrowserDownloadBehaviorDenied {
     type: 'denied';
 }
 
-export type BrowsingContextCommand = BrowsingContextActivate | BrowsingContextCaptureScreenshot | BrowsingContextClose | BrowsingContextCreate | BrowsingContextGetTree | BrowsingContextHandleUserPrompt | BrowsingContextLocateNodes | BrowsingContextNavigate | BrowsingContextPrint | BrowsingContextReload | BrowsingContextSetBypassCsp | BrowsingContextSetViewport | BrowsingContextTraverseHistory
+export type BrowsingContextCommand = BrowsingContextActivate | BrowsingContextCaptureScreenshot | BrowsingContextClose | BrowsingContextCreate | BrowsingContextGetTree | BrowsingContextHandleUserPrompt | BrowsingContextLocateNodes | BrowsingContextNavigate | BrowsingContextPrint | BrowsingContextReload | BrowsingContextSetBypassCsp | BrowsingContextSetViewport | BrowsingContextStartScreencast | BrowsingContextStopScreencast | BrowsingContextTraverseHistory
 export type BrowsingContextBrowsingContext = string
 export type BrowsingContextLocator = BrowsingContextAccessibilityLocator | BrowsingContextCssLocator | BrowsingContextContextLocator | BrowsingContextInnerTextLocator | BrowsingContextXPathLocator
 
@@ -259,6 +259,7 @@ export interface BrowsingContextXPathLocator {
 }
 
 export type BrowsingContextNavigation = string
+export type BrowsingContextDownload = string
 export type BrowsingContextReadinessState = 'none' | 'interactive' | 'complete'
 export type BrowsingContextUserPromptType = 'alert' | 'beforeunload' | 'confirm' | 'prompt'
 
@@ -469,6 +470,37 @@ export interface BrowsingContextSetViewportParameters {
 export interface BrowsingContextViewport {
     width: JsUint;
     height: JsUint;
+}
+
+export interface BrowsingContextStartScreencast {
+    method: 'browsingContext.startScreencast';
+    params: BrowsingContextStartScreencastParameters;
+}
+
+export interface BrowsingContextStartScreencastParameters {
+    context: BrowsingContextBrowsingContext;
+    mimeType?: string;
+    streamOptions?: BrowsingContextMediaStreamOptions;
+}
+
+export interface BrowsingContextMediaStreamOptions {
+    video?: BrowsingContextMediaTrackConstraints;
+    audio?: boolean;
+}
+
+export interface BrowsingContextMediaTrackConstraints {
+    width?: JsUint;
+    height?: JsUint;
+    frameRate?: JsUint;
+}
+
+export interface BrowsingContextStopScreencast {
+    method: 'browsingContext.stopScreencast';
+    params: BrowsingContextStopScreencastParameters;
+}
+
+export interface BrowsingContextStopScreencastParameters {
+    screencast: BrowsingContextScreencast;
 }
 
 export interface BrowsingContextTraverseHistory {
@@ -1533,3 +1565,9 @@ export interface WebExtensionUninstall {
 export interface WebExtensionUninstallParameters {
     extension: WebExtensionExtension;
 }
+
+export type BrowsingContextScreencast = string
+/**
+ * @deprecated Use SessionSubscribeParameters instead, will be removed in v10.
+ */
+export interface SessionSubscriptionRequest extends SessionSubscribeParameters {}

--- a/scripts/bidi/constants.ts
+++ b/scripts/bidi/constants.ts
@@ -56,6 +56,22 @@ export const GENERATED_FILE_COMMENT = `/**
  * ./scripts/bidi/**
  */`
 
+/**
+ * Aliases that the WebDriver BiDi CDDL spec has renamed but that we keep
+ * around as deprecated re-exports so consumers can migrate without an immediate
+ * break. Appended to the generated `remoteTypes.ts` after CDDL transformation.
+ *
+ * When promoting one of these to a breaking change (typically at a major
+ * version), delete the corresponding entry here and update any code/tests that
+ * still rely on the old name.
+ */
+export const REMOTE_TYPE_DEPRECATIONS = `
+/**
+ * @deprecated Use SessionSubscribeParameters instead, will be removed in v10.
+ */
+export interface SessionSubscriptionRequest extends SessionSubscribeParameters {}
+`
+
 export const CDDL_PARSE_ERROR_MESSAGE = `
 ====================
 CDDL PARSING FAILED!

--- a/scripts/bidi/index.ts
+++ b/scripts/bidi/index.ts
@@ -11,7 +11,7 @@ import { parse as parseCDDL, type PropertyReference, type Property } from 'cddl'
 import downloadSpec from './downloadSpec.js'
 import type { CddlType } from './utils.js'
 import { backfillCrossCddlRefs, findGroupByName, writeFile } from './utils.js'
-import { BASE_PROTOCOL_SPEC, CDDL_PARSE_ERROR_MESSAGE } from './constants.js'
+import { BASE_PROTOCOL_SPEC, CDDL_PARSE_ERROR_MESSAGE, REMOTE_TYPE_DEPRECATIONS } from './constants.js'
 
 const b = types.builders
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
@@ -52,7 +52,10 @@ backfillCrossCddlRefs(astRemote, astLocal)
 backfillCrossCddlRefs(astLocal, astRemote)
 
 await Promise.all(cddlTypes.map(async (type, i) => {
-    const cddl = transform(asts[i], { useUnknown: true })
+    let cddl = transform(asts[i], { useUnknown: true })
+    if (type === 'remote') {
+        cddl += REMOTE_TYPE_DEPRECATIONS
+    }
     await writeFile(
         path.resolve(__dirname, '..', '..', 'packages', 'webdriver', 'src', 'bidi', `${type}Types.ts`),
         cddl

--- a/scripts/bidi/index.ts
+++ b/scripts/bidi/index.ts
@@ -10,7 +10,7 @@ import { parse as parseCDDL, type PropertyReference, type Property } from 'cddl'
 
 import downloadSpec from './downloadSpec.js'
 import type { CddlType } from './utils.js'
-import { findGroupByName, writeFile } from './utils.js'
+import { backfillCrossCddlRefs, findGroupByName, writeFile } from './utils.js'
 import { BASE_PROTOCOL_SPEC, CDDL_PARSE_ERROR_MESSAGE } from './constants.js'
 
 const b = types.builders
@@ -31,23 +31,32 @@ if (!hasNewSpec) {
 }
 
 const cddlTypes: CddlType[] = ['local', 'remote']
-const [astLocal, astRemote] = await Promise.all(cddlTypes.map(async (type) => {
+const asts = cddlTypes.map((type) => {
     const cddlPath = path.join(__dirname, 'cddl', `${type}.cddl`)
-
-    let ast
     try {
-        ast = parseCDDL(cddlPath)
+        return parseCDDL(cddlPath)
     } catch (err) {
         console.error(util.format(CDDL_PARSE_ERROR_MESSAGE, `Failed to parse ${type}.cddl: ${(err as Error).stack}`))
         process.exit(0)
     }
+})
+const [astLocal, astRemote] = asts
 
-    const cddl = transform(ast, { useUnknown: true })
+/**
+ * The CDDL spec sometimes references shared type aliases (e.g.
+ * `browsingContext.Screencast = text`) only from `local.cddl` even though
+ * `remote.cddl` consumes them. Backfill missing references in each direction
+ * from the other AST before transforming so neither output has dangling types.
+ */
+backfillCrossCddlRefs(astRemote, astLocal)
+backfillCrossCddlRefs(astLocal, astRemote)
+
+await Promise.all(cddlTypes.map(async (type, i) => {
+    const cddl = transform(asts[i], { useUnknown: true })
     await writeFile(
         path.resolve(__dirname, '..', '..', 'packages', 'webdriver', 'src', 'bidi', `${type}Types.ts`),
         cddl
     )
-    return ast
 }))
 
 const code = `

--- a/scripts/bidi/utils.ts
+++ b/scripts/bidi/utils.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 
 import { GENERATED_FILE_COMMENT } from './constants.js'
-import type { Assignment, Group } from 'cddl'
+import type { Assignment, Group, Property, PropertyReference, PropertyType } from 'cddl'
 
 export type CddlType = 'local' | 'remote'
 
@@ -22,4 +22,54 @@ export async function writeFile (filePath: string, content: string) {
 
 export function findGroupByName (ast: Assignment[], name: string): Group | undefined {
     return ast.find((a: Assignment): a is Group => a.Type === 'group' && a.Name === name)
+}
+
+const isPropertyReference = (t: PropertyType): t is PropertyReference =>
+    typeof t === 'object' && t !== null && 'Value' in t && typeof (t as PropertyReference).Value === 'string'
+
+function collectTypeRefs (types: PropertyType | PropertyType[], acc: Set<string>) {
+    const arr = Array.isArray(types) ? types : [types]
+    for (const t of arr) {
+        if (isPropertyReference(t) && (t.Type === 'group' || t.Type === 'group_array')) {
+            acc.add(t.Value as string)
+        }
+    }
+}
+
+/**
+ * The W3C WebDriver BiDi CDDL splits its specification across `local.cddl`
+ * (response types) and `remote.cddl` (command types), but some shared aliases
+ * (e.g. `browsingContext.Screencast = text`) are only declared in `local.cddl`
+ * even though `remote.cddl` references them. Generating each file in isolation
+ * leaves dangling references in `remoteTypes.ts`.
+ *
+ * Walk the remote AST, find references whose name is not defined in the remote
+ * AST but is defined in the local AST, and copy those assignments into the
+ * remote AST so the generated TS has its aliases.
+ */
+export function backfillCrossCddlRefs (target: Assignment[], source: Assignment[]): void {
+    const refs = new Set<string>()
+    for (const a of target) {
+        if (a.Type === 'group') {
+            for (const p of (a as Group).Properties) {
+                const props = Array.isArray(p) ? p : [p]
+                for (const pp of props as Property[]) {collectTypeRefs(pp.Type, refs)}
+            }
+        } else if (a.Type === 'array') {
+            for (const v of a.Values) {
+                const vs = Array.isArray(v) ? v : [v]
+                for (const vv of vs as Property[]) {collectTypeRefs(vv.Type, refs)}
+            }
+        }
+    }
+    const defined = new Set(target.map((a) => a.Name))
+    for (const ref of refs) {
+        if (defined.has(ref)) {
+            continue
+        }
+        const fromSource = source.find((a) => a.Name === ref)
+        if (fromSource) {
+            target.push(fromSource)
+        }
+    }
 }


### PR DESCRIPTION


## Summary

`pnpm run generate:bidi` against the current W3C CDDL artifact produces a `remoteTypes.ts` that fails `tsc --emitDeclarationOnly`, breaking `pnpm run setup`. Even after fixing that, the unit test `bidi.test-d.ts` fails because a manually-preserved deprecation alias is wiped on every regeneration. Both problems are addressed here, and the regenerated sources are committed so Unit Tests can see them.

### 1. Dangling cross-file CDDL references

The spec splits types across `local.cddl` and `remote.cddl`, but some shared aliases (e.g. `browsingContext.Screencast = text`) are declared in only one file even though both reference them. The generator transforms each file in isolation, so the output has dangling references:

```
src/bidi/remoteTypes.ts(503,17): error TS2552:
  Cannot find name 'BrowsingContextScreencast'. Did you mean 'BrowsingContextStopScreencast'?
```

**Fix:** before transforming, walk each AST for unresolved `group`/`group_array` references and copy missing assignments from the other AST. Symmetric so drift in either direction is handled. Against the current artifact this backfills exactly one ref (`browsingContext.Screencast`).

### 2. Lost manual deprecation aliases

[#15158](https://github.com/webdriverio/webdriverio/pull/15158) deprecated `SessionSubscriptionRequest` in v9 (renamed to `SessionSubscribeParameters`) and kept the old name as a re-export so existing consumers wouldn't break until v10. The alias was added manually to the auto-generated `remoteTypes.ts`, so the next regeneration wipes it — which is exactly why [#15223](https://github.com/webdriverio/webdriverio/pull/15223) ("Regenerate BiDi-related files") was reverted via [#15224](https://github.com/webdriverio/webdriverio/pull/15224): regenerating broke `packages/webdriver/tests/bidi.test-d.ts`.

**Fix:** add a `REMOTE_TYPE_DEPRECATIONS` constant in `scripts/bidi/constants.ts` that the generator appends to `remoteTypes.ts` after CDDL transformation. Single source of truth — to graduate a deprecation to a breaking change in v10, delete its entry.

### 3. Regenerated sources committed

The Build job (`pnpm run setup`) regenerates `remoteTypes.ts` in its working tree and uploads `packages/*/build` as an artifact. The Unit Tests job downloads that artifact but runs vitest against the **checked-in source** — so without committed regenerated sources, the generator fixes above only help the Build job, and Unit Tests still see stale types.

Regenerated against the current CDDL artifact (`2026-05-22T14:37:09Z`) with both generator fixes applied. The regenerated files also pick up unrelated upstream spec additions (`BrowsingContextStartScreencastResult`, `BrowsingContextStopScreencastResult`, new `ErrorCode` entries) — picking up the latest spec is the point of regenerating.

## Stacking

Depends on [#15262](https://github.com/webdriverio/webdriverio/pull/15262) — until the browserstack-service compile errors land, CI never reaches the BiDi compile step.

## Test plan

- [x] `pnpm run generate:bidi` produces a clean `remoteTypes.ts` with both `BrowsingContextScreencast` and `SessionSubscriptionRequest` defined
- [x] `pnpm run setup` completes with exit 0
- [x] `vitest packages/webdriver/tests/` — 170/170 pass, including the previously-failing `bidi.test-d.ts`
- [x] ESLint clean on `scripts/bidi/`

## SOX compliance

Changes to a build script and to auto-generated WebDriver BiDi type definitions. No runtime business logic.