### PR TITLE
disable build error to keep safari12 and delay breaking change to v10

### DIFF
--- a/infra/compiler/src/index.ts
+++ b/infra/compiler/src/index.ts
@@ -211,10 +211,12 @@ const configs = packages.map(([packageDir, pkg]) => {
                 entryPoints: [path.resolve(absWorkingDir, browserSource)],
                 platform: 'browser',
                 format: 'esm',
+                // Starting esbuild 0.28.1, we should also upgrade to safari14.1. TODO in v10 since this is breaking!
                 target: ['es2021', 'chrome90', 'edge90', 'firefox90', 'safari12'],
                 plugins: [],
                 supported: {
-                    'top-level-await': true //browsers can handle top-level-await features
+                    'top-level-await': true, //browsers can handle top-level-await features
+                    'destructuring': true, // TODO remove in v10: Required since esbuild 0.28.1, otherwise esbuild generates invalid code for destructured imports/exports
                 }
             }
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
