### PR TITLE
fix(wdio-utils): use supported EdgeDriver CDN

### DIFF
--- a/packages/wdio-utils/src/node/startWebDriver.ts
+++ b/packages/wdio-utils/src/node/startWebDriver.ts
@@ -11,12 +11,12 @@ import { deepmerge } from 'deepmerge-ts'
 
 import { start as startSafaridriver, type SafaridriverOptions as SafaridriverParameters } from 'safaridriver'
 import { start as startGeckodriver, type GeckodriverParameters } from 'geckodriver'
-import { start as startEdgedriver, findEdgePath, type EdgedriverParameters } from 'edgedriver'
 import type { InstallOptions } from '@puppeteer/browsers'
+import type { EdgedriverParameters } from 'edgedriver'
 
 import type { Capabilities } from '@wdio/types'
 
-import { parseParams, setupPuppeteerBrowser, setupChromedriver, getCacheDir, generateDefaultPrefs } from './utils.js'
+import { parseParams, setupPuppeteerBrowser, setupChromedriver, getCacheDir, generateDefaultPrefs, setDefaultEdgedriverCdnUrl } from './utils.js'
 import { isChrome, isFirefox, isEdge, isSafari, isAppiumCapability } from '../utils.js'
 import { SUPPORTED_BROWSERNAMES } from '../constants.js'
 
@@ -181,6 +181,8 @@ export async function startWebDriver(options: Capabilities.RemoteConfig) {
             edgedriverOptions.customEdgeDriverPath = binary
         }
 
