### PR TITLE
fix(wdio-browserstack-service): ship a11y Browser type augmentations

### DIFF
--- a/packages/wdio-browserstack-service/src/@types/bstack-service-types.d.ts
+++ b/packages/wdio-browserstack-service/src/@types/bstack-service-types.d.ts
@@ -1,8 +1,8 @@
-// The WebdriverIO.Browser / WebdriverIO.MultiRemoteBrowser accessibility
-// augmentations (getAccessibilityResultsSummary, getAccessibilityResults,
-// performScan, startA11yScanning, stopA11yScanning) now live in src/index.ts
-// inside `declare global { namespace WebdriverIO { ... } }`, so that tsc emits
-// them into build/index.d.ts for consumers. They were moved out of this ambient
+// The WebdriverIO.Browser accessibility augmentations
+// (getAccessibilityResultsSummary, getAccessibilityResults, performScan,
+// startA11yScanning, stopA11yScanning) now live in src/index.ts inside
+// `declare global { namespace WebdriverIO { ... } }`, so that tsc emits them
+// into build/index.d.ts for consumers. They were moved out of this ambient
 // file to avoid duplicate-declaration conflicts. The setCustomTags augmentation
 // stays here (it is not part of the a11y type-shipping fix).
 declare namespace WebdriverIO {

--- a/packages/wdio-browserstack-service/src/@types/bstack-service-types.d.ts
+++ b/packages/wdio-browserstack-service/src/@types/bstack-service-types.d.ts
@@ -1,19 +1,16 @@
+// The WebdriverIO.Browser / WebdriverIO.MultiRemoteBrowser accessibility
+// augmentations (getAccessibilityResultsSummary, getAccessibilityResults,
+// performScan, startA11yScanning, stopA11yScanning) now live in src/index.ts
+// inside `declare global { namespace WebdriverIO { ... } }`, so that tsc emits
+// them into build/index.d.ts for consumers. They were moved out of this ambient
+// file to avoid duplicate-declaration conflicts. The setCustomTags augmentation
+// stays here (it is not part of the a11y type-shipping fix).
 declare namespace WebdriverIO {
     interface Browser {
-        getAccessibilityResultsSummary: () => Promise<Record<string, unknown>>,
-        getAccessibilityResults: () => Promise<Array<Record<string, unknown>>>,
-        performScan: () => Promise<Record<string, unknown> | undefined>,
-        startA11yScanning: () => Promise<void>,
-        stopA11yScanning: () => Promise<void>,
         setCustomTags: (key: string, value: string) => Promise<void>
     }
 
     interface MultiRemoteBrowser {
-        getAccessibilityResultsSummary: () => Promise<Record<string, unknown>>,
-        getAccessibilityResults: () => Promise<Array<Record<string, unknown>>>,
-        performScan: () => Promise<Record<string, unknown> | undefined>,
-        startA11yScanning: () => Promise<void>,
-        stopA11yScanning: () => Promise<void>,
         setCustomTags: (key: string, value: string) => Promise<void>
     }
 }

--- a/packages/wdio-browserstack-service/src/accessibility-handler.ts
+++ b/packages/wdio-browserstack-service/src/accessibility-handler.ts
@@ -1,4 +1,3 @@
-/// <reference path="./@types/bstack-service-types.d.ts" />
 import util from 'node:util'
 
 import type { Capabilities, Frameworks, Options } from '@wdio/types'

--- a/packages/wdio-browserstack-service/src/cli/modules/accessibilityModule.ts
+++ b/packages/wdio-browserstack-service/src/cli/modules/accessibilityModule.ts
@@ -1,4 +1,3 @@
-/// <reference path="../../@types/bstack-service-types.d.ts" />
 import BaseModule from './baseModule.js'
 import { BrowserstackCLI } from '../index.js'
 import { BStackLogger } from '../cliLogger.js'

--- a/packages/wdio-browserstack-service/src/index.ts
+++ b/packages/wdio-browserstack-service/src/index.ts
@@ -20,6 +20,22 @@ export * from './types.js'
 declare global {
     namespace WebdriverIO {
         interface ServiceOption extends BrowserstackConfig {}
+
+        interface Browser {
+            getAccessibilityResultsSummary: () => Promise<Record<string, unknown>>,
+            getAccessibilityResults: () => Promise<Array<Record<string, unknown>>>,
+            performScan: () => Promise<Record<string, unknown> | undefined>,
+            startA11yScanning: () => Promise<void>,
+            stopA11yScanning: () => Promise<void>
+        }
+
+        interface MultiRemoteBrowser {
+            getAccessibilityResultsSummary: () => Promise<Record<string, unknown>>,
+            getAccessibilityResults: () => Promise<Array<Record<string, unknown>>>,
+            performScan: () => Promise<Record<string, unknown> | undefined>,
+            startA11yScanning: () => Promise<void>,
+            stopA11yScanning: () => Promise<void>
+        }
     }
     interface State {
         value: number,

--- a/packages/wdio-browserstack-service/src/index.ts
+++ b/packages/wdio-browserstack-service/src/index.ts
@@ -28,14 +28,6 @@ declare global {
             startA11yScanning: () => Promise<void>,
             stopA11yScanning: () => Promise<void>
         }
-
-        interface MultiRemoteBrowser {
-            getAccessibilityResultsSummary: () => Promise<Record<string, unknown>>,
-            getAccessibilityResults: () => Promise<Array<Record<string, unknown>>>,
-            performScan: () => Promise<Record<string, unknown> | undefined>,
-            startA11yScanning: () => Promise<void>,
-            stopA11yScanning: () => Promise<void>
-        }
     }
     interface State {
         value: number,

--- a/tests/typings/webdriverio/browserstackService.ts
+++ b/tests/typings/webdriverio/browserstackService.ts
@@ -1,0 +1,30 @@
+import { expectType } from 'tsd'
+import { browser } from '@wdio/globals'
+
+/**
+ * Regression guard for the @wdio/browserstack-service accessibility
+ * augmentation of WebdriverIO.Browser.
+ *
+ * These five methods are declared inside
+ *   declare global { namespace WebdriverIO { interface Browser { ... } } }
+ * in packages/wdio-browserstack-service/src/index.ts. They previously lived
+ * in an un-emitted ambient .d.ts file and silently never reached the published
+ * build/index.d.ts, so consumers lost the typings. This file pulls in the
+ * published @wdio/browserstack-service types (it is listed in this suite's
+ * tsconfig.json `types` array) and fails `test:typings:webdriverio` if any of
+ * the five methods ever stops being typed on WebdriverIO.Browser again.
+ */
+;(async () => {
+    expectType<() => Promise<Record<string, unknown>>>(browser.getAccessibilityResultsSummary)
+    expectType<() => Promise<Array<Record<string, unknown>>>>(browser.getAccessibilityResults)
+    expectType<() => Promise<Record<string, unknown> | undefined>>(browser.performScan)
+    expectType<() => Promise<void>>(browser.startA11yScanning)
+    expectType<() => Promise<void>>(browser.stopA11yScanning)
+
+    // also assert the call-site return types resolve as declared
+    expectType<Record<string, unknown>>(await browser.getAccessibilityResultsSummary())
+    expectType<Array<Record<string, unknown>>>(await browser.getAccessibilityResults())
+    expectType<Record<string, unknown> | undefined>(await browser.performScan())
+    expectType<void>(await browser.startA11yScanning())
+    expectType<void>(await browser.stopA11yScanning())
+})


### PR DESCRIPTION
## Proposed changes

Customers using `@wdio/browserstack-service` with TypeScript hit a compile error:

> `Property 'startA11yScanning' does not exist on type 'Browser'`

(and the same for `stopA11yScanning`, `performScan`, `getAccessibilityResults`, `getAccessibilityResultsSummary`).

The accessibility tests **run fine** — the methods are attached to `browser` at runtime (`accessibility-handler.ts`). The failure is **type-check only**, which blocks teams with strict `tsc`/lint gates.

### Root cause

The a11y method declarations lived **only** in `src/@types/bstack-service-types.d.ts`, written as a bare `declare namespace WebdriverIO { ... }` ambient (script-mode) file with no `import`/`export`. `tsc` treats it as a local auto-discovered ambient during the package's own compile, but **never emits it into the published `build/index.d.ts`** (the `package.json` `types` entry). So consumers install the package and the augmentation simply isn't there — `tsc` correctly errors. Adding the package to a consumer's `tsconfig` `types` cannot help, because the declarations were never shipped.

### Fix

Move the a11y `Browser` augmentation into the existing `declare global { namespace WebdriverIO { ... } }` block in `src/index.ts` — mirroring the `ServiceOption` augmentation already there, which *does* compile into `build/index.d.ts`. Strip the (now duplicate) a11y declarations from the ambient `src/@types/bstack-service-types.d.ts` and drop the two now-dead `/// <reference>` directives that pulled it in. The ambient file itself is **kept** — it still carries the unrelated `setCustomTags` augmentation, which is out of scope for this fix.

The augmentation is intentionally added to `Browser` only, not `MultiRemoteBrowser`: the a11y methods are attached to a single browser object at runtime (`accessibility-handler.ts`) with no multiremote fan-out, and the CLI a11y path is disabled for multiremote — so typing them on `MultiRemoteBrowser` would green-light calls that are `undefined` at runtime. Multiremote a11y runtime support is a separate follow-up.

### Verification

- `build/index.d.ts` now contains all 5 methods on `Browser` (before: 0).
- A minimal consumer `tsc` reproduction goes from **5 `TS2339` errors → 0** after the fix, with the change being the only variable.
- Added a type-level test under `tests/typings/` guarding the augmentation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate) — n/a, type-only fix
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

> The same type-shipping bug exists on `v8`. Happy to raise a matching PR against the `v8` branch if you'd like this back-ported — let me know.

## Further comments

The augmentation is deliberately kept minimal (only the `Browser` interface) to mirror the existing `ServiceOption` pattern already emitted into `build/index.d.ts`, rather than reintroducing a separate ambient file that `tsc` silently drops from the published types.

### Reviewers: @webdriverio/project-committers
