### PR TITLE
feat(create-wdio): add tracelane service to the config wizard

### DIFF
--- a/packages/create-wdio/src/constants.ts
+++ b/packages/create-wdio/src/constants.ts
@@ -197,7 +197,8 @@ export const SUPPORTED_PACKAGES = {
         { name: 'robonut', value: 'wdio-robonut-service$--$robonut' },
         { name: 'qunit', value: 'wdio-qunit-service$--$qunit' },
         { name: 'roku', value: 'wdio-roku-service$--$roku' },
-        { name: 'obsidian', value: 'wdio-obsidian-service$--$obsidian' }
+        { name: 'obsidian', value: 'wdio-obsidian-service$--$obsidian' },
+        { name: 'tracelane', value: '@tracelane/wdio$--$@tracelane/wdio' }
     ]
 }
 

--- a/scripts/docs-generation/3rd-party/services.json
+++ b/scripts/docs-generation/3rd-party/services.json
@@ -245,5 +245,12 @@
     "title": "Camera Service",
     "githubUrl": "https://github.com/webdriverio-community/wdio-camera-service",
     "npmUrl": "https://www.npmjs.com/package/wdio-camera-service"
+  },
+  {
+    "packageName": "@tracelane/wdio",
+    "title": "tracelane",
+    "githubUrl": "https://github.com/Cubenest/rrweb-stack",
+    "npmUrl": "https://www.npmjs.com/package/@tracelane/wdio",
+    "location": "packages/tracelane-wdio/README.md"
   }
 ]


### PR DESCRIPTION
## Proposed changes

Adds **@tracelane/wdio** to the config wizard's service choices and the 3rd-party services docs. [tracelane](https://github.com/Cubenest/rrweb-stack) is an open-source (Apache-2.0) WebdriverIO service that records an rrweb session plus console and failed-network responses while your tests run, and writes a single self-contained HTML report on failure (replay + console + network, fully offline, no server). It's [published on npm](https://www.npmjs.com/package/@tracelane/wdio) and used via the standard service hooks.

The wizard entry uses the literal scoped package name on **both** sides of the `$--$` delimiter:

```
{ name: 'tracelane', value: '@tracelane/wdio$--$@tracelane/wdio' }
```

This is deliberate. The package is scoped and not named `wdio-*`, so the wizard needs to write the full name into `wdio.conf` (`services: ['@tracelane/wdio']`) for `@wdio/utils` `initializePlugin` to import it via the `name[0] === '@'` (import-as-is) branch. A bare short (e.g. `…$--$tracelane`) would be rewritten to `@wdio/tracelane-service` / `wdio-tracelane-service` and fail to resolve this package. (The default export is the service class, so `services: ['@tracelane/wdio']` works as-is.)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (improvements to the project's docs)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests — N/A: this only appends entries to `SUPPORTED_PACKAGES.service` and the 3rd-party `services.json`. I worked from a sparse checkout and couldn't run the full local suite; glad to update a snapshot if CI flags one.
- [x] I have added the necessary documentation (the `services.json` entry, with `location` pointing at the package README)
- [ ] I have added proper type definitions for new commands (N/A)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported

## Further comments

Source: https://github.com/Cubenest/rrweb-stack (`packages/tracelane-wdio`). Happy to adjust the entry name/placement or the value form to your preference.