### PR TITLE
fix: node26 forbidden request headers

### DIFF
--- a/packages/webdriver/src/request/request.ts
+++ b/packages/webdriver/src/request/request.ts
@@ -19,7 +19,6 @@ const ERRORS_TO_EXCLUDE_FROM_RETRY = [
 
 const DEFAULT_HEADERS = {
     'Content-Type': 'application/json; charset=utf-8',
-    'Connection': 'keep-alive',
     'Accept': 'application/json',
     'User-Agent': 'webdriver/' + pkg.version
 }
@@ -82,8 +81,6 @@ export abstract class WebDriverRequest {
          */
         if (this.body && (Object.keys(this.body).length || this.method === 'POST')) {
             requestOptions.body = JSON.stringify(this.body)
-            const contentLength = new TextEncoder().encode(requestOptions.body).length
-            requestHeaders.set('Content-Length', `${contentLength}`)
         }
 
         /**

--- a/packages/webdriver/tests/request.test.ts
+++ b/packages/webdriver/tests/request.test.ts
@@ -142,7 +142,7 @@ describe('webdriver request', () => {
             expect((url! as URL).href)
                 .toBe('https://localhost:4445/session/foobar12345/element')
             expect([...(requestOptions.headers as unknown as Map<string, string>).keys()])
-                .toEqual(['accept', 'connection', 'content-length', 'content-type', 'foo', 'user-agent'])
+                .toEqual(['accept', 'content-type', 'foo', 'user-agent'])
             expect(requestOptions.signal?.aborted).toBeFalsy()
         })
 
@@ -211,8 +211,7 @@ describe('webdriver request', () => {
                 logLevel: 'warn'
             })
             expect([...(requestOptions.headers as unknown as Map<string, string>).keys()])
-                .toEqual(['accept', 'connection', 'content-length', 'content-type', 'user-agent'])
-            expect((requestOptions.headers as unknown as Map<string, string>).get('Content-Length')).toBe('13')
+                .toEqual(['accept', 'content-type', 'user-agent'])
         })
 
         it('should add Content-Length as well any other header provided in the request options if there is body in the request object', async () => {
@@ -223,7 +222,6 @@ describe('webdriver request', () => {
                 logLevel: 'warn'
             })
             expect((requestOptions.headers as unknown as Map<string, string>).get('foo')).toContain('bar')
-            expect((requestOptions.headers as unknown as Map<string, string>).get('Content-Length')).toBe('13')
         })
 
         it('should add only the headers provided if the request body is empty', async () => {
@@ -234,7 +232,6 @@ describe('webdriver request', () => {
                 headers: { foo: 'bar' },
                 logLevel: 'warn'
             })
-            expect([...(requestOptions.headers as unknown as Map<string, string>).keys()]).not.toContain('content-length')
             expect((requestOptions.headers as unknown as Map<string, string>).get('foo')).toContain('bar')
         })
     })


### PR DESCRIPTION
## Proposed changes

Clone of https://github.com/webdriverio/webdriverio/pull/15266 to fix unit tests.
Fixes https://github.com/webdriverio/webdriverio/issues/15265

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
