### PR TITLE
fix(types): allow async callbacks for element iterators and event listerners

### DIFF
--- a/packages/webdriver/src/types.ts
+++ b/packages/webdriver/src/types.ts
@@ -72,8 +72,8 @@ export type EventMap = {
     [Event in EventData['method']]: GetParam<EventData, Event>
 } & WebDriverClassicEvents
 interface BidiEventHandler {
-    on<K extends keyof EventMap>(event: K, listener: (this: Client, param: EventMap[K]) => void): this
-    once<K extends keyof EventMap>(event: K, listener: (this: Client, param: EventMap[K]) => void): this
+    on<K extends keyof EventMap>(event: K, listener: (this: Client, param: EventMap[K]) => unknown): this
+    once<K extends keyof EventMap>(event: K, listener: (this: Client, param: EventMap[K]) => unknown): this
 }
 
 export interface BaseClient extends EventEmitter, SessionFlags {

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -83,8 +83,8 @@ interface AsyncIterators<T> {
     /**
      * Unwrap the nth element of the element list.
      */
-    forEach: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => void, thisArg?: T) => Promise<void>
-    forEachSeries: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => void, thisArg?: T) => Promise<void>
+    forEach: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => unknown, thisArg?: T) => Promise<void>
+    forEachSeries: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => unknown, thisArg?: T) => Promise<void>
     map: <U>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => U | Promise<U>, thisArg?: T) => Promise<U[]>
     mapSeries: <T, U>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => U | Promise<U>, thisArg?: T) => Promise<U[]>;
     find: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<T>;
@@ -345,8 +345,8 @@ export type WebdriverIOEventMap = EventMap & {
 }
 
 interface BidiEventHandler {
-    on<K extends keyof WebdriverIOEventMap>(event: K, listener: (this: WebdriverIO.Browser, param: WebdriverIOEventMap[K]) => void): this
-    once<K extends keyof WebdriverIOEventMap>(event: K, listener: (this: WebdriverIO.Browser, param: WebdriverIOEventMap[K]) => void): this
+    on<K extends keyof WebdriverIOEventMap>(event: K, listener: (this: WebdriverIO.Browser, param: WebdriverIOEventMap[K]) => unknown): this
+    once<K extends keyof WebdriverIOEventMap>(event: K, listener: (this: WebdriverIO.Browser, param: WebdriverIOEventMap[K]) => unknown): this
 }
 
 /**

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -464,6 +464,17 @@ async function bar() {
     expectType<void>(
         await browser.$$('foo').forEach(() => true)
     )
+    expectType<void>(
+        await browser.$$('foo').forEach(async (el) => {
+            expectType<WebdriverIO.Element>(el)
+            await el.getText()
+        })
+    )
+    expectType<void>(
+        await browser.$$('foo').forEachSeries(async (el) => {
+            await el.getText()
+        })
+    )
     expectType<string[]>(
         await browser.$('foo').$$('bar').map((el) => {
             expectType<WebdriverIO.Element>(el)
@@ -514,6 +525,15 @@ async function bar() {
     const elemArrayTest: WebdriverIO.ElementArray = {} as any
     expectType<string>(elemArrayTest.foundWith)
     expectType<WebdriverIO.Element>(elemArrayTest[123])
+
+    // event listeners support both sync and async functions
+    browser.on('dialog', (dialog) => dialog.dismiss())
+    browser.on('dialog', async (dialog) => {
+        await dialog.dismiss()
+    })
+    browser.once('dialog', async (dialog) => {
+        await dialog.dismiss()
+    })
 
     // getElement type check
     const singleChainedElement = await browser.$('foo').getElement()


### PR DESCRIPTION
fixes #15276 & #15275 

## Proposed changes
The callback/listener return types for several APIs were declared as => void, so passing an async function triggers @typescript-eslint/no-misused-promises. This contradicts documented usage (the [dialog example](https://webdriver.io/docs/api/dialog/) uses an async listener) and runtime behavior (forEach/forEachSeries already await callbacks; on/once use Node's EventEmitter, which tolerates returns).

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
