### PR TITLE
feat(browserstack-service): one-to-many Test-Case-ID tagging (setCust…

### DIFF
--- a/packages/wdio-browserstack-service/src/@types/bstack-service-types.d.ts
+++ b/packages/wdio-browserstack-service/src/@types/bstack-service-types.d.ts
@@ -4,7 +4,8 @@ declare namespace WebdriverIO {
         getAccessibilityResults: () => Promise<Array<Record<string, unknown>>>,
         performScan: () => Promise<Record<string, unknown> | undefined>,
         startA11yScanning: () => Promise<void>,
-        stopA11yScanning: () => Promise<void>
+        stopA11yScanning: () => Promise<void>,
+        setCustomTags: (key: string, value: string) => Promise<void>
     }
 
     interface MultiRemoteBrowser {
@@ -12,6 +13,7 @@ declare namespace WebdriverIO {
         getAccessibilityResults: () => Promise<Array<Record<string, unknown>>>,
         performScan: () => Promise<Record<string, unknown> | undefined>,
         startA11yScanning: () => Promise<void>,
-        stopA11yScanning: () => Promise<void>
+        stopA11yScanning: () => Promise<void>,
+        setCustomTags: (key: string, value: string) => Promise<void>
     }
 }

--- a/packages/wdio-browserstack-service/src/cli/frameworks/constants/testFrameworkConstants.ts
+++ b/packages/wdio-browserstack-service/src/cli/frameworks/constants/testFrameworkConstants.ts
@@ -21,6 +21,7 @@ export const TestFrameworkConstants = {
     KEY_TEST_FAILURE_REASON : 'test_failure_reason',
     KEY_TEST_LOGS : 'test_logs',
     KEY_TEST_META : 'test_meta',
+    KEY_CUSTOM_TAGS : 'custom_metadata',
     KEY_TEST_DEFERRED : 'test_deferred',
     KEY_SESSION_NAME : 'test_session_name',
     KEY_AUTOMATE_SESSION_NAME : 'automate_session_name',

--- a/packages/wdio-browserstack-service/src/cli/index.ts
+++ b/packages/wdio-browserstack-service/src/cli/index.ts
@@ -19,6 +19,7 @@ import WdioMochaTestFramework from './frameworks/wdioMochaTestFramework.js'
 import WdioAutomationFramework from './frameworks/wdioAutomationFramework.js'
 import WebdriverIOModule from './modules/webdriverIOModule.js'
 import AccessibilityModule from './modules/accessibilityModule.js'
+import CustomTagsModule from './modules/customTagsModule.js'
 import { isTurboScale, processAccessibilityResponse, shouldAddServiceVersion } from '../util.js'
 import ObservabilityModule from './modules/observabilityModule.js'
 import type { BrowserstackConfig, BrowserstackOptions, LaunchResponse } from '../types.js'
@@ -165,6 +166,10 @@ export class BrowserstackCLI {
             }
 
             this.modules[TestHubModule.MODULE_NAME] = new TestHubModule(startBinResponse.testhub)
+
+            // Custom-tag (multi Test-Case-ID) tagging rides the per-test event_json
+            // to TestHub, so it is gated on the testhub pipeline being active.
+            this.modules[CustomTagsModule.MODULE_NAME] = new CustomTagsModule()
 
             if (startBinResponse.accessibility?.success){
                 process.env[BROWSERSTACK_ACCESSIBILITY] = 'true'

--- a/packages/wdio-browserstack-service/src/cli/modules/customTagsModule.ts
+++ b/packages/wdio-browserstack-service/src/cli/modules/customTagsModule.ts
@@ -1,0 +1,122 @@
+/// <reference path="../../@types/bstack-service-types.d.ts" />
+import BaseModule from './baseModule.js'
+import { BStackLogger } from '../cliLogger.js'
+import TestFramework from '../frameworks/testFramework.js'
+import AutomationFramework from '../frameworks/automationFramework.js'
+import type AutomationFrameworkInstance from '../instances/automationFrameworkInstance.js'
+import type TestFrameworkInstance from '../instances/testFrameworkInstance.js'
+import { AutomationFrameworkState } from '../states/automationFrameworkState.js'
+import { HookState } from '../states/hookState.js'
+import { TestFrameworkConstants } from '../frameworks/constants/testFrameworkConstants.js'
+import { CLIUtils } from '../cliUtils.js'
+import WdioMochaTestFramework from '../frameworks/wdioMochaTestFramework.js'
+import { mergeIntoTags, parseCommaSeparatedValues } from '../../customTags.js'
+import type { CustomMetadata } from '../../customTags.js'
+
+/**
+ * CustomTagsModule — CLI/gRPC path registration for `browser.setCustomTags`.
+ *
+ * Mirrors AccessibilityModule: registers the browser method in onBeforeExecute()
+ * (observer-bound to AutomationFrameworkState.CREATE / HookState.POST), instantiated
+ * from BrowserstackCLI.loadModules() whenever the binary is up.
+ *
+ * The per-test custom_metadata is merged directly into the tracked
+ * TestFrameworkInstance map under KEY_CUSTOM_TAGS ('custom_metadata'). That whole
+ * map is serialized verbatim into event_json (testHubModule.sendTestFrameworkEvent),
+ * so the binary reads it as event.custom_metadata. The instance is created fresh
+ * per test, so per-instance merge gives test-scoped union/dedupe; the binary is a
+ * strict pass-through and does NOT consolidate across events.
+ */
+export default class CustomTagsModule extends BaseModule {
+
+    logger = BStackLogger
+    name: string
+    static MODULE_NAME = 'CustomTagsModule'
+
+    constructor() {
+        super()
+        this.name = 'CustomTagsModule'
+        AutomationFramework.registerObserver(AutomationFrameworkState.CREATE, HookState.POST, this.onBeforeExecute.bind(this))
+    }
+
+    getModuleName() {
+        return CustomTagsModule.MODULE_NAME
+    }
+
+    async onBeforeExecute() {
+        try {
+            const autoInstance: AutomationFrameworkInstance = AutomationFramework.getTrackedInstance()
+            if (!autoInstance) {
+                this.logger.debug('CustomTagsModule: No tracked automation instance found!')
+                return
+            }
+
+            const browser = AutomationFramework.getDriver(autoInstance) as WebdriverIO.Browser
+            if (!browser) {
+                this.logger.debug('CustomTagsModule: No browser instance found for setCustomTags registration')
+                return
+            }
+
+            (browser as WebdriverIO.Browser).setCustomTags = async (key: string, value: string): Promise<void> => {
+                try {
+                    if (!key || !value) {
+                        this.logger.warn('setCustomTags: key and value are required; ignoring call')
+                        return
+                    }
+
+                    const testInstance: TestFrameworkInstance = TestFramework.getTrackedInstance()
+                    if (!testInstance) {
+                        this.logger.warn('setCustomTags called outside of a resolvable test context; ignoring')
+                        return
+                    }
+
+                    const values = parseCommaSeparatedValues(value)
+                    if (values.length === 0) {
+                        this.logger.warn(`setCustomTags: no usable values parsed from "${value}"; ignoring call`)
+                        return
+                    }
+
+                    // Merge into the per-test instance map (test-scoped accumulator).
+                    const existing = (TestFramework.getState(testInstance, TestFrameworkConstants.KEY_CUSTOM_TAGS) as CustomMetadata) || {}
+                    mergeIntoTags(existing, key, values)
+                    testInstance.updateMultipleEntries({
+                        [TestFrameworkConstants.KEY_CUSTOM_TAGS]: existing
+                    })
+
+                    // Hook-level: if a hook is currently active, also stamp custom_metadata
+                    // onto the active hook so binary reads hook.custom_metadata.
+                    this.applyToActiveHook(testInstance, key, values)
+
+                    this.logger.debug(`setCustomTags: merged key=${key} values=${JSON.stringify(values)}`)
+                } catch (error) {
+                    this.logger.warn(`setCustomTags: error while recording custom tags: ${error}`)
+                }
+            }
+        } catch (error) {
+            this.logger.error(`Error in CustomTagsModule.onBeforeExecute: ${error}`)
+        }
+    }
+
+    /**
+     * If the test framework is currently inside a hook, merge custom_metadata onto
+     * the last-started hook record so the binary receives hook.custom_metadata.
+     * Best-effort: silently no-ops when no active hook is resolvable.
+     */
+    private applyToActiveHook(testInstance: TestFrameworkInstance, key: string, values: string[]) {
+        try {
+            const currentState = testInstance.getCurrentTestState().toString()
+            if (!CLIUtils.matchHookRegex(currentState)) {
+                return
+            }
+            const hook = WdioMochaTestFramework.lastActiveHook(testInstance, WdioMochaTestFramework.KEY_HOOK_LAST_STARTED)
+            if (!hook) {
+                return
+            }
+            const hookTags = (hook[TestFrameworkConstants.KEY_CUSTOM_TAGS] as CustomMetadata) || {}
+            mergeIntoTags(hookTags, key, values)
+            hook[TestFrameworkConstants.KEY_CUSTOM_TAGS] = hookTags
+        } catch (error) {
+            this.logger.debug(`setCustomTags: could not apply to active hook: ${error}`)
+        }
+    }
+}

--- a/packages/wdio-browserstack-service/src/custom-tags-handler.ts
+++ b/packages/wdio-browserstack-service/src/custom-tags-handler.ts
@@ -1,0 +1,91 @@
+/// <reference path="./@types/bstack-service-types.d.ts" />
+import InsightsHandler from './insights-handler.js'
+import { CustomTagAccumulator, parseCommaSeparatedValues } from './customTags.js'
+import type { CustomMetadata } from './customTags.js'
+import { o11yClassErrorHandler } from './util.js'
+import { BStackLogger } from './bstackLogger.js'
+
+/**
+ * Legacy/Listener-path handler for `browser.setCustomTags`.
+ *
+ * Registered from service.ts in the `!BrowserstackCLI.getInstance().isRunning()`
+ * branch (alongside AccessibilityHandler.before() / InsightsHandler.before()).
+ * Deliberately NOT folded into InsightsHandler.before() — that method registers
+ * no browser methods and is SKIPPED when the CLI is running.
+ *
+ * Accumulates (key, value) pairs per active test, keyed on
+ * InsightsHandler.currentTest.uuid (set in beforeTest / setTestData). The
+ * accumulator is static so InsightsHandler.getRunData can drain it into the
+ * TestData.custom_metadata field at TestRunFinished (flushed in afterTest).
+ */
+class _CustomTagsHandler {
+    // Static so the flush sink (InsightsHandler.getRunData) can read it without a
+    // handler reference. Keyed on the per-test uuid.
+    public static accumulator: CustomTagAccumulator = new CustomTagAccumulator()
+
+    constructor(
+        private _browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
+        private _caps: WebdriverIO.Capabilities | Record<string, unknown>,
+        private _framework?: string
+    ) {}
+
+    before() {
+        const register = (browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser) => {
+            (browser as WebdriverIO.Browser).setCustomTags = async (key: string, value: string): Promise<void> => {
+                try {
+                    if (this._framework !== 'mocha') {
+                        BStackLogger.warn('setCustomTags is only supported for the mocha framework; ignoring call')
+                        return
+                    }
+                    if (!key || !value) {
+                        BStackLogger.warn('setCustomTags: key and value are required; ignoring call')
+                        return
+                    }
+                    const testUuid = InsightsHandler.currentTest.uuid
+                    if (!testUuid) {
+                        BStackLogger.warn('setCustomTags called outside of a resolvable test context; ignoring')
+                        return
+                    }
+                    const added = _CustomTagsHandler.accumulator.add(testUuid, key, value)
+                    if (!added) {
+                        BStackLogger.warn(`setCustomTags: no usable values parsed from "${value}"; ignoring call`)
+                        return
+                    }
+                    BStackLogger.debug(`setCustomTags: recorded key=${key} values=${JSON.stringify(parseCommaSeparatedValues(value))} for test=${testUuid}`)
+                } catch (error) {
+                    BStackLogger.warn(`setCustomTags: error while recording custom tags: ${error}`)
+                }
+            }
+        }
+
+        // Fan out to every MultiRemote instance (mirror service._executeCommand),
+        // plus the top-level browser object the user calls directly.
+        register(this._browser)
+        if ((this._browser as WebdriverIO.Browser).isMultiremote) {
+            const multiRemoteBrowser = this._browser as unknown as WebdriverIO.MultiRemoteBrowser
+            Object.keys(this._caps).forEach((browserName) => {
+                try {
+                    const instance = multiRemoteBrowser.getInstance(browserName)
+                    if (instance) {
+                        register(instance)
+                    }
+                } catch (error) {
+                    BStackLogger.debug(`setCustomTags: could not register on multiremote instance ${browserName}: ${error}`)
+                }
+            })
+        }
+    }
+
+    /** Drain the accumulated custom_metadata for a test uuid; clears after read. */
+    static drain(testUuid: string | undefined): CustomMetadata | undefined {
+        const data = _CustomTagsHandler.accumulator.get(testUuid)
+        _CustomTagsHandler.accumulator.clear(testUuid)
+        return data
+    }
+}
+
+// https://github.com/microsoft/TypeScript/issues/6543
+const CustomTagsHandler: typeof _CustomTagsHandler = o11yClassErrorHandler(_CustomTagsHandler)
+type CustomTagsHandler = _CustomTagsHandler
+
+export default CustomTagsHandler

--- a/packages/wdio-browserstack-service/src/custom-tags-handler.ts
+++ b/packages/wdio-browserstack-service/src/custom-tags-handler.ts
@@ -1,6 +1,6 @@
 /// <reference path="./@types/bstack-service-types.d.ts" />
 import InsightsHandler from './insights-handler.js'
-import { CustomTagAccumulator, parseCommaSeparatedValues } from './customTags.js'
+import { CustomTagAccumulator } from './customTags.js'
 import type { CustomMetadata } from './customTags.js'
 import { o11yClassErrorHandler } from './util.js'
 import { BStackLogger } from './bstackLogger.js'
@@ -51,7 +51,7 @@ class _CustomTagsHandler {
                         BStackLogger.warn(`setCustomTags: no usable values parsed from "${value}"; ignoring call`)
                         return
                     }
-                    BStackLogger.debug(`setCustomTags: recorded key=${key} values=${JSON.stringify(parseCommaSeparatedValues(value))} for test=${testUuid}`)
+                    BStackLogger.debug(`setCustomTags: recorded key=${key} value="${value}" for test=${testUuid}`)
                 } catch (error) {
                     BStackLogger.warn(`setCustomTags: error while recording custom tags: ${error}`)
                 }

--- a/packages/wdio-browserstack-service/src/customTags.ts
+++ b/packages/wdio-browserstack-service/src/customTags.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared helpers for one-to-many custom-tag (Test-Case-ID) tagging.
+ *
+ * Both runtime paths (CLI/gRPC module + legacy listener handler) funnel through
+ * the same tokenizer + merge engine so they produce an identical `custom_metadata`
+ * payload shape:
+ *   { [key]: { field_type: 'multi_dropdown', values: [...] } }
+ *
+ * The binary is a strict pass-through for per-test/per-hook `custom_metadata` — it
+ * does NOT merge or dedupe across events — so the union+dedupe (set semantics)
+ * MUST be completed SDK-side before serialization. Value parsing mirrors the
+ * node-agent quote-aware tokenizer (helper.js `parseCommaSeparatedValues`).
+ */
+
+export interface CustomMetadataEntry {
+    field_type: 'multi_dropdown'
+    values: string[]
+}
+
+export type CustomMetadata = Record<string, CustomMetadataEntry>
+
+/**
+ * Quote-aware comma split. Mirrors node-agent `helper.js` tokenizer
+ * `/\s*"([^"]*)"\s*|[^,]+/g` — a quoted body is preserved verbatim (so an
+ * embedded comma is kept), otherwise the raw token is trimmed; empties dropped.
+ *   '"checkout,cart", header' -> ['checkout,cart', 'header']
+ *   'TC-1, TC-2'              -> ['TC-1', 'TC-2']
+ * Backward compatible: unquoted input tokenizes identically to a naive
+ * split(',').map(trim).filter(Boolean).
+ */
+export function parseCommaSeparatedValues(value: string | string[] | undefined | null): string[] {
+    if (!value) {
+        return []
+    }
+
+    if (Array.isArray(value)) {
+        return value
+    }
+
+    const str = value.toString()
+    if (str.trim() === '') {
+        return []
+    }
+
+    const tokenizer = /\s*"([^"]*)"\s*|[^,]+/g
+    const out: string[] = []
+    let match: RegExpExecArray | null
+    while ((match = tokenizer.exec(str)) !== null) {
+        // Group 1 = quoted body (preserved verbatim); otherwise trim the raw match.
+        const token = match[1] !== undefined ? match[1] : match[0].trim()
+        if (token !== '') {
+            out.push(token)
+        }
+    }
+    return out
+}
+
+/**
+ * Union + dedupe, existing-first ordering. Mirrors node-agent
+ * `CustomTagManager.mergeValues` — repeated calls accumulate, they do not override.
+ */
+export function mergeValues(existingValues: string[] | undefined | null, incomingValues: string[] | undefined | null): string[] {
+    return Array.from(new Set([...(existingValues || []), ...(incomingValues || [])]))
+}
+
+/**
+ * Create-or-merge a single tag key inside a `custom_metadata` container.
+ * Always produces `{ field_type: 'multi_dropdown', values: [...] }`; merges values
+ * via mergeValues. The container is mutated in place and returned for chaining.
+ * Mirrors node-agent `CustomTagManager.mergeIntoTags`.
+ */
+export function mergeIntoTags(tagsContainer: CustomMetadata, key: string, incomingValues: string[]): CustomMetadata {
+    if (!tagsContainer[key]) {
+        tagsContainer[key] = {
+            field_type: 'multi_dropdown',
+            values: [...(incomingValues || [])]
+        }
+    } else {
+        // Defensive: tolerate malformed pre-existing entries.
+        if (!tagsContainer[key].field_type) {
+            tagsContainer[key].field_type = 'multi_dropdown'
+        }
+        if (!Array.isArray(tagsContainer[key].values)) {
+            tagsContainer[key].values = []
+        }
+        tagsContainer[key].values = mergeValues(tagsContainer[key].values, incomingValues)
+    }
+
+    return tagsContainer
+}
+
+/**
+ * Per-test-uuid accumulator. Both paths key on `InsightsHandler.currentTest.uuid`
+ * so repeated `setCustomTags` calls within a single test union into one entry, and
+ * the flush sink reads the final consolidated map for that test.
+ */
+export class CustomTagAccumulator {
+    private store: Map<string, CustomMetadata> = new Map()
+
+    /**
+     * Add (key, value) for a test uuid. value is quote-aware comma-split; the
+     * resulting values union+dedupe into the test's custom_metadata for that key.
+     * Returns false (no-op) when uuid/key/value resolve to nothing.
+     */
+    add(testUuid: string | undefined, key: string, value: string): boolean {
+        if (!testUuid || !key) {
+            return false
+        }
+        const values = parseCommaSeparatedValues(value)
+        if (values.length === 0) {
+            return false
+        }
+        const container = this.store.get(testUuid) || {}
+        mergeIntoTags(container, key, values)
+        this.store.set(testUuid, container)
+        return true
+    }
+
+    /** Final consolidated custom_metadata for a test uuid, or undefined if none. */
+    get(testUuid: string | undefined): CustomMetadata | undefined {
+        if (!testUuid) {
+            return undefined
+        }
+        return this.store.get(testUuid)
+    }
+
+    /** Drop the accumulated entry once flushed (avoid unbounded growth). */
+    clear(testUuid: string | undefined): void {
+        if (testUuid) {
+            this.store.delete(testUuid)
+        }
+    }
+}

