### PR TITLE
fix(@wdio/browserstack-service): isolate per-batch failures in the request queue

### DIFF
--- a/packages/wdio-browserstack-service/src/request-handler.ts
+++ b/packages/wdio-browserstack-service/src/request-handler.ts
@@ -67,7 +67,14 @@ export default class RequestQueueHandler {
 
     callCallback = async (data: UploadType[], kind: string) => {
         BStackLogger.debug('calling callback with kind ' + kind)
-        await this.callback?.(data)
+        // SDK-6275: isolate per-batch failures so one failing upload never aborts
+        // the rest of the queue flush (notably the shutdown() drain loop, which
+        // awaits this for each batch and would otherwise stop on the first error).
+        try {
+            await this.callback?.(data)
+        } catch (e) {
+            BStackLogger.debug(`Exception while sending data batch (${kind}); continuing with remaining batches: ${e}`)
+        }
     }
 
     resetEventBatchPolling () {


### PR DESCRIPTION
## Motivation

`RequestQueueHandler.shutdown()` drains the event queue one batch at a time with `await this.callCallback(batch)` ([`request-handler.ts`](https://github.com/webdriverio/webdriverio/blob/main/packages/wdio-browserstack-service/src/request-handler.ts) `shutdown()`), and `callCallback` → `callback` → `uploadEventData` **rethrows** on a failed POST (`testOps/requestUtils.ts`). So if a single batch upload fails during the final drain (transient 5xx / network blip at end-of-run), the `while` loop aborts and **every remaining queued event is dropped** — instead of just the one failed batch.

The `add()` path already isolates this (`.catch` on `sendBatch`), but the shutdown drain and the interval poll do not.

## Change

Guard `callCallback` with a try/catch that logs and continues, so one failing batch never aborts the rest of the flush. Single chokepoint — covers the `shutdown()` drain, the interval poll, and `add()`.

```ts
callCallback = async (data, kind) => {
    BStackLogger.debug('calling callback with kind ' + kind)
    try {
        await this.callback?.(data)
    } catch (e) {
        BStackLogger.debug(`Exception while sending data batch (${kind}); continuing with remaining batches: ${e}`)
    }
}
```

This matches the "one failing request must not kill the entire event queue" hardening already shipped on the sibling BrowserStack Python SDK.

## Notes
- Defensive isolation only — no behavioural change on the success path.
- Surfaced via an internal instrumentation/exception-handling audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
