### PR TITLE
Fix/patch stale i18n devtools electron links

### DIFF
--- a/scripts/bidi/index.ts
+++ b/scripts/bidi/index.ts
@@ -42,16 +42,7 @@ const [astLocal, astRemote] = await Promise.all(cddlTypes.map(async (type) => {
         process.exit(0)
     }
 
-    let cddl = transform(ast, { useUnknown: true })
-
-    if (type === 'remote') {
-        // TODO to remove when CDDL generation date from webdriver-bidi are after May 26th
-        const remoteTypesPatch = `\n
-// Fix merged but CDDL not yet updated. See https://github.com/w3c/webdriver-bidi/pull/1126
-export type BrowsingContextScreencast = string
-`
-        cddl = cddl.concat(remoteTypesPatch)
-    }
+    const cddl = transform(ast, { useUnknown: true })
 
     await writeFile(
         path.resolve(__dirname, '..', '..', 'packages', 'webdriver', 'src', 'bidi', `${type}Types.ts`),

--- a/scripts/docs-generation/3rdPartyDocs.ts
+++ b/scripts/docs-generation/3rdPartyDocs.ts
@@ -176,7 +176,12 @@ function normalizeDoc(readme: string, githubUrl: string, branch: string, preface
 
     return [...preface, ...repoInfo, ...readmeArr]
         .join('\n')
-        .replace(/<br>/g, '<br />')
+        /**
+         * Self-close void HTML elements that must be self-closing in MDX/JSX.
+         * External READMEs often use HTML5 syntax (<br>, <img ...>, <hr>) which
+         * breaks Docusaurus. Normalizes both unclosed and already-closed forms.
+         */
+        .replace(/<(img|br|hr|input|source|col|area|base|wbr|embed|track)\b([^>]*?)\s*\/?>/g, '<$1$2 />')
 }
 
 /**

--- a/scripts/docs-generation/3rdPartyDocs.ts
+++ b/scripts/docs-generation/3rdPartyDocs.ts
@@ -177,10 +177,13 @@ function normalizeDoc(readme: string, githubUrl: string, branch: string, preface
     return [...preface, ...repoInfo, ...readmeArr]
         .join('\n')
         /**
-         * Self-close void HTML elements that must be self-closing in MDX/JSX.
-         * External READMEs often use HTML5 syntax (<br>, <img ...>, <hr>) which
-         * breaks Docusaurus. Normalizes both unclosed and already-closed forms.
+         * Normalize void HTML elements so they parse as MDX/JSX. External READMEs
+         * often use HTML5 syntax (<br>, <img ...>, even invalid <img ...></img>)
+         * which breaks Docusaurus.
          */
+        // 1. drop stray closing tags for void elements (e.g. `</img>`)
+        .replace(/<\/(img|br|hr|input|source|col|area|base|wbr|embed|track)>/g, '')
+        // 2. self-close opening void tags; idempotent on already-closed forms
         .replace(/<(img|br|hr|input|source|col|area|base|wbr|embed|track)\b([^>]*?)\s*\/?>/g, '<$1$2 />')
 }
 

--- a/scripts/docs-generation/downloadDocsTranslations.ts
+++ b/scripts/docs-generation/downloadDocsTranslations.ts
@@ -31,7 +31,12 @@ export function downloadDocsTranslations() {
  * Add entries here whenever a doc restructure breaks translated pages.
  */
 async function applyTranslationFixes(i18nPath: string) {
-    const locales = await fs.readdir(i18nPath).catch(() => [] as string[])
+    const locales = await fs.readdir(i18nPath).catch((err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOENT') {
+            return [] as string[]
+        }
+        throw err
+    })
 
     for (const locale of locales) {
         const contentPath = path.join(i18nPath, locale, 'docusaurus-plugin-content-docs', 'current')
@@ -49,7 +54,12 @@ async function applyTranslationFixes(i18nPath: string) {
                 await fs.writeFile(devtoolsPath, fixed)
                 console.log(`Applied devtools link fix to ${locale}/Devtools.md`)
             }
-        } catch { /* file may not exist for this locale */ }
+        } catch (err) {
+            // ignore missing translation file for this locale; rethrow real errors
+            if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+                throw err
+            }
+        }
 
         // Fix: Electron.md links to /mocking page which no longer exists — point to
         // /api-reference instead (matches the English source's "how to mock" link)
@@ -64,7 +74,12 @@ async function applyTranslationFixes(i18nPath: string) {
                 await fs.writeFile(electronPath, fixed)
                 console.log(`Applied electron mocking link fix to ${locale}/desktop-testing/Electron.md`)
             }
-        } catch { /* file may not exist for this locale */ }
+        } catch (err) {
+            // ignore missing translation file for this locale; rethrow real errors
+            if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+                throw err
+            }
+        }
     }
 }
 

