### PR TITLE
fix mock calls postData

### DIFF
--- a/packages/webdriverio/src/utils/interception/index.ts
+++ b/packages/webdriverio/src/utils/interception/index.ts
@@ -22,6 +22,10 @@ interface Overwrite {
     abort?: boolean
 }
 
+type RequestWithPostData<T extends local.NetworkBeforeRequestSentParameters | Response> = T & {
+    postData?: string
+}
+
 /**
  * Network interception class based on a WebDriver Bidi implementation.
  *
@@ -40,6 +44,7 @@ export default class WebDriverInterception {
     #respondOverwrites: Overwrite[] = []
     #calls: Response[] = []
     #overwrittenResponseBodies = new Map<string, remote.NetworkBytesValue>()
+    #requestPostData = new Map<string, string>()
 
     constructor(
         pattern: URLPattern,
@@ -77,7 +82,7 @@ export default class WebDriverInterception {
             try {
                 if (browser.options.maxSpyCollectedBodySize !== 0) {
                     await browser.networkAddDataCollector({
-                        dataTypes: ['response'],
+                        dataTypes: ['request', 'response'],
                         maxEncodedDataSize: typeof browser.options.maxSpyCollectedBodySize === 'number'
                             ? browser.options.maxSpyCollectedBodySize
                             : DEFAULT_SPY_COLLECTED_BODY_SIZE
@@ -148,6 +153,19 @@ export default class WebDriverInterception {
             return
         }
 
+        if (this.#filterOptions.postData) {
+            return this.#handleBeforeRequestSentWithPostData(request)
+        }
+
+        return this.#continueBeforeRequestSent(request)
+    }
+
+    async #handleBeforeRequestSentWithPostData(request: local.NetworkBeforeRequestSentParameters) {
+        await this.#populateRequestPostData(request)
+        return this.#continueBeforeRequestSent(request)
+    }
+
+    #continueBeforeRequestSent(request: local.NetworkBeforeRequestSentParameters) {
         /**
          * check if request matches filter option and do nothing if not
          */
@@ -200,6 +218,8 @@ export default class WebDriverInterception {
             }
             return
         }
+
+        this.#attachPostData(request)
 
         /**
          * continue mock if not matching filter
@@ -260,14 +280,19 @@ export default class WebDriverInterception {
     async #handleResponseCompleted(request: Response) {
         /**
          * don't do anything if:
-         * - request is not matching the pattern or filter options
+         * - request is not matching the pattern
          * - data collection is disabled
          */
         if (
             this.#browser.options.maxSpyCollectedBodySize === 0 ||
-            !this.#pattern.test(request.request.url) ||
-            !this.#matchesFilterOptions(request)
+            !this.#pattern.test(request.request.url)
         ) {
+            return
+        }
+
+        await this.#populateRequestPostData(request)
+
+        if (!this.#matchesFilterOptions(request)) {
             return
         }
 
