### PR TITLE
ci: fix ubuntu e2e failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,23 +59,23 @@ jobs:
     uses: ./.github/workflows/test-launch.yml
 
   cloud_tests:
-    name: E2E Tests
+    name: Cloud E2E Tests
     needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
     uses: ./.github/workflows/test-cloud.yml
     secrets: inherit
 
   testrunner_tests:
-    name: E2E Tests
+    name: Testrunner E2E Tests
     needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
     uses: ./.github/workflows/test-testrunner.yml
 
   multiremote_tests:
-    name: E2E Tests
+    name: Multiremote E2E Tests
     needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
     uses: ./.github/workflows/test-multiremote.yml
 
   standalone_tests:
-    name: E2E Tests
+    name: Standalone E2E Tests
     needs: [smoke_tests, component_tests, unit_tests, interop_tests, typing_tests]
     uses: ./.github/workflows/test-standalone.yml
 

--- a/e2e/wdio/headless/bidi.e2e.ts
+++ b/e2e/wdio/headless/bidi.e2e.ts
@@ -337,7 +337,6 @@ describe('bidi e2e test', () => {
         describe('Browser ClientWindowState', () => {
 
             it('can get window state', async () => {
-                console.log('Getting window state')
                 await browser.url('https://guinea-pig.webdriver.io')
 
                 const windowState = await browser.browserGetClientWindows({})
@@ -466,7 +465,7 @@ describe('bidi e2e test', () => {
                 await browser.setPermissions({ name: 'geolocation' }, 'granted')
 
                 return browser.execute(() => {
-                // You must wrap callback-based APIs in a Promise even in an async function
+                    // You must wrap callback-based APIs in a Promise even in an async function
                     return new Promise((resolve, reject) => {
                         if (!navigator.geolocation) {
                             return reject(new Error('Geolocation not supported'))

--- a/e2e/wdio/wdio.local.conf.ts
+++ b/e2e/wdio/wdio.local.conf.ts
@@ -46,7 +46,8 @@ export const config: WebdriverIO.Config = {
                 args: [
                     'headless',
                     'disable-gpu',
-                    // Having `WebDriverError: session not created: Chrome instance exited` on ubuntu without it!
+                    // Having `WebDriverError: session not created: Chrome instance exited` since ubuntu 22.04 to 24.04, since the below is no more wrapped by default.
+                    // See https://github.com/webdriverio/webdriverio/issues/14168.
                     ...(isLinux ? ['no-sandbox'] : [])
                 ]
             },

--- a/e2e/wdio/wdio.local.conf.ts
+++ b/e2e/wdio/wdio.local.conf.ts
@@ -6,6 +6,7 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
 const isLinux = os.platform() === 'linux'
 const isApple = os.platform() === 'darwin'
+const isWindows = os.platform() === 'win32'
 
 /**
  * with this config file we verify that the `webdriverio` package can spin
@@ -52,7 +53,7 @@ export const config: WebdriverIO.Config = {
                 ]
             },
         },
-        {
+        ...(!isWindows ? [{
             browserName: 'chromium',
             webSocketUrl: true,
             'goog:chromeOptions': {
@@ -64,7 +65,7 @@ export const config: WebdriverIO.Config = {
                     ...(isLinux ? ['no-sandbox'] : [])
                 ]
             }
-        },
+        }] : []),
         ...(isApple ? [{
         // Not yet supported, safari use classic WebDriver for now.
         // webSocketUrl: true,

--- a/e2e/wdio/wdio.local.conf.ts
+++ b/e2e/wdio/wdio.local.conf.ts
@@ -53,6 +53,7 @@ export const config: WebdriverIO.Config = {
                 ]
             },
         },
+        // Excluding Chromium on Windows due to `Error: chromium is not available on Windows.`
         ...(!isWindows ? [{
             browserName: 'chromium',
             webSocketUrl: true,
@@ -67,8 +68,8 @@ export const config: WebdriverIO.Config = {
             }
         }] : []),
         ...(isApple ? [{
-        // Not yet supported, safari use classic WebDriver for now.
-        // webSocketUrl: true,
+            // Not yet supported, safari use classic WebDriver for now.
+            // webSocketUrl: true,
             browserName: 'safari'
         }] : [])
     ],

--- a/e2e/wdio/wdio.local.conf.ts
+++ b/e2e/wdio/wdio.local.conf.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
-const isLinux = process.platform === 'linux'
+const isLinux = os.platform() === 'linux'
 
 /**
  * with this config file we verify that the `webdriverio` package can spin

--- a/e2e/wdio/wdio.local.conf.ts
+++ b/e2e/wdio/wdio.local.conf.ts
@@ -40,8 +40,8 @@ export const config: WebdriverIO.Config = {
         webSocketUrl: true,
         'ms:edgeOptions': {
             args: [
-                'headless'
-                , 'disable-gpu',
+                'headless',
+                'disable-gpu',
                 // Having `WebDriverError: session not created: Chrome instance exited` on ubuntu without it!
                 ...(isLinux ? ['no-sandbox'] : [])
             ]

--- a/e2e/wdio/wdio.local.conf.ts
+++ b/e2e/wdio/wdio.local.conf.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
 const isLinux = os.platform() === 'linux'
+const isApple = os.platform() === 'darwin'
 
 /**
  * with this config file we verify that the `webdriverio` package can spin
@@ -23,30 +24,46 @@ export const config: WebdriverIO.Config = {
     /**
      * capabilities
      */
-    capabilities: [{
-        browserName: 'chrome',
-        webSocketUrl: true,
-        'goog:chromeOptions': {
-            args: ['headless', 'disable-gpu']
-        }
-    }, {
-        browserName: 'firefox',
-        webSocketUrl: true,
-        'moz:firefoxOptions': {
-            args: ['-headless']
-        }
-    }, {
-        browserName: 'edge',
-        webSocketUrl: true,
-        'ms:edgeOptions': {
-            args: [
-                'headless',
-                'disable-gpu',
-                // Having `WebDriverError: session not created: Chrome instance exited` on ubuntu without it!
-                ...(isLinux ? ['no-sandbox'] : [])
-            ]
-        }
-    }],
+    capabilities: [
+        {
+            browserName: 'chrome',
+            webSocketUrl: true,
+            'goog:chromeOptions': {
+                args: ['headless', 'disable-gpu']
+            }
+        },
+        {
+            browserName: 'firefox',
+            webSocketUrl: true,
+            'moz:firefoxOptions': {
+                args: ['-headless']
+            }
+        },
+        {
+            browserName: 'edge',
+            webSocketUrl: true,
+            'ms:edgeOptions': {
+                args: [
+                    'headless',
+                    'disable-gpu',
+                    // Having `WebDriverError: session not created: Chrome instance exited` on ubuntu without it!
+                    ...(isLinux ? ['no-sandbox'] : [])
+                ]
+            },
+        },
+        {
+            browserName: 'chromium',
+            webSocketUrl: true,
+            'goog:chromeOptions': {
+                args: ['headless', 'disable-gpu']
+            }
+        },
+        ...(isApple ? [{
+        // Not yet supported, safari use classic WebDriver for now.
+        // webSocketUrl: true,
+            browserName: 'safari'
+        }] : [])
+    ],
 
     /**
      * test configurations
@@ -62,26 +79,3 @@ export const config: WebdriverIO.Config = {
         timeout: 60000
     }
 }
-
-if (os.platform() === 'darwin') {
-    config.capabilities.push({
-        // Not yet supported, safari use classic WebDriver for now.
-        // webSocketUrl: true,
-        browserName: 'safari'
-    })
-}
-
-/**
- * Disable these tests as they started failing, due to:
- *   > WebDriver Bidi command "browsingContext.navigate" failed with error:
- *     unknown error - net::ERR_BLOCKED_BY_CLIENT
- */
-// if (os.platform() !== 'win32') {
-//     config.capabilities.push({
-//         browserName: 'chromium',
-//         webSocketUrl: true,
-//         'goog:chromeOptions': {
-//             args: ['headless', 'disable-gpu']
-//         }
-//     })
-// }

--- a/e2e/wdio/wdio.local.conf.ts
+++ b/e2e/wdio/wdio.local.conf.ts
@@ -4,11 +4,14 @@ import path from 'node:path'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
+const isLinux = process.platform === 'linux'
+
 /**
  * with this config file we verify that the `webdriverio` package can spin
  * up the necessary browser runner without needing a service anymore.
  */
 export const config: WebdriverIO.Config = {
+
     /**
      * specify test files
      */
@@ -26,13 +29,6 @@ export const config: WebdriverIO.Config = {
         'goog:chromeOptions': {
             args: ['headless', 'disable-gpu']
         }
-    // }, {
-    //     browserName: 'chrome',
-    //     browserVersion: 'canary',
-    //     webSocketUrl: true,
-    //     'goog:chromeOptions': {
-    //         args: ['headless', 'disable-gpu']
-    //     }
     }, {
         browserName: 'firefox',
         webSocketUrl: true,
@@ -43,7 +39,12 @@ export const config: WebdriverIO.Config = {
         browserName: 'edge',
         webSocketUrl: true,
         'ms:edgeOptions': {
-            args: ['headless', 'disable-gpu']
+            args: [
+                'headless'
+                , 'disable-gpu',
+                // Having `WebDriverError: session not created: Chrome instance exited` on ubuntu without it!
+                ...(isLinux ? ['no-sandbox'] : [])
+            ]
         }
     }],
 
@@ -81,22 +82,6 @@ if (os.platform() === 'darwin') {
 //         webSocketUrl: true,
 //         'goog:chromeOptions': {
 //             args: ['headless', 'disable-gpu']
-//         }
-//     })
-// }
-
-/**
- * latest Firefox 124.0a1 is not available on Linux
- * Disable FF nightly tests due to WebDriver Bidi command "browsingContext.navigate" failed with error: unknown error
- * @see https://bugzilla.mozilla.org/show_bug.cgi?id=1908515
- */
-// if (os.platform() === 'win32' || os.platform() === 'darwin') {
-//     config.capabilities.push({
-//         browserName: 'firefox',
-//         webSocketUrl: true,
-//         browserVersion: 'latest',
-//         'moz:firefoxOptions': {
-//             args: ['-headless']
 //         }
 //     })
 // }

--- a/e2e/wdio/wdio.local.conf.ts
+++ b/e2e/wdio/wdio.local.conf.ts
@@ -56,7 +56,13 @@ export const config: WebdriverIO.Config = {
             browserName: 'chromium',
             webSocketUrl: true,
             'goog:chromeOptions': {
-                args: ['headless', 'disable-gpu']
+                args: [
+                    'headless',
+                    'disable-gpu',
+                    // Having `WebDriverError: session not created: Chrome instance exited` since ubuntu 22.04 to 24.04, since the below is no more wrapped by default.
+                    // See https://github.com/webdriverio/webdriverio/issues/14168.
+                    ...(isLinux ? ['no-sandbox'] : [])
+                ]
             }
         },
         ...(isApple ? [{


### PR DESCRIPTION
## Proposed changes

Fix main e2e pipeline failing with below error on edge under ubuntu platform.
> [edge (unknown) #2-0] Running: edge on (unknown)
[edge (unknown) #2-0]
[edge (unknown) #2-0] ✖ Failed to create a session:
[edge (unknown) #2-0] WebDriverError: session not created: Chrome instance exited. Examine ChromeDriver verbose log to determine the cause. when running "http://localhost:35789/session" with method "POST"

Fixes
- Using `no-sandbox` argument capability does the trick.
- Regroup all capabilities together
- Add back Chromiun case

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
