### PR TITLE
docs: add docusaurus-plugin-copy-page-button

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2225,6 +2225,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      docusaurus-plugin-copy-page-button:
+        specifier: ^0.8.3
+        version: 0.8.3(@docusaurus/core@3.9.2(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(@swc/core@1.15.8)(acorn@8.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)
       docusaurus-theme-github-codeblock:
         specifier: ^2.0.2
         version: 2.0.2(@swc/core@1.15.8)(acorn@8.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9011,6 +9014,13 @@ packages:
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
+
+  docusaurus-plugin-copy-page-button@0.8.3:
+    resolution: {integrity: sha512-2/k4H/ePsuZUVv5S91XC2zhnIWLufHzEPTdo/6jYcvonQqHKcLK9vfOp24L5qwMO16VGhHRIEYcEVrXOshxaBw==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/core': ^3.0.0
+      react: ^18.0.0 || ^19.0.0
 
   docusaurus-theme-github-codeblock@2.0.2:
     resolution: {integrity: sha512-H2WoQPWOLjGZO6KS58Gsd+eUVjTFJemkReiSSu9chqokyLc/3Ih3+zPRYfuEZ/HsDvSMIarf7CNcp+Vt+/G+ig==}
@@ -25537,6 +25547,11 @@ snapshots:
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
+
+  docusaurus-plugin-copy-page-button@0.8.3(@docusaurus/core@3.9.2(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(@swc/core@1.15.8)(acorn@8.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1):
+    dependencies:
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.0(@types/react@19.2.17)(react@18.3.1))(@swc/core@1.15.8)(acorn@8.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      react: 18.3.1
 
   docusaurus-theme-github-codeblock@2.0.2(@swc/core@1.15.8)(acorn@8.17.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -267,6 +267,7 @@ const config: Config = {
         ]
     ],
     plugins: [
+        'docusaurus-plugin-copy-page-button',
         [
             'client-redirects',
             {

--- a/website/package.json
+++ b/website/package.json
@@ -27,6 +27,7 @@
     "@mendable/search": "^0.0.206",
     "@tsconfig/docusaurus": "^2.0.3",
     "clsx": "^2.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.8.3",
     "docusaurus-theme-github-codeblock": "^2.0.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
Hi! This PR adds [docusaurus-plugin-copy-page-button](https://www.npmjs.com/package/docusaurus-plugin-copy-page-button) to the docs site.

It adds a "Copy page" button to each docs page that lets readers copy the page as clean markdown or open it directly in ChatGPT / Claude / Perplexity / Gemini — handy for anyone pulling docs into an LLM.

**Changes**
- Added the plugin to the `plugins` array in `website/docusaurus.config.ts`
- Added `docusaurus-plugin-copy-page-button` to `dependencies`

The plugin is zero-config and auto-injects the button into the table-of-contents sidebar (falls back to the top of the article on mobile / no-TOC pages). I kept the diff minimal — the `pnpm-lock.yaml` change is just this one package's entries and passes `pnpm install --frozen-lockfile`. Docusaurus loads and validates the full plugin config cleanly with this added (I confirmed the site's existing docs-generation build step behaves identically with and without the change).

Happy to adjust placement, styling, or which AI actions show — there are config options for all of it. Demo/showcase: https://portdeveloper.github.io/copy-page-button-showcase/

Thanks for taking a look!
