### PR TITLE
feat(browserstack-service): support proxyCaCertificate for SSL-inspecting proxies

### DIFF
--- a/packages/wdio-browserstack-service/src/caCert.ts
+++ b/packages/wdio-browserstack-service/src/caCert.ts
@@ -92,6 +92,13 @@ export function configureCaCertificate(options?: { proxyCaCertificate?: string }
         // Trade-off: if something had already installed a custom global dispatcher (tuned
         // timeouts/pools, interceptors), that config is discarded — the idiomatic undici approach.
         setGlobalDispatcher(new Agent({ connect: { ca: mergedCa } }))
+        // The custom CA is now trusted for this process's undici fetch — the primary effect is
+        // done, so mark configured BEFORE the secondary NODE_EXTRA_CA_CERTS export below. This
+        // stops a failure in that best-effort export from (a) being logged as a total "setup
+        // failed / falling back to system trust store" when the dispatcher is in fact active, and
+        // (b) leaving `configured` false so a later call re-installs the global dispatcher.
+        configured = true
+        BStackLogger.info(`proxyCaCertificate: trusting custom CA from ${certPath} (merged with system roots).`)
         // Child Node processes (e.g. the detached cleanup spawn) inherit NODE_EXTRA_CA_CERTS and
         // trust it at startup. It must be a PEM file: reuse the customer's path when already PEM,
         // else write a PEM-converted copy (Node can't load a raw DER through that var).
@@ -99,26 +106,30 @@ export function configureCaCertificate(options?: { proxyCaCertificate?: string }
         // detached Node children, but NOT the BrowserStack Local (Go) binary, which has its own
         // proxy flags (--proxy-host, etc.). proxyCaCertificate intentionally covers the service's
         // egress, not the Local tunnel binary (consistent with the Java agent's tool-scope).
-        if (!process.env.NODE_EXTRA_CA_CERTS) {
-            let nodeExtra = certPath
-            if (!isPem) {
-                // Write the PEM-converted trust anchor into a fresh, owner-only temp dir
-                // (random name via mkdtemp) with mode 0600 + O_EXCL/O_NOFOLLOW. A predictable
-                // path in a world-writable tmpdir would let a local attacker pre-plant or
-                // symlink-race the file the process is about to TRUST as a CA.
-                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browserstack_sdk_ca_'))
-                nodeExtra = path.join(tmpDir, 'ca.pem')
-                const fd = fs.openSync(nodeExtra, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | (fs.constants.O_NOFOLLOW || 0), 0o600)
-                try {
-                    fs.writeFileSync(fd, pemCerts.join(''))
-                } finally {
-                    fs.closeSync(fd)
+        // Best-effort + scoped: a failure here only affects detached children, not this process
+        // (which already trusts the CA via the global dispatcher installed above).
+        try {
+            if (!process.env.NODE_EXTRA_CA_CERTS) {
+                let nodeExtra = certPath
+                if (!isPem) {
+                    // Write the PEM-converted trust anchor into a fresh, owner-only temp dir
+                    // (random name via mkdtemp) with mode 0600 + O_EXCL/O_NOFOLLOW. A predictable
+                    // path in a world-writable tmpdir would let a local attacker pre-plant or
+                    // symlink-race the file the process is about to TRUST as a CA.
+                    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browserstack_sdk_ca_'))
+                    nodeExtra = path.join(tmpDir, 'ca.pem')
+                    const fd = fs.openSync(nodeExtra, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | (fs.constants.O_NOFOLLOW || 0), 0o600)
+                    try {
+                        fs.writeFileSync(fd, pemCerts.join(''))
+                    } finally {
+                        fs.closeSync(fd)
+                    }
                 }
+                process.env.NODE_EXTRA_CA_CERTS = nodeExtra
             }
-            process.env.NODE_EXTRA_CA_CERTS = nodeExtra
+        } catch (e) {
+            BStackLogger.warn(`proxyCaCertificate: CA is trusted for this process, but exporting NODE_EXTRA_CA_CERTS for detached child processes failed (children may not trust the custom CA): ${(e as Error).message}`)
         }
-        configured = true
-        BStackLogger.info(`proxyCaCertificate: trusting custom CA from ${certPath} (merged with system roots).`)
     } catch (e) {
         BStackLogger.warn(`proxyCaCertificate: setup failed, falling back to system trust store: ${(e as Error).message}`)
     }

--- a/packages/wdio-browserstack-service/src/caCert.ts
+++ b/packages/wdio-browserstack-service/src/caCert.ts
@@ -93,8 +93,18 @@ export function configureCaCertificate(options?: { proxyCaCertificate?: string }
         if (!process.env.NODE_EXTRA_CA_CERTS) {
             let nodeExtra = certPath
             if (!isPem) {
-                nodeExtra = path.join(os.tmpdir(), `browserstack_sdk_ca_${process.pid}.pem`)
-                fs.writeFileSync(nodeExtra, pemCerts.join(''))
+                // Write the PEM-converted trust anchor into a fresh, owner-only temp dir
+                // (random name via mkdtemp) with mode 0600 + O_EXCL/O_NOFOLLOW. A predictable
+                // path in a world-writable tmpdir would let a local attacker pre-plant or
+                // symlink-race the file the process is about to TRUST as a CA.
+                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browserstack_sdk_ca_'))
+                nodeExtra = path.join(tmpDir, 'ca.pem')
+                const fd = fs.openSync(nodeExtra, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | (fs.constants.O_NOFOLLOW || 0), 0o600)
+                try {
+                    fs.writeFileSync(fd, pemCerts.join(''))
+                } finally {
+                    fs.closeSync(fd)
+                }
             }
             process.env.NODE_EXTRA_CA_CERTS = nodeExtra
         }

--- a/packages/wdio-browserstack-service/src/caCert.ts
+++ b/packages/wdio-browserstack-service/src/caCert.ts
@@ -86,10 +86,19 @@ export function configureCaCertificate(options?: { proxyCaCertificate?: string }
         // Merge (not replace) the customer cert(s) with Node's default roots. Covers every
         // global fetch() call in this process (undici) + the fetchWrapper ProxyAgent tunnel.
         mergedCa = [...tls.rootCertificates, ...pemCerts]
+        // NOTE: setGlobalDispatcher REPLACES (not extends) the process-wide undici dispatcher.
+        // Safe here because we merge with the system roots, so every fetch() in the process still
+        // validates public endpoints (and still rejects the MITM cert when no custom CA is set).
+        // Trade-off: if something had already installed a custom global dispatcher (tuned
+        // timeouts/pools, interceptors), that config is discarded — the idiomatic undici approach.
         setGlobalDispatcher(new Agent({ connect: { ca: mergedCa } }))
         // Child Node processes (e.g. the detached cleanup spawn) inherit NODE_EXTRA_CA_CERTS and
         // trust it at startup. It must be a PEM file: reuse the customer's path when already PEM,
         // else write a PEM-converted copy (Node can't load a raw DER through that var).
+        // SCOPE: NODE_EXTRA_CA_CERTS is Node-only — it covers this service's outbound HTTPS and
+        // detached Node children, but NOT the BrowserStack Local (Go) binary, which has its own
+        // proxy flags (--proxy-host, etc.). proxyCaCertificate intentionally covers the service's
+        // egress, not the Local tunnel binary (consistent with the Java agent's tool-scope).
         if (!process.env.NODE_EXTRA_CA_CERTS) {
             let nodeExtra = certPath
             if (!isPem) {

--- a/packages/wdio-browserstack-service/src/caCert.ts
+++ b/packages/wdio-browserstack-service/src/caCert.ts
@@ -1,0 +1,75 @@
+import { setGlobalDispatcher, Agent } from 'undici'
+import tls from 'node:tls'
+import fs from 'node:fs'
+
+import { BStackLogger } from './bstackLogger.js'
+
+/*
+ * SDK-5953: trust a customer-provided CA certificate for SSL-inspecting corporate
+ * proxies (Zscaler, Netskope, Forcepoint).
+ *
+ * Resolution order for the cert path:
+ *   1. env BROWSERSTACK_EXTRA_CA_CERTS   (consistency with the other SDKs)
+ *   2. the `proxyCaCertificate` service option
+ *
+ * The service makes outbound HTTPS via undici `fetch`: most call sites use the
+ * global fetch (covered by a global undici Agent), and the proxy path in
+ * fetchWrapper uses a ProxyAgent (which needs the CA on `requestTls`). We build a
+ * MERGED ca list (Node's default roots + the customer cert) so non-intercepted
+ * endpoints still validate. Also export NODE_EXTRA_CA_CERTS for child processes.
+ *
+ * Never throws — a misconfigured cert must not break the customer's run.
+ */
+
+let mergedCa: string[] | undefined
+let configured = false
+
+function resolveCaCertPath(options?: { proxyCaCertificate?: string }): string | undefined {
+    let p = process.env.BROWSERSTACK_EXTRA_CA_CERTS
+    if ((!p || !p.trim()) && options?.proxyCaCertificate) {
+        p = options.proxyCaCertificate
+    }
+    if (!p || !String(p).trim()) {
+        return undefined
+    }
+    p = String(p).trim()
+    try {
+        if (fs.existsSync(p) && fs.statSync(p).isFile()) {
+            return p
+        }
+        BStackLogger.warn(`proxyCaCertificate: path does not exist or is not a file, falling back to system trust store: ${p}`)
+    } catch (e) {
+        BStackLogger.warn(`proxyCaCertificate: failed to stat cert path ${p}: ${(e as Error).message}`)
+    }
+    return undefined
+}
+
+/** The merged CA list (system roots + customer cert), or undefined when not configured. */
+export function getMergedCa(): string[] | undefined {
+    return mergedCa
+}
+
+/** Idempotent. Sets a global undici dispatcher trusting the merged CA, and NODE_EXTRA_CA_CERTS. */
+export function configureCaCertificate(options?: { proxyCaCertificate?: string }): void {
+    if (configured) {
+        return
+    }
+    try {
+        const certPath = resolveCaCertPath(options)
+        if (!certPath) {
+            return
+        }
+        const caPem = fs.readFileSync(certPath, 'utf8')
+        mergedCa = [...tls.rootCertificates, caPem]
+        // Covers every global fetch() call in this process (undici-backed). Merge, not replace.
+        setGlobalDispatcher(new Agent({ connect: { ca: mergedCa } }))
+        // Child Node processes (e.g. the detached cleanup spawn) inherit and trust it at startup.
+        if (!process.env.NODE_EXTRA_CA_CERTS) {
+            process.env.NODE_EXTRA_CA_CERTS = certPath
+        }
+        configured = true
+        BStackLogger.info(`proxyCaCertificate: trusting custom CA from ${certPath} (merged with system roots).`)
+    } catch (e) {
+        BStackLogger.warn(`proxyCaCertificate: setup failed, falling back to system trust store: ${(e as Error).message}`)
+    }
+}

--- a/packages/wdio-browserstack-service/src/caCert.ts
+++ b/packages/wdio-browserstack-service/src/caCert.ts
@@ -1,8 +1,25 @@
 import { setGlobalDispatcher, Agent } from 'undici'
 import tls from 'node:tls'
 import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
 import { BStackLogger } from './bstackLogger.js'
+
+// Convert a DER (binary) certificate Buffer to a PEM string (base64, 64-char lines).
+function derToPem(der: Buffer): string {
+    const b64 = der.toString('base64').replace(/(.{64})/g, '$1\n')
+    return `-----BEGIN CERTIFICATE-----\n${b64}${b64.endsWith('\n') ? '' : '\n'}-----END CERTIFICATE-----\n`
+}
+
+// Read a customer CA Buffer into an array of PEM cert strings, supporting BOTH PEM
+// (single or multi-cert bundle) and DER (binary) — any extension (.pem/.crt/.cer/.der).
+function loadCaCertsAsPem(buf: Buffer): string[] {
+    if (buf.includes('-----BEGIN CERTIFICATE-----')) {
+        return buf.toString('utf8').match(/-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g) || []
+    }
+    return [derToPem(buf)] // DER (binary) single cert
+}
 
 /*
  * SDK-5953: trust a customer-provided CA certificate for SSL-inspecting corporate
@@ -59,13 +76,27 @@ export function configureCaCertificate(options?: { proxyCaCertificate?: string }
         if (!certPath) {
             return
         }
-        const caPem = fs.readFileSync(certPath, 'utf8')
-        mergedCa = [...tls.rootCertificates, caPem]
-        // Covers every global fetch() call in this process (undici-backed). Merge, not replace.
+        const buf = fs.readFileSync(certPath)
+        const isPem = buf.includes('-----BEGIN CERTIFICATE-----')
+        const pemCerts = loadCaCertsAsPem(buf)
+        if (!pemCerts.length) {
+            BStackLogger.warn(`proxyCaCertificate: no certificate found in ${certPath}; falling back to system trust store.`)
+            return
+        }
+        // Merge (not replace) the customer cert(s) with Node's default roots. Covers every
+        // global fetch() call in this process (undici) + the fetchWrapper ProxyAgent tunnel.
+        mergedCa = [...tls.rootCertificates, ...pemCerts]
         setGlobalDispatcher(new Agent({ connect: { ca: mergedCa } }))
-        // Child Node processes (e.g. the detached cleanup spawn) inherit and trust it at startup.
+        // Child Node processes (e.g. the detached cleanup spawn) inherit NODE_EXTRA_CA_CERTS and
+        // trust it at startup. It must be a PEM file: reuse the customer's path when already PEM,
+        // else write a PEM-converted copy (Node can't load a raw DER through that var).
         if (!process.env.NODE_EXTRA_CA_CERTS) {
-            process.env.NODE_EXTRA_CA_CERTS = certPath
+            let nodeExtra = certPath
+            if (!isPem) {
+                nodeExtra = path.join(os.tmpdir(), `browserstack_sdk_ca_${process.pid}.pem`)
+                fs.writeFileSync(nodeExtra, pemCerts.join(''))
+            }
+            process.env.NODE_EXTRA_CA_CERTS = nodeExtra
         }
         configured = true
         BStackLogger.info(`proxyCaCertificate: trusting custom CA from ${certPath} (merged with system roots).`)

--- a/packages/wdio-browserstack-service/src/fetchWrapper.ts
+++ b/packages/wdio-browserstack-service/src/fetchWrapper.ts
@@ -1,5 +1,7 @@
 import { fetch as undiciFetch, type RequestInit as UndiciRequestInit, ProxyAgent, Agent, type Dispatcher } from 'undici'
 
+import { getMergedCa } from './caCert.js'
+
 export class ResponseError extends Error {
     public response: Response
     constructor(message: string, res: Response) {
@@ -25,18 +27,32 @@ export interface FetchOptions {
     connectTimeoutMs?: number
 }
 
-// Dispatchers are relatively expensive to build and hold a connection pool, so we
-// cache one per (proxy, connectTimeout) combination instead of creating a new one
-// on every request.
+// Dispatchers are relatively expensive to build and hold a connection pool, so we cache one per
+// (proxy, connectTimeout, hasCa) combination instead of creating a new one on every request.
+// SDK-5953: when a customer `proxyCaCertificate` is configured, an explicit dispatcher bypasses the
+// global one installed in caCert.ts, so the merged CA (system roots + customer cert) must be applied
+// here too — on the proxy tunnel's upstream TLS (`requestTls.ca`) and on a direct `Agent`
+// (`connect.ca`). `hasCa` is a sufficient cache discriminator since the merged CA is process-stable.
 const dispatcherCache = new Map<string, Dispatcher>()
 
-function getDispatcher(proxyUrl: string | undefined, connectTimeoutMs: number): Dispatcher {
-    const key = `${proxyUrl ?? 'direct'}:${connectTimeoutMs}`
+function getDispatcher(proxyUrl: string | undefined, connectTimeoutMs?: number): Dispatcher {
+    const ca = getMergedCa()
+    const key = `${proxyUrl ?? 'direct'}:${connectTimeoutMs ?? 'default'}:${ca ? 'ca' : 'noca'}`
     let dispatcher = dispatcherCache.get(key)
     if (!dispatcher) {
-        dispatcher = proxyUrl
-            ? new ProxyAgent({ uri: proxyUrl, connect: { timeout: connectTimeoutMs } })
-            : new Agent({ connect: { timeout: connectTimeoutMs } })
+        const connect: { timeout?: number, ca?: string[] } = {}
+        if (connectTimeoutMs) {
+            connect.timeout = connectTimeoutMs
+        }
+        if (proxyUrl) {
+            // requestTls.ca = upstream (through-tunnel) TLS, which the inspecting proxy re-signs.
+            dispatcher = new ProxyAgent({ uri: proxyUrl, connect, ...(ca ? { requestTls: { ca } } : {}) })
+        } else {
+            if (ca) {
+                connect.ca = ca
+            }
+            dispatcher = new Agent({ connect })
+        }
         dispatcherCache.set(key, dispatcher)
     }
     return dispatcher
@@ -60,9 +76,10 @@ export function _fetch(input: RequestInfo | URL, init?: RequestInit, options?: F
         const request = new Request(input)
         const url = new URL(request.url)
         if (!noProxy.some((str) => url.hostname.endsWith(str))) {
-            const dispatcher = connectTimeoutMs
-                ? getDispatcher(proxyUrl, connectTimeoutMs)
-                : new ProxyAgent(proxyUrl)
+            // Always route the proxy tunnel through getDispatcher: an explicit dispatcher bypasses
+            // the global one, so its upstream TLS must trust the customer CA (SDK-5953). getDispatcher
+            // also applies connectTimeoutMs when provided and caches the agent per key.
+            const dispatcher = getDispatcher(proxyUrl, connectTimeoutMs)
             return undiciFetch(
                 request.url,
                 { ...(init as UndiciRequestInit), dispatcher },
@@ -71,7 +88,8 @@ export function _fetch(input: RequestInfo | URL, init?: RequestInit, options?: F
     }
     // Without a proxy, global fetch's connect timeout is fixed at 10s and cannot be
     // overridden, so when a caller needs a larger one we go through undici directly
-    // with a custom Agent. The default path is left untouched.
+    // with a custom Agent (which also carries the custom CA when configured). The default
+    // path is left untouched — non-proxy fetch already trusts the CA via the global dispatcher.
     if (connectTimeoutMs) {
         return undiciFetch(
             new Request(input).url,

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -50,6 +50,7 @@ import {
 } from './util.js'
 import CrashReporter from './crash-reporter.js'
 import { BStackLogger } from './bstackLogger.js'
+import { configureCaCertificate } from './caCert.js'
 import { PercyLogger } from './Percy/PercyLogger.js'
 import type Percy from './Percy/Percy.js'
 import BrowserStackConfig from './config.js'
@@ -87,6 +88,9 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         BStackLogger.clearLogFile()
         PercyLogger.clearLogFile()
         setupExitHandlers()
+        // SDK-5953: trust the customer CA (proxyCaCertificate / BROWSERSTACK_EXTRA_CA_CERTS)
+        // for all outbound HTTPS (undici fetch) before any request fires. Merged with system roots.
+        configureCaCertificate(this._options)
         // added to maintain backward compatibility with webdriverIO v5
         if (!this._config) {
             this._config = _options

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -14,6 +14,7 @@ import type { Pickle, Feature, ITestCaseHookParameter, CucumberHook } from './cu
 import InsightsHandler from './insights-handler.js'
 import TestReporter from './reporter.js'
 import { DEFAULT_OPTIONS, NOT_ALLOWED_KEYS_IN_CAPS, PERF_MEASUREMENT_ENV } from './constants.js'
+import { configureCaCertificate } from './caCert.js'
 import CrashReporter from './crash-reporter.js'
 import AccessibilityHandler from './accessibility-handler.js'
 import { BStackLogger } from './bstackLogger.js'
@@ -72,6 +73,9 @@ export default class BrowserstackService implements Services.ServiceInstance {
         private _config: Options.Testrunner
     ) {
         this._options = { ...DEFAULT_OPTIONS, ...options }
+        // SDK-5953: trust the customer CA (proxyCaCertificate / BROWSERSTACK_EXTRA_CA_CERTS)
+        // for all outbound HTTPS (undici fetch) in the worker process. Merged with system roots.
+        configureCaCertificate(this._options)
         // added to maintain backward compatibility with webdriverIO v5
         if (!this._config) {
             this._config = this._options

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -65,6 +65,13 @@ export interface BrowserstackOptions extends Options.Testrunner {
 
 export interface BrowserstackConfig {
     /**
+     * Absolute path to a CA certificate (PEM, single cert or bundle) to trust for outbound
+     * HTTPS when behind an SSL-inspecting corporate proxy (Zscaler/Netskope/Forcepoint).
+     * Overridable via the `BROWSERSTACK_EXTRA_CA_CERTS` env var. Merged with the system
+     * trust store (never replaces it).
+     */
+    proxyCaCertificate?: string;
+    /**
      *`buildIdentifier` is a unique id to differentiate every execution that gets appended to
      * buildName. Choose your buildIdentifier format from the available expressions:
      * ${BUILD_NUMBER} (Default): Generates an incremental counter with every execution


### PR DESCRIPTION
### Proposed changes

Adds a `proxyCaCertificate` service option (and a `BROWSERSTACK_EXTRA_CA_CERTS` env equivalent) so users behind SSL-inspecting corporate proxies (Zscaler, Netskope, Forcepoint, …) can have the service trust their proxy's root CA for outbound HTTPS.

- **New `caCert.ts`** — reads the customer CA (PEM single cert or bundle, **or** DER, any extension), merges it with Node's default roots (`tls.rootCertificates`), installs a global undici dispatcher trusting the merged CA, and exports `NODE_EXTRA_CA_CERTS` so detached child Node processes trust it at startup. Idempotent and **never throws** — a missing/misconfigured cert falls back to the system trust store.
- **`fetchWrapper.ts`** — the proxy path attaches the merged CA to the `ProxyAgent`'s `requestTls`, so the tunnel's upstream TLS also validates. The `ProxyAgent` is cached per `(proxyUrl, hasCa)` to avoid re-parsing the CA on every request.
- **Security** — when converting a DER cert to a PEM trust-anchor file, it is written into a fresh `mkdtemp` dir with mode `0600` + `O_EXCL`/`O_NOFOLLOW`, avoiding a symlink / pre-plant race on the file the process is about to trust as a CA.

**Scope:** covers the service's own egress and detached Node children. The BrowserStack Local (Go) binary has its own proxy flags and is intentionally out of scope (consistent with the other BrowserStack SDKs).

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

---
ℹ️ This edits `fetchWrapper.ts`, also touched by a companion CLI connect-timeout PR. Validated together; whichever lands second needs only a trivial rebase of the shared dispatcher helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
