### PR TITLE
fix: make `waitForResponse` wait for networkCollector's response

### DIFF
--- a/e2e/wdio/headless/mocking.e2e.ts
+++ b/e2e/wdio/headless/mocking.e2e.ts
@@ -111,10 +111,8 @@ describe('network mocking', () => {
 
         await browser.url('https://guinea-pig.webdriver.io/')
 
-        await browser.waitUntil(() => mock.calls[0]?.body !== undefined, {
-            timeoutMsg: 'Expected response body to be populated',
-            timeout: 5000
-        })
+        await mock.waitForResponse()
+
         expect(mock.calls[0].body).toContain('<title>WebdriverJS Testpage</title>')
     })
 

--- a/packages/webdriverio/src/utils/interception/index.ts
+++ b/packages/webdriverio/src/utils/interception/index.ts
@@ -45,17 +45,21 @@ export default class WebDriverInterception {
     #calls: Response[] = []
     #overwrittenResponseBodies = new Map<string, remote.NetworkBytesValue>()
     #requestPostData = new Map<string, string>()
+    #isCollectingNetworkData: boolean
+    #isResponseCollected = false
 
     constructor(
         pattern: URLPattern,
         mockId: string,
         filterOptions: MockFilterOptions,
-        browser: WebdriverIO.Browser
+        browser: WebdriverIO.Browser,
+        isCollectingNetworkData = false
     ) {
         this.#pattern = pattern
         this.#mockId = mockId
         this.#filterOptions = filterOptions
         this.#browser = browser
+        this.#isCollectingNetworkData = isCollectingNetworkData
 
         /**
          * attach network listener to this mock
@@ -71,6 +75,8 @@ export default class WebDriverInterception {
         browser: WebdriverIO.Browser
     ) {
         const pattern = parseUrlPattern(url)
+        const isCollectingNetworkData = browser.options.maxSpyCollectedBodySize !== 0
+
         if (!hasSubscribedToEvents) {
             await browser.sessionSubscribe({
                 events: [
@@ -80,7 +86,7 @@ export default class WebDriverInterception {
                 ]
             })
             try {
-                if (browser.options.maxSpyCollectedBodySize !== 0) {
+                if (isCollectingNetworkData) {
                     await browser.networkAddDataCollector({
                         dataTypes: ['request', 'response'],
                         maxEncodedDataSize: typeof browser.options.maxSpyCollectedBodySize === 'number'
@@ -111,7 +117,7 @@ export default class WebDriverInterception {
             }]
         })
 
-        return new WebDriverInterception(pattern, interception.intercept, filterOptions, browser)
+        return new WebDriverInterception(pattern, interception.intercept, filterOptions, browser, isCollectingNetworkData)
     }
 
     #emit(event: string, args: unknown) {
@@ -322,6 +328,7 @@ export default class WebDriverInterception {
         } catch (err: unknown) {
             log.debug(`Failed to get response body for ${request.request.request}: ${(err as Error).message}`)
         } finally {
+            this.#isResponseCollected = true
             this.#requestPostData.delete(request.request.request)
         }
     }
@@ -509,6 +516,11 @@ export default class WebDriverInterception {
         return this.#calls
     }
 
+    get hasAtLeastOneResponseReceived(): boolean {
+        const isResponseReceived = this.calls && this.calls.length > 0
+        return isResponseReceived && (!this.#isCollectingNetworkData || this.#isResponseCollected)
+    }
+
     /**
      * Resets all information stored in the `mock.calls` set.
      */
@@ -516,6 +528,7 @@ export default class WebDriverInterception {
         this.#calls = []
         this.#overwrittenResponseBodies.clear()
         this.#requestPostData.clear()
+        this.#isResponseCollected = false
         return this
     }
 
@@ -664,9 +677,8 @@ export default class WebDriverInterception {
             interval = this.#browser.options.waitforInterval as number
         }
 
-        /* istanbul ignore next */
-        const fn = async () => this.calls && (await this.calls).length > 0
-        const timer = new Timer(interval, timeout, fn, true) as unknown as Promise<boolean>
+        const isResponseReceived = () => this.hasAtLeastOneResponseReceived
+        const timer = new Timer(interval, timeout, isResponseReceived, true)
 
         return this.#browser.call(() => timer.catch((e) => {
             if (e.message === 'timeout') {

--- a/packages/webdriverio/src/utils/interception/index.ts
+++ b/packages/webdriverio/src/utils/interception/index.ts
@@ -46,7 +46,7 @@ export default class WebDriverInterception {
     #overwrittenResponseBodies = new Map<string, remote.NetworkBytesValue>()
     #requestPostData = new Map<string, string>()
     #isCollectingNetworkData: boolean
-    #isResponseCollected = false
+    #hasOneResponseCollected = false
 
     constructor(
         pattern: URLPattern,
@@ -283,7 +283,7 @@ export default class WebDriverInterception {
         }).catch(this.#handleNetworkProvideResponseError)
     }
 
-    async #handleResponseCompleted(request: Response) {
+    async #handleResponseCompleted(response: Response) {
         /**
          * don't do anything if:
          * - request is not matching the pattern
@@ -291,45 +291,42 @@ export default class WebDriverInterception {
          */
         if (
             this.#browser.options.maxSpyCollectedBodySize === 0 ||
-            !this.#pattern.test(request.request.url)
+            !this.#pattern.test(response.request.url) ||
+            !this.#matchesFilterOptions(response, { includePostData: false })
         ) {
             return
         }
 
-        if (!this.#matchesFilterOptions(request, { includePostData: false })) {
-            return
-        }
-
-        const requestWithPostData = await this.#populateRequestPostData(request)
+        const requestWithPostData = await this.#populateRequestPostData(response)
         if (!this.#matchesPostDataFilter(requestWithPostData)) {
-            this.#requestPostData.delete(request.request.request)
+            this.#requestPostData.delete(response.request.request)
             return
         }
 
-        const call = this.#getCall(request.request.request)
-        if (call) {
-            this.#attachPostData(call)
+        const call = this.#getCall(response.request.request)
+        if (!call) {
+            return
         }
+
+        this.#attachPostData(call)
 
         /**
          * try populate response body
          */
         try {
             const { bytes } = await this.#browser.networkGetData({
-                request: request.request.request,
+                request: response.request.request,
                 dataType: 'response'
             })
 
             if (bytes) {
-                if (call) {
-                    call.body = bytes.value
-                }
+                call.body = bytes.value
             }
         } catch (err: unknown) {
-            log.debug(`Failed to get response body for ${request.request.request}: ${(err as Error).message}`)
+            log.debug(`Failed to get response body for ${response.request.request}: ${(err as Error).message}`)
         } finally {
-            this.#isResponseCollected = true
-            this.#requestPostData.delete(request.request.request)
+            this.#hasOneResponseCollected = true
+            this.#requestPostData.delete(response.request.request)
         }
     }
 
@@ -518,7 +515,7 @@ export default class WebDriverInterception {
 
     get hasAtLeastOneResponseReceived(): boolean {
         const isResponseReceived = this.calls && this.calls.length > 0
-        return isResponseReceived && (!this.#isCollectingNetworkData || this.#isResponseCollected)
+        return isResponseReceived && (!this.#isCollectingNetworkData || this.#hasOneResponseCollected)
     }
 
     /**
@@ -528,7 +525,7 @@ export default class WebDriverInterception {
         this.#calls = []
         this.#overwrittenResponseBodies.clear()
         this.#requestPostData.clear()
-        this.#isResponseCollected = false
+        this.#hasOneResponseCollected = false
         return this
     }
 

--- a/packages/webdriverio/tests/utils/interception/index.test.ts
+++ b/packages/webdriverio/tests/utils/interception/index.test.ts
@@ -22,7 +22,7 @@ vi.mock('@wdio/logger', () => {
 })
 
 describe('WebDriverInterception', () => {
-    const waitForAsyncHandlers = () => new Promise((resolve) => setTimeout(resolve, 10))
+    const waitForAsyncHandlers = (timeout = 50) => new Promise((resolve) => setTimeout(resolve, timeout))
 
     const getResponseCollectionBrowserMock = (
         options: WebdriverIO.Browser['options'] = {},
@@ -38,7 +38,8 @@ describe('WebDriverInterception', () => {
                 bytes: { type: 'string', value: dataType === 'request' ? 'request-body' : 'response-body' }
             })),
             networkContinueRequest: vi.fn().mockReturnValue(Promise.resolve()),
-            networkFailRequest: vi.fn().mockReturnValue(Promise.resolve())
+            networkFailRequest: vi.fn().mockReturnValue(Promise.resolve()),
+            call: vi.fn(),
         } satisfies Partial<WebdriverIO.Browser>
         const browser = Object.assign(new EventEmitter(), defaults, overrides) as unknown as WebdriverIO.Browser
         return browser
@@ -724,6 +725,284 @@ describe('WebDriverInterception', () => {
                 request: 'req-123',
                 dataType: 'response'
             })
+        })
+    })
+
+    describe('isResponseReceived getter', () => {
+        let WebDriverInterception: WebDriverInterceptionClass
+
+        beforeEach(async () => {
+            vi.resetModules()
+            WebDriverInterception = (await import('../../../src/utils/interception/index.js')).default
+        })
+
+        describe('when network collection is disabled', () => {
+
+            let browser: WebdriverIO.Browser
+
+            beforeEach(async () => {
+                browser = getResponseCollectionBrowserMock({ maxSpyCollectedBodySize: 0 })
+            })
+
+            it('should return true if calls are recorded and response body is not collected', async () => {
+                const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+                const request = getResponseCollectionRequestStub()
+
+                browser.emit('network.responseStarted', request)
+                browser.emit('network.responseCompleted', { ...request, isBlocked: false } as Partial<local.NetworkResponseCompletedParameters> as local.NetworkResponseCompletedParameters)
+
+                await waitForAsyncHandlers()
+
+                expect(mock.hasAtLeastOneResponseReceived).toBe(true)
+                expect(browser.networkGetData).not.toHaveBeenCalled()
+                expect(mock.calls[0].body).toBeUndefined()
+            })
+        })
+
+        describe('when network collection is enabled', () => {
+
+            it('should return false if no calls are recorded', async () => {
+                const browser = getResponseCollectionBrowserMock()
+                const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+
+                await waitForAsyncHandlers()
+
+                expect(mock.hasAtLeastOneResponseReceived).toBe(false)
+                expect(browser.networkGetData).not.toHaveBeenCalled()
+
+            })
+
+            it('should return true if calls are recorded and at least one call has response body collected', async () => {
+                const browser = getResponseCollectionBrowserMock({ maxSpyCollectedBodySize: 1024 })
+                const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+                const request = getResponseCollectionRequestStub()
+
+                browser.emit('network.responseStarted', request)
+                browser.emit('network.responseCompleted', { ...request, isBlocked: false } as Partial<local.NetworkResponseCompletedParameters> as local.NetworkResponseCompletedParameters)
+
+                await waitForAsyncHandlers()
+
+                expect(mock.hasAtLeastOneResponseReceived).toBe(true)
+                expect(browser.networkGetData).toHaveBeenCalled()
+
+            })
+
+            it('should return true if response collected but undefined', async () => {
+                const browser = getResponseCollectionBrowserMock({ maxSpyCollectedBodySize: 1024 }, {
+                    networkGetData: vi.fn().mockResolvedValue({
+                        bytes: undefined
+                    })
+                })
+                const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+                const request = getResponseCollectionRequestStub()
+
+                browser.emit('network.responseStarted', request)
+                browser.emit('network.responseCompleted', { ...request, isBlocked: false } as Partial<local.NetworkResponseCompletedParameters> as local.NetworkResponseCompletedParameters)
+
+                await waitForAsyncHandlers()
+
+                expect(mock.hasAtLeastOneResponseReceived).toBe(true)
+            })
+
+            it('should return true if response collected but empty string', async () => {
+                const browser = getResponseCollectionBrowserMock({ maxSpyCollectedBodySize: 1024 }, {
+                    networkGetData: vi.fn().mockResolvedValue({
+                        bytes: { type: 'string', value: '' }
+                    })
+                })
+                const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+                const request = getResponseCollectionRequestStub()
+
+                browser.emit('network.responseStarted', request)
+                browser.emit('network.responseCompleted', { ...request, isBlocked: false } as Partial<local.NetworkResponseCompletedParameters> as local.NetworkResponseCompletedParameters)
+
+                await waitForAsyncHandlers()
+
+                expect(mock.hasAtLeastOneResponseReceived).toBe(true)
+            })
+
+            it('should return false then true if response take time to collect', async () => {
+                const browser = getResponseCollectionBrowserMock({ maxSpyCollectedBodySize: 1024 }, {
+                    networkGetData: vi.fn().mockImplementation(() => new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve({
+                                bytes: { type: 'string', value: 'response-body' }
+                            })
+                        }, 50)
+                    }))
+                })
+                const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+                const request = getResponseCollectionRequestStub()
+
+                browser.emit('network.responseStarted', request)
+                browser.emit('network.responseCompleted', { ...request, isBlocked: false } as Partial<local.NetworkResponseCompletedParameters> as local.NetworkResponseCompletedParameters)
+
+                await waitForAsyncHandlers(25)
+                expect(mock.hasAtLeastOneResponseReceived).toBe(false)
+
+                await waitForAsyncHandlers(100)
+                expect(mock.hasAtLeastOneResponseReceived).toBe(true)
+            })
+        })
+    })
+
+    describe('waitForResponse', () => {
+        it('should resolve when a response has been received', async () => {
+            const browser = getResponseCollectionBrowserMock({
+                waitforTimeout: 5000,
+                waitforInterval: 100
+            }, {
+                call: vi.fn().mockImplementation((fn) => fn())
+            })
+            const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+            const request = getResponseCollectionRequestStub()
+
+            // Simulate response arriving
+            browser.emit('network.responseStarted', request)
+            browser.emit('network.responseCompleted', { ...request, isBlocked: false } as Partial<local.NetworkResponseCompletedParameters> as local.NetworkResponseCompletedParameters)
+
+            await expect(mock.waitForResponse()).resolves.toBeDefined()
+        })
+
+        it('should throw timeout error when no response is received', async () => {
+            const browser = getResponseCollectionBrowserMock({
+                waitforTimeout: 100,
+                waitforInterval: 10
+            }, {
+                call: vi.fn().mockImplementation((fn) => fn())
+            })
+            const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+
+            await expect(mock.waitForResponse()).rejects.toThrow('waitForResponse timed out after 100ms')
+        })
+
+        it('should throw custom timeout message when provided', async () => {
+            const browser = getResponseCollectionBrowserMock({
+                waitforTimeout: 100,
+                waitforInterval: 10
+            }, {
+                call: vi.fn().mockImplementation((fn) => fn())
+            })
+            const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+
+            await expect(mock.waitForResponse({ timeoutMsg: 'Custom timeout message' }))
+                .rejects.toThrow('Custom timeout message')
+        })
+
+        it('should use provided timeout and interval options', async () => {
+            const browser = getResponseCollectionBrowserMock({
+                waitforTimeout: 5000,
+                waitforInterval: 100
+            }, {
+                call: vi.fn().mockImplementation((fn) => fn())
+            })
+            const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+
+            await expect(mock.waitForResponse({ timeout: 50, interval: 10 }))
+                .rejects.toThrow('waitForResponse timed out after 50ms')
+        })
+
+        it('should use browser defaults when timeout/interval are not numbers', async () => {
+            const browser = getResponseCollectionBrowserMock({
+                waitforTimeout: 100,
+                waitforInterval: 10
+            }, {
+                call: vi.fn().mockImplementation((fn) => fn())
+            })
+            const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+
+            await expect(mock.waitForResponse({ timeout: undefined, interval: undefined }))
+                .rejects.toThrow('waitForResponse timed out after 100ms')
+        })
+
+        it('should resolve when response arrives during wait', async () => {
+            const browser = getResponseCollectionBrowserMock({
+                waitforTimeout: 5000,
+                waitforInterval: 10
+            }, {
+                call: vi.fn().mockImplementation((fn) => fn())
+            })
+            const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+            const request = getResponseCollectionRequestStub()
+
+            setTimeout(() => {
+                // Simulate response arriving
+                browser.emit('network.responseStarted', request)
+                browser.emit('network.responseCompleted', { ...request, isBlocked: false } as Partial<local.NetworkResponseCompletedParameters> as local.NetworkResponseCompletedParameters)
+
+            }, 100)
+
+            await expect(mock.waitForResponse()).resolves.toBeDefined()
+        })
+    })
+
+    describe('clear', () => {
+        it('should reset calls array', async () => {
+            const browser = getResponseCollectionBrowserMock()
+            const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+            const request = getResponseCollectionRequestStub()
+
+            // Trigger a response to populate calls
+            browser.emit('network.responseStarted', request)
+            expect(mock.calls.length).toBe(1)
+
+            mock.clear()
+            expect(mock.calls.length).toBe(0)
+        })
+
+        it('should reset hasAtLeastOneResponseReceived to false', async () => {
+            const browser = getResponseCollectionBrowserMock({ maxSpyCollectedBodySize: 1024 })
+            const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+            const request = getResponseCollectionRequestStub()
+
+            browser.emit('network.responseStarted', request)
+            browser.emit('network.responseCompleted', { ...request, isBlocked: false } as Partial<local.NetworkResponseCompletedParameters> as local.NetworkResponseCompletedParameters)
+
+            await waitForAsyncHandlers()
+            expect(mock.hasAtLeastOneResponseReceived).toBe(true)
+
+            mock.clear()
+            expect(mock.hasAtLeastOneResponseReceived).toBe(false)
+        })
+
+        it('should clear overwritten response bodies', async () => {
+            const browser = getResponseCollectionBrowserMock()
+            const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+            const request = getResponseCollectionRequestStub()
+
+            mock.respond('mocked response')
+            browser.emit('network.responseStarted', request)
+
+            expect(mock.debugResponseBodies().size).toBe(1)
+
+            mock.clear()
+            expect(mock.debugResponseBodies().size).toBe(0)
+        })
+
+        it('should return the mock instance for chaining', async () => {
+            const browser = getResponseCollectionBrowserMock()
+            const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+
+            const result = mock.clear()
+            expect(result).toBe(mock)
+        })
+
+        it('should not remove request or response overwrites', async () => {
+            const browser = getResponseCollectionBrowserMock()
+            const mock = await WebDriverInterception.initiate('http://test.com/**', {}, browser)
+
+            mock.respond('mocked response')
+            mock.clear()
+
+            // After clear, respond overwrites should still be active
+            const request = getResponseCollectionRequestStub()
+            browser.emit('network.responseStarted', request)
+
+            expect(browser.networkProvideResponse).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: { type: 'string', value: 'mocked response' }
+                })
+            )
         })
     })
 })


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/webdriverio/webdriverio/issues/15295
Added booleans so once `networkGetData` is called to retrieve the response, we make `waitForResponse` passes.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
