### PR TITLE
fix(browserstack-service): don't mark external-grid runs as Automate

### DIFF
--- a/packages/wdio-browserstack-service/src/config.ts
+++ b/packages/wdio-browserstack-service/src/config.ts
@@ -65,9 +65,10 @@ class BrowserStackConfig {
         options?: BrowserstackConfig & Options.Testrunner,
         config?: Options.Testrunner,
         capabilities?: Capabilities.TestrunnerCapabilities,
+        isBrowserStackInfra?: boolean,
     ): BrowserStackConfig {
         if (!this._instance && options && config) {
-            this._instance = new BrowserStackConfig(options, config, capabilities)
+            this._instance = new BrowserStackConfig(options, config, capabilities, isBrowserStackInfra)
         }
         return this._instance
     }
@@ -94,6 +95,7 @@ class BrowserStackConfig {
         options: BrowserstackConfig & Options.Testrunner,
         config: Options.Testrunner,
         capabilities?: Capabilities.TestrunnerCapabilities,
+        isBrowserStackInfra: boolean = true,
     ) {
         this.framework = config.framework
         this.userName = config.user
@@ -102,8 +104,12 @@ class BrowserStackConfig {
         this.percy = options.percy || false
         this.accessibility = options.accessibility
         this.app = options.app
-        this.appAutomate = !isUndefined(options.app) || detectAppAutomate(capabilities)
-        this.automate = !this.appAutomate
+        // `automate`/`app_automate` describe a BrowserStack-hosted run. When the session
+        // runs on an external (non-BrowserStack) grid — e.g. Test Observability only, with
+        // credentials inside testObservabilityOptions — neither should be set, otherwise the
+        // build is reported with origin `Automate` even though it never touched BrowserStack.
+        this.appAutomate = isBrowserStackInfra && (!isUndefined(options.app) || detectAppAutomate(capabilities))
+        this.automate = isBrowserStackInfra && !this.appAutomate
         this.buildIdentifier = options.buildIdentifier
         this.sdkRunID = uuidv4()
         BStackLogger.info(`BrowserStack service started with id: ${this.sdkRunID}`)

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -33,6 +33,7 @@ import {
     stopBuildUpstream,
     getCiInfo,
     isBStackSession,
+    isBrowserstackInfra,
     isUndefined,
     isAccessibilityAutomationSession,
     isTrue,
@@ -116,7 +117,8 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             process.env.TEST_OBSERVABILITY_BUILD_TAG = process.env.TEST_REPORTING_BUILD_TAG
         }
 
-        this.browserStackConfig = BrowserStackConfig.getInstance(_options, _config, capabilities)
+        const isBrowserStackInfra = isBrowserstackInfra(_config as BrowserstackConfig & Options.Testrunner)
+        this.browserStackConfig = BrowserStackConfig.getInstance(_options, _config, capabilities, isBrowserStackInfra)
         BStackLogger.debug(`_options data: ${JSON.stringify(_options)}`)
         BStackLogger.debug(`webdriver capabilities data: ${JSON.stringify(capabilities)}`)
         const configCopy = JSON.parse(JSON.stringify(_config))

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -117,7 +117,10 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
             process.env.TEST_OBSERVABILITY_BUILD_TAG = process.env.TEST_REPORTING_BUILD_TAG
         }
 
-        const isBrowserStackInfra = isBrowserstackInfra(_config as BrowserstackConfig & Options.Testrunner)
+        // Pass `capabilities` so per-capability `hostname` overrides are honored too (e.g. a
+        // multi-remote config where only some capabilities target an external grid), mirroring
+        // the `shouldAddServiceVersion`/`isBrowserstackInfra` usage elsewhere in this package.
+        const isBrowserStackInfra = isBrowserstackInfra(_config as BrowserstackConfig & Options.Testrunner, capabilities as Capabilities.BrowserStackCapabilities)
         this.browserStackConfig = BrowserStackConfig.getInstance(_options, _config, capabilities, isBrowserStackInfra)
         BStackLogger.debug(`_options data: ${JSON.stringify(_options)}`)
         BStackLogger.debug(`webdriver capabilities data: ${JSON.stringify(capabilities)}`)

--- a/packages/wdio-browserstack-service/tests/config.test.ts
+++ b/packages/wdio-browserstack-service/tests/config.test.ts
@@ -55,3 +55,33 @@ describe('BrowserStackConfig appAutomate detection', () => {
         expect(cfg.appAutomate).toBe(true)
     })
 })
+
+describe('BrowserStackConfig isBrowserStackInfra gating', () => {
+    beforeEach(() => {
+        ;(BrowserStackConfig as any)._instance = undefined
+    })
+
+    it('marks neither automate nor app_automate for a web run on an external (non-BrowserStack) grid', () => {
+        const cfg = new BrowserStackConfig(baseOptions, baseConfig, [
+            { browserName: 'chrome' },
+        ] as any, false)
+        expect(cfg.automate).toBe(false)
+        expect(cfg.appAutomate).toBe(false)
+    })
+
+    it('does not mark app_automate from app caps when not on BrowserStack infra', () => {
+        const cfg = new BrowserStackConfig(baseOptions, baseConfig, [
+            { platformName: 'iOS', 'appium:app': 'bs://xyz' },
+        ] as any, false)
+        expect(cfg.appAutomate).toBe(false)
+        expect(cfg.automate).toBe(false)
+    })
+
+    it('keeps automate true for a web run on BrowserStack infra', () => {
+        const cfg = new BrowserStackConfig(baseOptions, baseConfig, [
+            { browserName: 'chrome' },
+        ] as any, true)
+        expect(cfg.automate).toBe(true)
+        expect(cfg.appAutomate).toBe(false)
+    })
+})


### PR DESCRIPTION
### Proposed changes

When a run executes against an **external (non-BrowserStack) Selenium Grid**, the service still classified the run's origin as `Automate` because `config.automate` ignored `isBrowserstackInfra`. This mis-attributed external-grid runs.

**Change:** thread `isBrowserstackInfra` through to `BrowserStackConfig` so the origin is classified correctly and external-grid runs are no longer reported as Automate.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
