### PR TITLE
test(e2e): retry headless specs to absorb external-site flakiness

### DIFF
--- a/e2e/wdio/wdio.classic.conf.ts
+++ b/e2e/wdio/wdio.classic.conf.ts
@@ -33,6 +33,12 @@ export const config: WebdriverIO.Config = {
 
     reporters: ['spec'],
 
+    /**
+     * Retry the whole spec file so a transient third-party-site blip (the headless
+     * specs load external pages) doesn't redden the run. Matches wdio.local.conf.ts.
+     */
+    specFileRetries: 3,
+
     mochaOpts: {
         ui: 'bdd',
         timeout: 60000

--- a/e2e/wdio/wdio.conf.ts
+++ b/e2e/wdio/wdio.conf.ts
@@ -42,6 +42,15 @@ export const config: WebdriverIO.Config = {
 
     reporters: ['spec'],
 
+    /**
+     * Several headless specs load third-party sites (e.g. the-internet.herokuapp.com,
+     * guinea-pig.webdriver.io); a transient cold-start/network blip there fails the
+     * spec through no fault of WebdriverIO. Retry the whole spec file so a flaky
+     * external dependency doesn't redden the run. Matches wdio.local.conf.ts.
+     * (wdio-multiremote.conf.ts inherits this via `...baseConfig`.)
+     */
+    specFileRetries: 3,
+
     mochaOpts: {
         ui: 'bdd',
         timeout: 60000


### PR DESCRIPTION
## Proposed changes

Several headless e2e specs load **third-party sites**:

- `e2e/wdio/headless/test.e2e.ts` → `the-internet.herokuapp.com/shadowdom` and `/basic_auth`, plus `guinea-pig.webdriver.io` for the `switchFrame` / window-close cases.

When one of those hosts cold-starts or has a transient network blip, the spec fails through no fault of WebdriverIO — e.g. `element ("h1") still not displayed after 5000ms` / `Congratulations ... not displayed`. This most recently reddened the **Testrunner E2E** job on **macOS and Windows simultaneously** (same tests, same time — a shared external hiccup), while chromedriver setup and 4/5 spec files passed.

This adds `specFileRetries: 3` to the headless CI e2e configs that lacked it, so a flaky external dependency is retried rather than failing the whole run. The value matches what `wdio.local.conf.ts` already uses.

- `e2e/wdio/wdio.conf.ts` — testrunner classic e2e (the one that flaked).
- `e2e/wdio/wdio.classic.conf.ts` — WebDriver-classic headless e2e.
- `e2e/wdio/wdio-multiremote.conf.ts` inherits the setting via `...baseConfig`, so it is **not** edited.

`wdio.sauce.conf.ts` (cloud) is intentionally left out of scope.

### Why retries (and not removing the external sites)

`specFileRetries` is WebdriverIO's native mechanism for exactly this and is already the precedent in this repo (`wdio.local.conf.ts: specFileRetries: 3`). A larger follow-up could self-host the `the-internet`/frame fixtures to remove the external dependency entirely, but that's a separate change.

## Types of changes

- [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