+        setDefaultEdgedriverCdnUrl()
+        const { start: startEdgedriver, findEdgePath } = await import('edgedriver')
         driver = 'EdgeDriver'
         driverProcess = await startEdgedriver({ ...edgedriverOptions, cacheDir, port, allowedIps: ['0.0.0.0'] }).catch((err) => {
             log.warn(`Couldn't start EdgeDriver: ${err.message}, retry ...`)

--- a/packages/wdio-utils/src/node/utils.ts
+++ b/packages/wdio-utils/src/node/utils.ts
@@ -11,13 +11,21 @@ import {
     computeExecutablePath, type InstallOptions
 } from '@puppeteer/browsers'
 import { download as downloadGeckodriver } from 'geckodriver'
-import { download as downloadEdgedriver } from 'edgedriver'
 import { locateChrome, locateFirefox, locateApp } from 'locate-app'
 import type { EdgedriverParameters } from 'edgedriver'
 import type { Options } from '@wdio/types'
 
 const log = logger('webdriver')
 const EXCLUDED_PARAMS = ['version', 'help']
+export const DEFAULT_EDGEDRIVER_CDN_URL = 'https://msedgedriver.microsoft.com'
+const LEGACY_EDGEDRIVER_CDN_URL = 'https://msedgedriver.azureedge.net'
+
+export function setDefaultEdgedriverCdnUrl () {
+    const edgedriverCdnUrl = process.env.EDGEDRIVER_CDNURL?.replace(/\/+$/, '')
+    if (!edgedriverCdnUrl || edgedriverCdnUrl === LEGACY_EDGEDRIVER_CDN_URL) {
+        process.env.EDGEDRIVER_CDNURL = DEFAULT_EDGEDRIVER_CDN_URL
+    }
+}
 
 /**
  * Helper utility to check file access
@@ -337,7 +345,9 @@ export function setupGeckodriver (cacheDir: string, driverVersion?: string) {
     return downloadGeckodriver(driverVersion, cacheDir)
 }
 
-export function setupEdgedriver (cacheDir: string, driverVersion?: string) {
+export async function setupEdgedriver (cacheDir: string, driverVersion?: string) {
+    setDefaultEdgedriverCdnUrl()
+    const { download: downloadEdgedriver } = await import('edgedriver')
     return downloadEdgedriver(driverVersion, cacheDir)
 }
 

--- a/packages/wdio-utils/tests/node/index.test.ts
+++ b/packages/wdio-utils/tests/node/index.test.ts
@@ -9,10 +9,11 @@ import split2 from 'split2'
 import waitPort from 'wait-port'
 import { start as startSafaridriver } from 'safaridriver'
 import { start as startGeckodriver } from 'geckodriver'
-import { start as startEdgedriver } from 'edgedriver'
+import { start as startEdgedriver, download as downloadEdgedriver } from 'edgedriver'
 import { install } from '@puppeteer/browsers'
 
 import { startWebDriver } from '../../src/node/index.js'
+import { DEFAULT_EDGEDRIVER_CDN_URL, setupEdgedriver } from '../../src/node/utils.js'
 import { SUPPORTED_BROWSERNAMES } from '../../src/constants.js'
 
 vi.mock('split2', () => ({ default: vi.fn() }))
@@ -62,6 +63,7 @@ vi.mock('safaridriver', () => ({
     })
 }))
 vi.mock('edgedriver', () => ({
+    download: vi.fn().mockResolvedValue('/foo/bar/edgedriver'),
     start: vi.fn().mockResolvedValue('edgedriver'),
     findEdgePath: vi.fn().mockReturnValue('/foo/bar/executable')
 }))
@@ -90,18 +92,27 @@ vi.mock('../../src/node/utils.js', async (actualMod) => ({
 
 describe('startWebDriver', () => {
     const WDIO_SKIP_DRIVER_SETUP = process.env.WDIO_SKIP_DRIVER_SETUP
+    const EDGEDRIVER_CDNURL = process.env.EDGEDRIVER_CDNURL
     beforeEach(() => {
         delete process.env.WDIO_SKIP_DRIVER_SETUP
+        delete process.env.EDGEDRIVER_CDNURL
         vi.mocked(install).mockClear()
         vi.mocked(fsp.access).mockClear()
         vi.mocked(fsp.mkdir).mockClear()
         vi.mocked(cp.spawn).mockClear()
         vi.mocked(startGeckodriver).mockClear()
+        vi.mocked(startEdgedriver).mockClear()
+        vi.mocked(downloadEdgedriver).mockClear()
         vi.mocked(fs.createWriteStream).mockClear()
     })
 
     afterEach(() => {
         process.env.WDIO_SKIP_DRIVER_SETUP = WDIO_SKIP_DRIVER_SETUP
+        if (EDGEDRIVER_CDNURL) {
+            process.env.EDGEDRIVER_CDNURL = EDGEDRIVER_CDNURL
+        } else {
+            delete process.env.EDGEDRIVER_CDNURL
+        }
     })
 
     it('should start safari driver', async () => {
@@ -165,6 +176,7 @@ describe('startWebDriver', () => {
     })
 
     it('should start edge driver', async () => {
+        process.env.EDGEDRIVER_CDNURL = 'https://msedgedriver.azureedge.net'
         const options = {
             capabilities: {
                 browserName: 'edge',
@@ -192,7 +204,15 @@ describe('startWebDriver', () => {
             cacheDir: expect.any(String),
             allowedIps: ['0.0.0.0'],
         })
+        expect(process.env.EDGEDRIVER_CDNURL).toBe(DEFAULT_EDGEDRIVER_CDN_URL)
         expect(options.capabilities.browserName).toBe('MicrosoftEdge')
+    })
+
+    it('should set the supported edge driver CDN before downloading edge driver', async () => {
+        process.env.EDGEDRIVER_CDNURL = 'https://msedgedriver.azureedge.net/'
+        await expect(setupEdgedriver('/foo/bar/cache', '148.0.3967.96')).resolves.toBe('/foo/bar/edgedriver')
+        expect(downloadEdgedriver).toBeCalledWith('148.0.3967.96', '/foo/bar/cache')
+        expect(process.env.EDGEDRIVER_CDNURL).toBe(DEFAULT_EDGEDRIVER_CDN_URL)
     })
 
     it('should start chrome driver', async () => {

--- a/packages/wdio-utils/tests/node/index.test.ts
+++ b/packages/wdio-utils/tests/node/index.test.ts
@@ -209,6 +209,12 @@ describe('startWebDriver', () => {
     })
 
     it('should set the supported edge driver CDN before downloading edge driver', async () => {
+        await expect(setupEdgedriver('/foo/bar/cache', '148.0.3967.96')).resolves.toBe('/foo/bar/edgedriver')
+        expect(downloadEdgedriver).toBeCalledWith('148.0.3967.96', '/foo/bar/cache')
+        expect(process.env.EDGEDRIVER_CDNURL).toBe(DEFAULT_EDGEDRIVER_CDN_URL)
+    })
+
+    it('should replace the deprecated edge driver CDN before downloading edge driver', async () => {
         process.env.EDGEDRIVER_CDNURL = 'https://msedgedriver.azureedge.net/'
         await expect(setupEdgedriver('/foo/bar/cache', '148.0.3967.96')).resolves.toBe('/foo/bar/edgedriver')
         expect(downloadEdgedriver).toBeCalledWith('148.0.3967.96', '/foo/bar/cache')


### PR DESCRIPTION
## Proposed changes

Force WebdriverIO's EdgeDriver setup to use Microsoft's supported EdgeDriver CDN when no CDN is configured or when the deprecated `msedgedriver.azureedge.net` endpoint is configured. The `edgedriver` package resolves its CDN URL during module import, so `@wdio/utils` now sets the CDN before dynamically loading `edgedriver` for both download and start flows while preserving custom CDN mirrors.

Fixes #15277

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Validated locally with:

- `pnpm exec vitest --config vitest.config.ts --run packages/wdio-utils/tests/node/index.test.ts packages/wdio-utils/tests/node/manager.test.ts`
- `pnpm exec eslint packages/wdio-utils/src/node/utils.ts packages/wdio-utils/src/node/startWebDriver.ts packages/wdio-utils/tests/node/index.test.ts`
- `pnpm -r --filter=@wdio/compiler run build -p @wdio/utils`

### Reviewers: @webdriverio/project-committers