--- a/scripts/docs-generation/downloadDocsTranslations.ts
+++ b/scripts/docs-generation/downloadDocsTranslations.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises'
+import type { Dirent } from 'node:fs'
 import url from 'node:url'
 import path from 'node:path'
 import unzipper from 'unzipper'
@@ -31,12 +32,14 @@ export function downloadDocsTranslations() {
  * Add entries here whenever a doc restructure breaks translated pages.
  */
 async function applyTranslationFixes(i18nPath: string) {
-    const locales = await fs.readdir(i18nPath).catch((err: NodeJS.ErrnoException) => {
+    const entries = await fs.readdir(i18nPath, { withFileTypes: true }).catch((err: NodeJS.ErrnoException) => {
         if (err.code === 'ENOENT') {
-            return [] as string[]
+            return [] as Dirent[]
         }
         throw err
     })
+    // only iterate locale directories; ignore stray files (e.g. .gitkeep, config)
+    const locales = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name)
 
     for (const locale of locales) {
         const contentPath = path.join(i18nPath, locale, 'docusaurus-plugin-content-docs', 'current')
@@ -47,8 +50,8 @@ async function applyTranslationFixes(i18nPath: string) {
         try {
             const content = await fs.readFile(devtoolsPath, 'utf-8')
             const fixed = content.replace(
-                /\(devtools\/(interactive-test-rerunning|multi-framework-support|console-logs|network-logs|testlens|screencast)\)/g,
-                '(devtools/wdio/$1)'
+                /\(devtools\/(interactive-test-rerunning|multi-framework-support|console-logs|network-logs|testlens|screencast)([^)]*)\)/g,
+                '(devtools/wdio/$1$2)'
             )
             if (fixed !== content) {
                 await fs.writeFile(devtoolsPath, fixed)

--- a/scripts/docs-generation/downloadDocsTranslations.ts
+++ b/scripts/docs-generation/downloadDocsTranslations.ts
@@ -24,6 +24,50 @@ export function downloadDocsTranslations() {
     return downloadAndExtractRepo(REPO_OWNER, REPO_NAME)
 }
 
+/**
+ * Patches known stale links in translated i18n files that become broken when English
+ * source docs are restructured but translations haven't been updated yet.
+ *
+ * Add entries here whenever a doc restructure breaks translated pages.
+ */
+async function applyTranslationFixes(i18nPath: string) {
+    const locales = await fs.readdir(i18nPath).catch(() => [] as string[])
+
+    for (const locale of locales) {
+        const contentPath = path.join(i18nPath, locale, 'docusaurus-plugin-content-docs', 'current')
+
+        // Fix: Devtools.md links missing wdio/ prefix after devtools section was restructured
+        // Old: devtools/interactive-test-rerunning  New: devtools/wdio/interactive-test-rerunning
+        const devtoolsPath = path.join(contentPath, 'Devtools.md')
+        try {
+            const content = await fs.readFile(devtoolsPath, 'utf-8')
+            const fixed = content.replace(
+                /\(devtools\/(interactive-test-rerunning|multi-framework-support|console-logs|network-logs|testlens|screencast)\)/g,
+                '(devtools/wdio/$1)'
+            )
+            if (fixed !== content) {
+                await fs.writeFile(devtoolsPath, fixed)
+                console.log(`Applied devtools link fix to ${locale}/Devtools.md`)
+            }
+        } catch { /* file may not exist for this locale */ }
+
+        // Fix: Electron.md links to /mocking page which no longer exists — point to
+        // /api-reference instead (matches the English source's "how to mock" link)
+        const electronPath = path.join(contentPath, 'desktop-testing', 'Electron.md')
+        try {
+            const content = await fs.readFile(electronPath, 'utf-8')
+            const fixed = content.replace(
+                /\/docs\/desktop-testing\/electron\/mocking/g,
+                '/docs/desktop-testing/electron/api-reference'
+            )
+            if (fixed !== content) {
+                await fs.writeFile(electronPath, fixed)
+                console.log(`Applied electron mocking link fix to ${locale}/desktop-testing/Electron.md`)
+            }
+        } catch { /* file may not exist for this locale */ }
+    }
+}
+
 async function downloadAndExtractRepo(owner: string, repo: string, branch?: string) {
     // Step 1: Determine default branch if not specified
     if (!branch) {
@@ -98,6 +142,7 @@ async function downloadAndExtractRepo(owner: string, repo: string, branch?: stri
         }
 
         console.log(`Repository extracted to ${finalExtractPath}`)
+        await applyTranslationFixes(finalExtractPath)
     } finally {
         // Clean up temp directory
         try {


### PR DESCRIPTION
## Proposed changes
The Docs Deploy workflow has been failing, blocking all documentation updates. There were two independent root causes, both fixed here:
Stale links in translated docs (i18n)
Invalid HTML in third-party READMEs breaking MDX

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments
These are build-time patches in the doc-generation pipeline rather than fixes in the upstream sources, chosen deliberately so the deploy self-heals
[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
