### PR TITLE
fix(browserstack-service): report mocha hooks in the CLI/testhub flow [SDK-6809]

### DIFF
--- a/packages/wdio-browserstack-service/src/cli/frameworks/wdioMochaTestFramework.ts
+++ b/packages/wdio-browserstack-service/src/cli/frameworks/wdioMochaTestFramework.ts
@@ -80,7 +80,14 @@ export default class WdioMochaTestFramework extends TestFramework {
                 this.loadTestResult(instance, args)
             }
 
-            await this.trackHookEvents(instance, testFrameworkState, hookState, args)
+            // Only real hook states accumulate into test_hooks_started/finished. trackEvent runs
+            // for every state (TEST/INIT_TEST/LOG/...); without this gate those push pseudo-hook
+            // entries which — now that the Map serializer actually emits them — get flat-mapped into
+            // TestRunFinished.hooks (duplicating the last hook id / adding '') and accumulate in
+            // test_hooks_started forever (never popped).
+            if (CLIUtils.matchHookRegex(testFrameworkState.toString().split('.')[1])) {
+                await this.trackHookEvents(instance, testFrameworkState, hookState, args)
+            }
             logger.debug(`trackEvent: tracked instance data=${JSON.stringify(Object.fromEntries(instance.getAllData()))}`)
         } catch (error) {
             logger.error(`trackEvent: Error in tracking events: ${error} hookState=${hookState} testFrameworkState=${testFrameworkState}`)
@@ -123,10 +130,14 @@ export default class WdioMochaTestFramework extends TestFramework {
                 this.trackWdioMochaInstance(testFrameworkState, args)
             }
         } else if (isHook && hookState === HookState.PRE) {
-            // Suite-level (`before all`/`after all`) and the first `before each` fire before any
-            // INIT_TEST, so no instance exists yet — and a before-hook right after a completed test
-            // starts a new test. Create an instance so the hook is captured instead of dropped.
-            if (!instance || isNewTestBoundary) {
+            // Suite-level (`before all`) and the first `before each` fire before any INIT_TEST, so
+            // no instance exists yet — create one. Also, a BEFORE hook right after a completed test
+            // (new-test boundary) starts a new test. The boundary restriction must be limited to
+            // BEFORE hooks: `after each`/`after all` also fire at a POST->PRE boundary (afterTest
+            // emits TEST POST just before `after each`), but they belong to the just-finished test.
+            // Creating a fresh (uuid-less) instance for them would drop test_run_id and orphan the
+            // hook from TestRunFinished.hooks — so let after-hooks reuse the finished test's instance.
+            if (!instance || (isNewTestBoundary && shortState.startsWith('BEFORE_'))) {
                 this.trackWdioMochaInstance(testFrameworkState, args)
             }
         }
@@ -241,7 +252,7 @@ export default class WdioMochaTestFramework extends TestFramework {
         const logRecord: Record<string, unknown> = {}
         const { level, message, timestamp } = logEntry
 
-        if (CLIUtils.matchHookRegex(instance.getCurrentTestState().toString())) {
+        if (CLIUtils.matchHookRegex(instance.getCurrentTestState().toString().split('.')[1])) {
             logRecord[TestFrameworkConstants.KEY_HOOK_ID] = TestFramework.getState(instance, TestFrameworkConstants.KEY_HOOK_ID)
         }
         logRecord.kind = TestFrameworkConstants.KIND_LOG

--- a/packages/wdio-browserstack-service/src/cli/frameworks/wdioMochaTestFramework.ts
+++ b/packages/wdio-browserstack-service/src/cli/frameworks/wdioMochaTestFramework.ts
@@ -44,7 +44,11 @@ export default class WdioMochaTestFramework extends TestFramework {
         }
 
         try {
-            if (CLIUtils.matchHookRegex(testFrameworkState.toString()) && hookState === HookState.PRE) {
+            // matchHookRegex expects the short state name (e.g. AFTER_EACH); `toString()` yields
+            // the fully-qualified `TestFrameworkState.AFTER_EACH`, which never matches `^(BEFORE_|AFTER_)`.
+            // Without this, KEY_HOOK_ID is never set, hook_run.uuid ends up empty, and the backend
+            // (BigQuery) drops the hook events despite them being sent.
+            if (CLIUtils.matchHookRegex(testFrameworkState.toString().split('.')[1]) && hookState === HookState.PRE) {
                 instance.updateMultipleEntries({
                     [TestFrameworkConstants.KEY_HOOK_ID]: uuidv4(),
                 })
@@ -93,13 +97,45 @@ export default class WdioMochaTestFramework extends TestFramework {
    * @returns {TestFrameworkInstance}
    */
     resolveInstance(testFrameworkState: State, hookState: State, args: Record<string, unknown> = {}): TestFrameworkInstance|null {
-        let instance = null
         logger.info(`resolveInstance: resolving instance for testFrameworkState=${testFrameworkState} hookState=${hookState}`)
-        if (testFrameworkState === TestFrameworkState.INIT_TEST || testFrameworkState === TestFrameworkState.NONE) {
+        const shortState = testFrameworkState.toString().split('.')[1]
+        const isHook = CLIUtils.matchHookRegex(shortState)
+        let instance = TestFramework.getTrackedInstance()
+
+        // Whether the current tracked instance has already run its test body.
+        const hasRunTest = !!(instance && TestFramework.getState(instance, TestFrameworkConstants.KEY_TEST_ID))
+
+        // New-test boundary (ports Junit5Framework.resolveInstance): the previous method was a
+        // test / after-hook (POST) and the current is a before-hook / init (PRE) — the next test
+        // is starting. At entry, getCurrentTestState()/getCurrentHookState() still hold the PREVIOUS
+        // method's state (updateInstanceState has not run yet).
+        const prevState = instance ? instance.getCurrentTestState().toString() : ''
+        const prevWasTerminal = instance ? (instance.getCurrentTestState() === TestFrameworkState.TEST || prevState.includes('AFTER')) : false
+        const isNewTestBoundary = instance ? (prevWasTerminal && instance.getCurrentHookState() === HookState.POST && hookState === HookState.PRE) : false
+
+        if (testFrameworkState === TestFrameworkState.NONE) {
             this.trackWdioMochaInstance(testFrameworkState, args)
+        } else if (testFrameworkState === TestFrameworkState.INIT_TEST) {
+            // WDIO fires `before each` BEFORE `beforeTest` (INIT_TEST). Reuse the instance a
+            // preceding before-hook already opened for this same upcoming test; only start a new
+            // one if the current instance has already run a test (or none exists).
+            if (!instance || hasRunTest) {
+                this.trackWdioMochaInstance(testFrameworkState, args)
+            }
+        } else if (isHook && hookState === HookState.PRE) {
+            // Suite-level (`before all`/`after all`) and the first `before each` fire before any
+            // INIT_TEST, so no instance exists yet — and a before-hook right after a completed test
+            // starts a new test. Create an instance so the hook is captured instead of dropped.
+            if (!instance || isNewTestBoundary) {
+                this.trackWdioMochaInstance(testFrameworkState, args)
+            }
         }
 
         instance = TestFramework.getTrackedInstance()
+        if (!instance) {
+            logger.error(`resolveInstance: unable to resolve/create instance for testFrameworkState=${testFrameworkState} hookState=${hookState}`)
+            return null
+        }
         this.updateInstanceState(instance, testFrameworkState, hookState)
 
         return instance
@@ -321,7 +357,10 @@ export default class WdioMochaTestFramework extends TestFramework {
     ) {
         const testResult = args.result as Frameworks.TestResult
         const test = args.test as Frameworks.Test
-        const key = testFrameworkState.toString()
+        // Key hooks by the short state name (e.g. AFTER_EACH), matching how the binary looks them
+        // up via `event.test_hooks_started[request.testFrameworkState]`. `toString()` yields the
+        // fully-qualified `TestFrameworkState.AFTER_EACH`, which would never match.
+        const key = testFrameworkState.toString().split('.')[1]
 
         const hooksStarted = TestFramework.getState(instance, TestFrameworkConstants.KEY_HOOKS_STARTED) as Map<string, unknown[]>
         if (!hooksStarted.has(key)) {

--- a/packages/wdio-browserstack-service/src/cli/index.ts
+++ b/packages/wdio-browserstack-service/src/cli/index.ts
@@ -44,6 +44,7 @@ export class BrowserstackCLI {
     process: ChildProcess | null = null
     isMainConnected = false
     isChildConnected = false
+    modulesLoaded = false
     binSessionId: string | null = null
     modules: Record<string, BaseModule> = {}
     testFramework: WdioMochaTestFramework|null = null
@@ -129,6 +130,17 @@ export class BrowserstackCLI {
         // Defer imports to avoid circular dependencies
         this.binSessionId = startBinResponse.binSessionId
         this.logger.info(`loadModules: binSessionId=${this.binSessionId}`)
+
+        // Idempotency guard: startMain() and startChild() can both run in the same process
+        // (e.g. local runner, single instance). Each call constructs the modules again, whose
+        // constructors register observers on the shared eventDispatcher singleton — and
+        // registerObserver does not dedupe. Loading twice therefore double-registers every
+        // observer, so each test/hook event is dispatched (and uploaded) twice. Load once.
+        if (this.modulesLoaded) {
+            this.logger.info('loadModules: modules already loaded in this process; skipping to avoid duplicate observer registration')
+            return
+        }
+        this.modulesLoaded = true
 
         this.setConfig(startBinResponse)
 

--- a/packages/wdio-browserstack-service/src/cli/modules/testHubModule.ts
+++ b/packages/wdio-browserstack-service/src/cli/modules/testHubModule.ts
@@ -114,7 +114,10 @@ export default class TestHubModule extends BaseModule {
             this.logger.debug(`sendTestFrameworkEvent for testState: ${testFrameworkState} hookState: ${testHookState}`)
             const platformIndex = process.env.WDIO_WORKER_ID ? parseInt(process.env.WDIO_WORKER_ID.split('-')[0]) : 0
             const uuid = TestFramework.getState(instance, TestFrameworkConstants.KEY_TEST_UUID) || instance.getRef()
-            const eventJson = Buffer.from(JSON.stringify(Object.fromEntries(testData)))
+            // Nested values such as test_hooks_started/test_hooks_finished are JS Maps, which
+            // JSON.stringify would serialise to `{}` and strip the hook data. Convert any Map to
+            // a plain object so the binary receives populated hook maps.
+            const eventJson = Buffer.from(JSON.stringify(Object.fromEntries(testData), (_key, value) => value instanceof Map ? Object.fromEntries(value) : value))
             const executionContext = { hash: trackedContext.getId(), threadId: trackedContext.getThreadId().toString(), processId: trackedContext.getProcessId().toString() }
             const payload: Omit<TestFrameworkEventRequest, 'binSessionId'> = {
                 platformIndex,

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -399,9 +399,16 @@ export default class BrowserstackService implements Services.ServiceInstance {
         // Listener -> api/v1/batch path, which is no longer functional in the CLI pipeline, so
         // HookRunStarted/HookRunFinished never reach the dashboard.
         if (BrowserstackCLI.getInstance().isRunning()) {
-            const hookFrameworkState = TestFrameworkState[getHookType((test as Frameworks.Test).title) as keyof typeof TestFrameworkState]
-            if (hookFrameworkState) {
-                await BrowserstackCLI.getInstance().getTestFramework()!.trackEvent(hookFrameworkState, HookState.PRE, { test })
+            // Null-check the tracker rather than asserting: getTestFramework() is null for
+            // non-mocha frameworks (setupTestFramework only wires it for webdriverio-mocha) and
+            // during any startup race, so a `!` here could throw a TypeError inside this awaited
+            // WDIO hook and break the user's suite. Instrumentation must degrade quietly.
+            const framework = BrowserstackCLI.getInstance().getTestFramework()
+            if (framework) {
+                const hookFrameworkState = TestFrameworkState[getHookType((test as Frameworks.Test).title) as keyof typeof TestFrameworkState]
+                if (hookFrameworkState) {
+                    await framework.trackEvent(hookFrameworkState, HookState.PRE, { test })
+                }
             }
             return
         }
@@ -424,9 +431,14 @@ export default class BrowserstackService implements Services.ServiceInstance {
 
         // CLI flow: mirror beforeHook — close the hook via the TestFramework tracker (gRPC).
         if (BrowserstackCLI.getInstance().isRunning()) {
-            const hookFrameworkState = TestFrameworkState[getHookType((test as Frameworks.Test).title) as keyof typeof TestFrameworkState]
-            if (hookFrameworkState) {
-                await BrowserstackCLI.getInstance().getTestFramework()!.trackEvent(hookFrameworkState, HookState.POST, { test, result })
+            // Null-check the tracker rather than asserting (see beforeHook) so a missing tracker
+            // degrades quietly instead of throwing inside this awaited hook.
+            const framework = BrowserstackCLI.getInstance().getTestFramework()
+            if (framework) {
+                const hookFrameworkState = TestFrameworkState[getHookType((test as Frameworks.Test).title) as keyof typeof TestFrameworkState]
+                if (hookFrameworkState) {
+                    await framework.trackEvent(hookFrameworkState, HookState.POST, { test, result })
+                }
             }
             return
         }

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -8,7 +8,8 @@ import {
     isBrowserstackSession,
     patchConsoleLogs,
     isTrue,
-    getUniqueIdentifier
+    getUniqueIdentifier,
+    getHookType
 } from './util.js'
 import type { BrowserstackConfig, BrowserstackOptions, MultiRemoteAction } from './types.js'
 import type { Pickle, Feature, ITestCaseHookParameter, CucumberHook } from './cucumber-types.js'
@@ -392,6 +393,19 @@ export default class BrowserstackService implements Services.ServiceInstance {
         if (this._config.framework !== 'cucumber') {
             this._currentTest = test as Frameworks.Test // not update currentTest when this is called for cucumber step
         }
+
+        // CLI flow: route hook lifecycle to the binary via the TestFramework tracker (gRPC),
+        // mirroring beforeTest/afterTest. Without this, hook events fall through to the legacy
+        // Listener -> api/v1/batch path, which is no longer functional in the CLI pipeline, so
+        // HookRunStarted/HookRunFinished never reach the dashboard.
+        if (BrowserstackCLI.getInstance().isRunning()) {
+            const hookFrameworkState = TestFrameworkState[getHookType((test as Frameworks.Test).title) as keyof typeof TestFrameworkState]
+            if (hookFrameworkState) {
+                await BrowserstackCLI.getInstance().getTestFramework()!.trackEvent(hookFrameworkState, HookState.PRE, { test })
+            }
+            return
+        }
+
         await this._insightsHandler?.beforeHook(test, context)
     }
 
@@ -407,6 +421,16 @@ export default class BrowserstackService implements Services.ServiceInstance {
                 this._failReasons.push(hookError)
             }
         }
+
+        // CLI flow: mirror beforeHook — close the hook via the TestFramework tracker (gRPC).
+        if (BrowserstackCLI.getInstance().isRunning()) {
+            const hookFrameworkState = TestFrameworkState[getHookType((test as Frameworks.Test).title) as keyof typeof TestFrameworkState]
+            if (hookFrameworkState) {
+                await BrowserstackCLI.getInstance().getTestFramework()!.trackEvent(hookFrameworkState, HookState.POST, { test, result })
+            }
+            return
+        }
+
         await this._insightsHandler?.afterHook(test, result)
     }
 

--- a/packages/wdio-browserstack-service/tests/service.test.ts
+++ b/packages/wdio-browserstack-service/tests/service.test.ts
@@ -2601,3 +2601,50 @@ describe('ignoreHooksStatus feature', () => {
         })
     })
 })
+
+describe('beforeHook (CLI hook reporting)', () => {
+    const hookTest = { title: '"before all" hook for "spec"' } as any
+    let getInstanceSpy: ReturnType<typeof vi.spyOn>
+
+    // Restore only our own spy so the suite's shared mocks stay intact.
+    afterEach(() => {
+        getInstanceSpy?.mockRestore()
+    })
+
+    it('routes the hook to the CLI TestFramework tracker when the CLI is running', async () => {
+        const trackEvent = vi.fn().mockResolvedValue(undefined)
+        getInstanceSpy = vi.spyOn(BrowserstackCLI, 'getInstance').mockReturnValue({
+            isRunning: () => true,
+            getTestFramework: () => ({ trackEvent })
+        } as any)
+        service['_insightsHandler'] = { beforeHook: vi.fn() } as any
+
+        await service.beforeHook(hookTest, {})
+
+        expect(trackEvent).toHaveBeenCalledTimes(1)
+        expect(service['_insightsHandler']!.beforeHook).not.toHaveBeenCalled()
+    })
+
+    it('degrades quietly (no throw, no legacy fallback) when the CLI is running but the tracker is null', async () => {
+        getInstanceSpy = vi.spyOn(BrowserstackCLI, 'getInstance').mockReturnValue({
+            isRunning: () => true,
+            getTestFramework: () => null
+        } as any)
+        service['_insightsHandler'] = { beforeHook: vi.fn() } as any
+
+        await expect(service.beforeHook(hookTest, {})).resolves.toBeUndefined()
+        expect(service['_insightsHandler']!.beforeHook).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the legacy insights handler when the CLI is not running', async () => {
+        getInstanceSpy = vi.spyOn(BrowserstackCLI, 'getInstance').mockReturnValue({
+            isRunning: () => false,
+            getTestFramework: () => null
+        } as any)
+        service['_insightsHandler'] = { beforeHook: vi.fn() } as any
+
+        await service.beforeHook(hookTest, {})
+
+        expect(service['_insightsHandler']!.beforeHook).toHaveBeenCalledTimes(1)
+    })
+})


### PR DESCRIPTION
## Problem

In the `@wdio/browserstack-service` **CLI (binary/testhub) flow** — the path used since **9.21.0** — Mocha hook events (`before` / `beforeEach` / `afterEach` / `after`) are **not reported** to Test Observability. Test/log/session events migrated to the CLI binary over gRPC, but hooks were left on the legacy JS `Listener → api/v1/batch` path, which no longer functions when the build is created by the binary — so `HookRunStarted` / `HookRunFinished` never reach the dashboard/BigQuery. (Pre-9.21.0 / non-CLI runs are unaffected.)

## Root causes (all client-side)

1. **Not routed to the CLI pipeline** — `service.beforeHook`/`afterHook` had no `BrowserstackCLI.isRunning()` branch (unlike `beforeTest`/`afterTest`), so hooks fell through to the dead legacy endpoint.
2. **Nested `Map`s dropped on serialize** — `test_hooks_started` / `test_hooks_finished` are JS `Map`s; `JSON.stringify(Object.fromEntries(...))` emitted them as `{}`.
3. **Fully-qualified state name** used for the hook-map key and the hook-id gate — `TestFrameworkState.AFTER_EACH` never matched `^(BEFORE_|AFTER_)`, so `KEY_HOOK_ID` was never set → **empty `hook_run.uuid`** → backend dropped the events.
4. **Suite/first hooks dropped** — `before all` and the first `before each` fire before the first `INIT_TEST` creates a test instance, so `resolveInstance` returned `null`.
5. **Double observer registration** — `loadModules` runs on both `startMain` and `startChild`; `registerObserver` isn't idempotent → events double-dispatched.

## Changes

- **`service.ts`** — route `beforeHook`/`afterHook` through the CLI `TestFramework` tracker (gRPC), mirroring `beforeTest`/`afterTest`.
- **`testHubModule.ts`** — JSON replacer so nested `Map` hook data serializes.
- **`wdioMochaTestFramework.ts`** — use the short state name for the hook-map key and the hook-id gate (populates `hook_run.uuid`); port the `Junit5Framework.resolveInstance` lifecycle (null-instance + new-test-boundary) so suite/first hooks are captured.
- **`cli/index.ts`** — make `loadModules` idempotent per process.

No binary-side changes required (mirrors how the Java SDK's `Junit5Framework` handles the same lifecycle).

## Validation

Repro: WDIO v9 + Mocha, App Automate (Android), Observability enabled, spec exercising all Mocha hook types across 2 tests. Bisected the regression to **9.21.0** (last good **9.20.1**). With this change, `HookRunStarted`/`HookRunFinished` carry valid uuids and **hook events appear correctly in BigQuery** end-to-end (confirmed on 9.29.1).


## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate) — N/A (behavioural robustness fix, no public API change)
- [ ] I have added proper type definitions for new commands (if appropriate) — N/A (no new commands)