@@ -283,6 +308,7 @@ export default class WebDriverInterception {
             if (bytes) {
                 const call = this.#calls.find((call) => call.request.request === request.request.request)
                 if (call) {
+                    this.#attachPostData(call)
                     call.body = bytes.value
                 }
             }
@@ -319,6 +345,41 @@ export default class WebDriverInterception {
             return null
         }
         return Buffer.from(body.value, 'base64')
+    }
+
+    #attachPostData<T extends local.NetworkBeforeRequestSentParameters | Response>(request: T): RequestWithPostData<T> {
+        const requestWithPostData = request as RequestWithPostData<T>
+        const postData = this.#requestPostData.get(request.request.request)
+        if (postData !== undefined) {
+            requestWithPostData.postData = postData
+        }
+        return requestWithPostData
+    }
+
+    async #populateRequestPostData<T extends local.NetworkBeforeRequestSentParameters | Response>(request: T): Promise<RequestWithPostData<T>> {
+        const requestWithPostData = this.#attachPostData(request)
+        if (
+            requestWithPostData.postData !== undefined ||
+            this.#browser.options.maxSpyCollectedBodySize === 0
+        ) {
+            return requestWithPostData
+        }
+
+        try {
+            const { bytes } = await this.#browser.networkGetData({
+                request: request.request.request,
+                dataType: 'request'
+            })
+
+            if (bytes) {
+                requestWithPostData.postData = bytes.value
+                this.#requestPostData.set(request.request.request, bytes.value)
+            }
+        } catch (err: unknown) {
+            log.debug(`Failed to get request body for ${request.request.request}: ${(err as Error).message}`)
+        }
+
+        return requestWithPostData
     }
 
     /**
@@ -370,6 +431,13 @@ export default class WebDriverInterception {
                 })
         }
 
+        if (isRequestMatching && this.#filterOptions.postData) {
+            const { postData } = request as RequestWithPostData<T>
+            isRequestMatching = typeof this.#filterOptions.postData === 'function'
+                ? this.#filterOptions.postData(postData)
+                : postData === this.#filterOptions.postData
+        }
+
         if (isRequestMatching && this.#filterOptions.responseHeaders && 'response' in request) {
             isRequestMatching = typeof this.#filterOptions.responseHeaders === 'function'
                 ? this.#filterOptions.responseHeaders(request.response.headers.reduce((acc, { name, value }) => {
@@ -419,6 +487,7 @@ export default class WebDriverInterception {
     clear() {
         this.#calls = []
         this.#overwrittenResponseBodies.clear()
+        this.#requestPostData.clear()
         return this
     }
 

--- a/packages/webdriverio/src/utils/interception/index.ts
+++ b/packages/webdriverio/src/utils/interception/index.ts
@@ -290,10 +290,19 @@ export default class WebDriverInterception {
             return
         }
 
-        await this.#populateRequestPostData(request)
-
-        if (!this.#matchesFilterOptions(request)) {
+        if (!this.#matchesFilterOptions(request, { includePostData: false })) {
             return
+        }
+
+        const requestWithPostData = await this.#populateRequestPostData(request)
+        if (!this.#matchesPostDataFilter(requestWithPostData)) {
+            this.#requestPostData.delete(request.request.request)
+            return
+        }
+
+        const call = this.#getCall(request.request.request)
+        if (call) {
+            this.#attachPostData(call)
         }
 
         /**
@@ -306,14 +315,14 @@ export default class WebDriverInterception {
             })
 
             if (bytes) {
-                const call = this.#calls.find((call) => call.request.request === request.request.request)
                 if (call) {
-                    this.#attachPostData(call)
                     call.body = bytes.value
                 }
             }
         } catch (err: unknown) {
             log.debug(`Failed to get response body for ${request.request.request}: ${(err as Error).message}`)
+        } finally {
+            this.#requestPostData.delete(request.request.request)
         }
     }
 
@@ -399,12 +408,34 @@ export default class WebDriverInterception {
         return this.#overwrittenResponseBodies
     }
 
+    #getCall(requestId: string) {
+        for (let index = this.#calls.length - 1; index >= 0; index--) {
+            const call = this.#calls[index]
+            if (call.request.request === requestId) {
+                return call
+            }
+        }
+    }
+
     #isRequestMatching<T extends local.NetworkBeforeRequestSentParameters | Response>(request: T) {
         const matches = this.#pattern && this.#pattern.test(request.request.url)
         return request.isBlocked && matches
     }
 
-    #matchesFilterOptions<T extends local.NetworkBeforeRequestSentParameters | Response>(request: T) {
+    #matchesPostDataFilter<T extends local.NetworkBeforeRequestSentParameters | Response>(request: RequestWithPostData<T>) {
+        if (!this.#filterOptions.postData) {
+            return true
+        }
+
+        return typeof this.#filterOptions.postData === 'function'
+            ? this.#filterOptions.postData(request.postData)
+            : request.postData === this.#filterOptions.postData
+    }
+
+    #matchesFilterOptions<T extends local.NetworkBeforeRequestSentParameters | Response>(
+        request: T,
+        { includePostData = true }: { includePostData?: boolean } = {}
+    ) {
         let isRequestMatching = true
 
         if (isRequestMatching && this.#filterOptions.method) {
@@ -431,11 +462,8 @@ export default class WebDriverInterception {
                 })
         }
 
-        if (isRequestMatching && this.#filterOptions.postData) {
-            const { postData } = request as RequestWithPostData<T>
-            isRequestMatching = typeof this.#filterOptions.postData === 'function'
-                ? this.#filterOptions.postData(postData)
-                : postData === this.#filterOptions.postData
+        if (isRequestMatching && includePostData) {
+            isRequestMatching = this.#matchesPostDataFilter(request as RequestWithPostData<T>)
         }
 
         if (isRequestMatching && this.#filterOptions.responseHeaders && 'response' in request) {

--- a/packages/webdriverio/src/utils/interception/types.ts
+++ b/packages/webdriverio/src/utils/interception/types.ts
@@ -3,12 +3,14 @@ import type { Cookie } from '@wdio/protocols'
 
 export interface Response extends local.NetworkResponseCompletedParameters {
     body?: string
+    postData?: string
 }
 
 export type MockFilterOptions = {
     method?: string | ((method: string) => boolean)
     requestHeaders?: Record<string, string> | ((headers: Record<string, string>) => boolean)
     responseHeaders?: Record<string, string> | ((headers: Record<string, string>) => boolean)
+    postData?: string | ((postData?: string) => boolean)
     statusCode?: number | ((statusCode: number) => boolean)
 }
 

--- a/packages/webdriverio/tests/utils/interception/index.test.ts
+++ b/packages/webdriverio/tests/utils/interception/index.test.ts
@@ -34,7 +34,9 @@ describe('WebDriverInterception', () => {
             networkAddIntercept: vi.fn().mockReturnValue(Promise.resolve({ intercept: 'mock-id' })),
             networkAddDataCollector: vi.fn().mockReturnValue(Promise.resolve({ collector: '123' })),
             networkProvideResponse: vi.fn().mockReturnValue(Promise.resolve()),
-            networkGetData: vi.fn().mockReturnValue(Promise.resolve({ bytes: { type: 'string', value: 'response-body' } })),
+            networkGetData: vi.fn().mockImplementation(({ dataType }) => Promise.resolve({
+                bytes: { type: 'string', value: dataType === 'request' ? 'request-body' : 'response-body' }
+            })),
             networkContinueRequest: vi.fn().mockReturnValue(Promise.resolve()),
             networkFailRequest: vi.fn().mockReturnValue(Promise.resolve())
         } satisfies Partial<WebdriverIO.Browser>
@@ -564,6 +566,46 @@ describe('WebDriverInterception', () => {
         expect(mock.calls[0].body).toBe('response-body')
     })
 
+    it('should expose request postData on calls', async () => {
+        const browser = getResponseCollectionBrowserMock()
+
+        const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+        const request = getResponseCollectionRequestStub()
+
+        browser.emit('network.responseStarted', request)
+        browser.emit('network.responseCompleted', { ...request, isBlocked: false })
+
+        await waitForAsyncHandlers()
+
+        expect(browser.networkGetData).toHaveBeenCalledWith({
+            request: 'req-123',
+            dataType: 'request'
+        })
+        expect(mock.calls[0].postData).toBe('request-body')
+    })
+
+    it('should filter requests by postData', async () => {
+        const browser = getResponseCollectionBrowserMock()
+
+        const mock = await WebDriverInterception.initiate('http://test.com/**', {
+            postData: (postData) => postData === 'request-body'
+        }, browser)
+        const request = getResponseCollectionRequestStub()
+        const onRequest = vi.fn()
+
+        mock.on('request', onRequest)
+        browser.emit('network.beforeRequestSent', request)
+
+        await waitForAsyncHandlers()
+
+        expect(onRequest).toHaveBeenCalledWith(expect.objectContaining({
+            postData: 'request-body'
+        }))
+        expect(browser.networkContinueRequest).toHaveBeenCalledWith({
+            request: 'req-123'
+        })
+    })
+
     describe('WebDriverInterception options', () => {
         let WebDriverInterception: WebDriverInterceptionClass
 
@@ -582,7 +624,7 @@ describe('WebDriverInterception', () => {
             const browser = getResponseCollectionBrowserMock()
             await WebDriverInterception.initiate('http://foobar.com', {}, browser)
             expect(browser.networkAddDataCollector).toHaveBeenCalledWith({
-                dataTypes: ['response'],
+                dataTypes: ['request', 'response'],
                 maxEncodedDataSize: 10 * 1024 * 1024
             })
         })
@@ -591,7 +633,7 @@ describe('WebDriverInterception', () => {
             const browser = getResponseCollectionBrowserMock({ maxSpyCollectedBodySize: 1024 })
             await WebDriverInterception.initiate('http://foobar.com', {}, browser)
             expect(browser.networkAddDataCollector).toHaveBeenCalledWith({
-                dataTypes: ['response'],
+                dataTypes: ['request', 'response'],
                 maxEncodedDataSize: 1024
             })
         })
@@ -636,4 +678,3 @@ describe('WebDriverInterception', () => {
         })
     })
 })
-

--- a/packages/webdriverio/tests/utils/interception/index.test.ts
+++ b/packages/webdriverio/tests/utils/interception/index.test.ts
@@ -584,6 +584,55 @@ describe('WebDriverInterception', () => {
         expect(mock.calls[0].postData).toBe('request-body')
     })
 
+    it('should skip request postData lookup when cheaper responseCompleted filters do not match', async () => {
+        const browser = getResponseCollectionBrowserMock()
+
+        await WebDriverInterception.initiate('http://test.com/**', {
+            method: 'POST'
+        }, browser)
+        const request = getResponseCollectionRequestStub()
+
+        browser.emit('network.responseCompleted', { ...request, isBlocked: false })
+
+        await waitForAsyncHandlers()
+
+        expect(browser.networkGetData).not.toHaveBeenCalled()
+    })
+
+    it('should evict cached request postData after responseCompleted attaches it to a call', async () => {
+        const requestBodies = ['first-request-body', 'second-request-body']
+        const browser = getResponseCollectionBrowserMock({}, {
+            networkGetData: vi.fn().mockImplementation(({ dataType }) => Promise.resolve({
+                bytes: {
+                    type: 'string',
+                    value: dataType === 'request' ? requestBodies.shift() : 'response-body'
+                }
+            }))
+        })
+
+        const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+        const firstRequest = getResponseCollectionRequestStub()
+
+        browser.emit('network.responseStarted', firstRequest)
+        browser.emit('network.responseCompleted', { ...firstRequest, isBlocked: false })
+
+        await waitForAsyncHandlers()
+
+        const secondRequest = getResponseCollectionRequestStub()
+
+        browser.emit('network.responseStarted', secondRequest)
+        browser.emit('network.responseCompleted', { ...secondRequest, isBlocked: false })
+
+        await waitForAsyncHandlers()
+
+        const requestBodyCalls = vi.mocked(browser.networkGetData).mock.calls
+            .filter(([params]) => params.dataType === 'request')
+
+        expect(requestBodyCalls).toHaveLength(2)
+        expect(mock.calls[0].postData).toBe('first-request-body')
+        expect(mock.calls[1].postData).toBe('second-request-body')
+    })
+
     it('should filter requests by postData', async () => {
         const browser = getResponseCollectionBrowserMock()
 


### PR DESCRIPTION
## Proposed changes

Fixes #15237.

`mock.calls` now keeps the BiDi request body as `postData`. The mock data collector subscribes to request data alongside response data, caches the request body by request id, and attaches it to matching calls. This also makes the documented `filterOptions.postData` option work against the collected request body.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Before the fix, the new regression test failed because only response data was fetched:

- `pnpm exec vitest --config vitest.config.ts --run packages/webdriverio/tests/utils/interception/index.test.ts -t "should expose request postData on calls"`

Commands run after the fix:

- `pnpm exec vitest --config vitest.config.ts --run packages/webdriverio/tests/utils/interception/index.test.ts -t "postData|response body"`
- `pnpm exec vitest --config vitest.config.ts --run packages/webdriverio/tests/utils/interception/index.test.ts`
- `pnpm eslint packages/webdriverio/src/utils/interception/index.ts packages/webdriverio/src/utils/interception/types.ts packages/webdriverio/tests/utils/interception/index.test.ts`
- `pnpm -r --filter=@wdio/compiler run build -p webdriverio`
- `git diff --check`

### Reviewers: @webdriverio/project-committers