--- a/packages/wdio-browserstack-service/src/customTags.ts
+++ b/packages/wdio-browserstack-service/src/customTags.ts
@@ -1,5 +1,5 @@
 /**
- * Shared helpers for one-to-many custom-tag (Test-Case-ID) tagging.
+ * Helpers for one-to-many custom-tag (Test-Case-ID) tagging.
  *
  * Both runtime paths (CLI/gRPC module + legacy listener handler) funnel through
  * the same tokenizer + merge engine so they produce an identical `custom_metadata`

--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -44,6 +44,7 @@ import { TestFrameworkState } from './cli/states/testFrameworkState.js'
 import { HookState } from './cli/states/hookState.js'
 import PerformanceTester from './instrumentation/performance/performance-tester.js'
 import * as PERFORMANCE_SDK_EVENTS from './instrumentation/performance/constants.js'
+import CustomTagsHandler from './custom-tags-handler.js'
 
 class _InsightsHandler {
     private _tests: Record<string, TestMeta> = {}
@@ -732,6 +733,15 @@ class _InsightsHandler {
             testData.duration_in_ms = results.duration
             if (this._hooks[fullTitle]) {
                 testData.hooks = this._hooks[fullTitle]
+            }
+
+            // Drain any custom tags (multi Test-Case-ID) recorded for this test via
+            // browser.setCustomTags on the legacy/listener path. Keyed on the test
+            // uuid (the same uuid set in beforeTest / setTestData). The accumulator
+            // already completed union+dedupe SDK-side; the binary is pass-through.
+            const customMetadata = CustomTagsHandler.drain(testMetaData.uuid)
+            if (customMetadata && Object.keys(customMetadata).length > 0) {
+                testData.custom_metadata = customMetadata
             }
         }
 

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -17,6 +17,7 @@ import { DEFAULT_OPTIONS, NOT_ALLOWED_KEYS_IN_CAPS, PERF_MEASUREMENT_ENV } from 
 import { configureCaCertificate } from './caCert.js'
 import CrashReporter from './crash-reporter.js'
 import AccessibilityHandler from './accessibility-handler.js'
+import CustomTagsHandler from './custom-tags-handler.js'
 import { BStackLogger } from './bstackLogger.js'
 import PercyHandler from './Percy/Percy-Handler.js'
 import Listener from './testOps/listener.js'
@@ -63,6 +64,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
     private _insightsHandler?: InsightsHandler
     private _accessibility
     private _accessibilityHandler?: AccessibilityHandler
+    private _customTagsHandler?: CustomTagsHandler
     private _percy
     private _percyCaptureMode: string | undefined = undefined
     private _percyHandler?: PercyHandler
@@ -270,6 +272,25 @@ export default class BrowserstackService implements Services.ServiceInstance {
                         return
                     }
                     await this._insightsHandler.before()
+                }
+
+                /**
+                 * register custom-tag (multi Test-Case-ID) browser method on the
+                 * legacy/listener path. The CLI/gRPC path registers it via
+                 * CustomTagsModule.onBeforeExecute instead (both handlers' before()
+                 * are skipped when the binary is up).
+                 */
+                if (!BrowserstackCLI.getInstance().isRunning()) {
+                    try {
+                        this._customTagsHandler = new CustomTagsHandler(
+                            this._browser,
+                            this._caps,
+                            this._config.framework
+                        )
+                        this._customTagsHandler.before()
+                    } catch (err) {
+                        BStackLogger.error(`[Custom Tags] Error registering setCustomTags: ${err}`)
+                    }
                 }
 
                 /**

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -1,5 +1,6 @@
 import type { Capabilities, Options, Frameworks } from '@wdio/types'
 import type { Options as BSOptions } from 'browserstack-local'
+import type { CustomMetadata } from './customTags.js'
 
 export type MultiRemoteAction = (sessionId: string, browserName?: string) => Promise<unknown>
 
@@ -285,7 +286,7 @@ export interface TestData {
     tags?: string[],
     test_run_id?: string,
     product_map?: {},
-    custom_metadata?: { [key: string]: { field_type: string, values: string[] } }
+    custom_metadata?: CustomMetadata
 }
 
 export interface UserConfig {

--- a/packages/wdio-browserstack-service/src/types.ts
+++ b/packages/wdio-browserstack-service/src/types.ts
@@ -284,7 +284,8 @@ export interface TestData {
     meta?: TestMeta,
     tags?: string[],
     test_run_id?: string,
-    product_map?: {}
+    product_map?: {},
+    custom_metadata?: { [key: string]: { field_type: string, values: string[] } }
 }
 
 export interface UserConfig {


### PR DESCRIPTION
…omTags) for WebdriverIO + Mocha

Add `browser.setCustomTags(key, value)` so a single test can be tagged with multiple manual Test-Case IDs. Ports the contract from the Node SDK's Playwright support (SDK-5926): quote-aware comma split, union+dedupe on repeat calls (not override), and the `{ field_type: 'multi_dropdown', values: [...] }` payload under `custom_metadata`.

- customTags.ts: shared tokenizer + mergeValues/mergeIntoTags + per-test accumulator
- cli/modules/customTagsModule.ts: CLI/gRPC path (onBeforeExecute) -> per-test instance map -> event_json
- custom-tags-handler.ts: legacy/listener path; drains into TestData.custom_metadata at TestRunFinished
- types/@types: setCustomTags on Browser & MultiRemoteBrowser; custom_metadata on TestData; KEY_CUSTOM_TAGS

Dual-path registration since the service runs in both modes. No binary change required. Verified live on WDIO 9.x + Mocha: AC1/AC2/AC4 pass; values render in TM Custom fields.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
