### PR TITLE
fix(@wdio/utils): don't use Firefox browserVersion as Geckodriver version (#15337)

### DIFF
--- a/packages/wdio-types/src/index.ts
+++ b/packages/wdio-types/src/index.ts
@@ -85,7 +85,16 @@ declare global {
         interface WDIOVSCodeServiceOptions {}
         interface BrowserRunnerOptions {}
         interface ChromedriverOptions extends DriverOptions {}
-        interface GeckodriverOptions extends DriverOptions {}
+        interface GeckodriverOptions extends DriverOptions {
+            /**
+             * Version of Geckodriver to download. Firefox browser versions use a
+             * different versioning scheme than Geckodriver, so the `browserVersion`
+             * capability cannot be used to select the driver. Defaults to the
+             * latest available Geckodriver version.
+             * @see https://github.com/mozilla/geckodriver/releases
+             */
+            geckoDriverVersion?: string
+        }
         interface EdgedriverOptions extends DriverOptions {}
         interface SafaridriverOptions {}
     }

--- a/packages/wdio-utils/src/node/manager.ts
+++ b/packages/wdio-utils/src/node/manager.ts
@@ -17,8 +17,6 @@ enum BrowserDriverTaskLabel {
     DRIVER = 'browser driver'
 }
 
-const firefoxChannels: string[] = ['stable', 'latest'] as const
-
 function mapCapabilities (
     options: Options.WebdriverIO,
     caps: Capabilities.TestrunnerCapabilities,
@@ -113,15 +111,8 @@ export async function setupDriver (options: Omit<Options.WebDriver, 'capabilitie
         if (isEdge(cap.browserName)) {
             return setupEdgedriver(cacheDir, cap.browserVersion)
         } else if (isFirefox(cap.browserName)) {
-            /**
-             * Some Firefox channels are allowed to be set for the browserVersion.
-             * We unset these variables here to make `node-geckodriver` download
-             * the latest driver version.
-             */
-            const version = firefoxChannels.includes(cap.browserVersion ?? '')
-                ? undefined
-                : cap.browserVersion
-            return setupGeckodriver(cacheDir, version)
+            const driverVersion = cap['wdio:geckodriverOptions']?.geckoDriverVersion
+            return setupGeckodriver(cacheDir, driverVersion)
         } else if (isChrome(cap.browserName)) {
             return setupChromedriver(cacheDir, cap.browserVersion)
         }

--- a/packages/wdio-utils/tests/node/manager.test.ts
+++ b/packages/wdio-utils/tests/node/manager.test.ts
@@ -76,7 +76,10 @@ describe('setupDriver', () => {
             browserVersion: '5'
         }, {
             browserName: 'firefox',
-            browserVersion: '6'
+            browserVersion: '6',
+            'wdio:geckodriverOptions': {
+                geckoDriverVersion: '0.36.0'
+            }
         }])
         expect(setupChromedriver).toBeCalledTimes(2)
         expect(setupChromedriver).toBeCalledWith('/foo/bar', '1')
@@ -85,9 +88,11 @@ describe('setupDriver', () => {
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', undefined)
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', '3')
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', '4')
+        // the Firefox browser version must never be used as the Geckodriver version;
+        // the driver version is only set when `geckoDriverVersion` is provided explicitly
         expect(setupGeckodriver).toBeCalledTimes(2)
-        expect(setupGeckodriver).toBeCalledWith('/foo/bar', '5')
-        expect(setupGeckodriver).toBeCalledWith('/foo/bar', '6')
+        expect(setupGeckodriver).toBeCalledWith('/foo/bar', undefined)
+        expect(setupGeckodriver).toBeCalledWith('/foo/bar', '0.36.0')
     })
 
     test('with multiremote capabilities', async () => {
@@ -170,7 +175,10 @@ describe('setupDriver', () => {
             browserF: {
                 capabilities: {
                     browserName: 'firefox',
-                    browserVersion: '7'
+                    browserVersion: '7',
+                    'wdio:geckodriverOptions': {
+                        geckoDriverVersion: '0.36.0'
+                    }
                 }
             }
         })
@@ -181,8 +189,8 @@ describe('setupDriver', () => {
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', '3')
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', '4')
         expect(setupGeckodriver).toBeCalledTimes(2)
-        expect(setupGeckodriver).toBeCalledWith('/foo/bar', '5')
-        expect(setupGeckodriver).toBeCalledWith('/foo/bar', '7')
+        expect(setupGeckodriver).toBeCalledWith('/foo/bar', undefined)
+        expect(setupGeckodriver).toBeCalledWith('/foo/bar', '0.36.0')
     })
 
     test('with multiremote capabilities series', async () => {
@@ -252,7 +260,10 @@ describe('setupDriver', () => {
             browserF: {
                 capabilities: {
                     browserName: 'firefox',
-                    browserVersion: '6'
+                    browserVersion: '6',
+                    'wdio:geckodriverOptions': {
+                        geckoDriverVersion: '0.36.0'
+                    }
                 }
             },
             browserFWithDriverBinary: {
@@ -272,8 +283,8 @@ describe('setupDriver', () => {
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', '3')
         expect(setupEdgedriver).toBeCalledWith('/foo/bar', '4')
         expect(setupGeckodriver).toBeCalledTimes(2)
-        expect(setupGeckodriver).toBeCalledWith('/foo/bar', '5')
-        expect(setupGeckodriver).toBeCalledWith('/foo/bar', '6')
+        expect(setupGeckodriver).toBeCalledWith('/foo/bar', undefined)
+        expect(setupGeckodriver).toBeCalledWith('/foo/bar', '0.36.0')
     })
 })
 

--- a/website/docs/DriverBinaries.md
+++ b/website/docs/DriverBinaries.md
@@ -61,6 +61,26 @@ WebdriverIO won't automatically download Safari driver as it is already installe
 
 :::
 
+:::info Firefox / Geckodriver
+
+Firefox uses a different versioning scheme for the browser (e.g. `stable_151.0.1`) than [Geckodriver](https://github.com/mozilla/geckodriver/releases) (e.g. `0.36.0`), so `browserVersion` is **not** used to pick the driver version. By default WebdriverIO downloads the latest Geckodriver. To pin a specific driver version, set `geckoDriverVersion` in `wdio:geckodriverOptions`:
+
+```ts
+{
+    capabilities: [
+        {
+            browserName: 'firefox',
+            browserVersion: 'stable_151.0.1',
+            'wdio:geckodriverOptions': {
+                geckoDriverVersion: '0.36.0'
+            }
+        }
+    ]
+}
+```
+
+:::
+
 :::caution
 
 Avoid specifying a `binary` for the browser and omitting the corresponding driver `binary` or vice-versa. If only one of the `binary` values is specified, WebdriverIO will try to use or download a browser/driver compatible with it. However, in some scenarios it may result in an incompatible combination. Therefore, it's recommended that you always specify both to avoid any problems caused by version incompatibilities.


### PR DESCRIPTION
## Proposed changes
Fixes #15337 — Firefox `browserVersion` was incorrectly passed as the Geckodriver driver version, causing 404 downloads on clean caches because Firefox versions (`stable_151.0.1`, `131.0`) use a different versioning scheme than Geckodriver (`0.36.0`).

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
