### PR TITLE
PR: Bug Fix 🐛fix(allure-reporter): attach suite-level before/after all hook steps to every test

### DIFF
--- a/packages/wdio-allure-reporter/src/state.ts
+++ b/packages/wdio-allure-reporter/src/state.ts
@@ -241,15 +241,18 @@ export class AllureReportState {
 
     }
 
-    // A suite-scoped hook ("before all"/"after all") may only attach to a suite scope - it
-    // conceptually belongs to the whole suite, not to any one test, and attaching it to a
-    // test's own scope would hide it from every other test. Any other hook may attach to a
-    // test scope as long as that test hasn't been fully finalized yet (_currentTestUuid is
-    // only cleared by _writeLastTest) - this covers both an ordinary running test and a test
-    // that just ended and is merely pending close (see _closeDanglingTestScope), which is
-    // exactly when a trailing "after each" hook needs to attach. Anything else (no scope open
-    // at all, or a mismatch between the hook's own scope and the currently open one) has
-    // nowhere safe to attach to yet and is queued as a pending hook to be replayed later.
+    // The suite scope is shared by every test started under it, so it must only ever hold a
+    // genuinely suite-scoped hook ("before all"/"after all") - attaching anything else there
+    // would leak that hook's fixture onto every other test in the suite. A test scope, by
+    // contrast, is never shared across multiple real tests, so there's no such leakage risk in
+    // being permissive there: it accepts any hook - including a suite-scoped one with no suite
+    // scope currently available, e.g. a root-level hook outside any describe() being replayed
+    // from _pendingHookMessages (see _attachPendingHookToCurrentTest and the "root-level" test)
+    // - as long as that test hasn't been fully finalized yet (_currentTestUuid is only cleared
+    // by _writeLastTest). This covers an ordinary running test and a test that just ended and
+    // is merely pending close (see _closeDanglingTestScope), which is exactly when a trailing
+    // "after each" hook needs to attach. Anything else (no scope open at all) has nowhere safe
+    // to attach to yet and is queued as a pending hook to be replayed later.
     private _hasAttachableScope(hookName: string): boolean {
         const kind = this._scopeKindsStack[this._scopeKindsStack.length - 1]
         if (kind === 'suite') {

--- a/packages/wdio-allure-reporter/src/state.ts
+++ b/packages/wdio-allure-reporter/src/state.ts
@@ -13,6 +13,19 @@ import { findLast, findLastIndex, last } from './utils.js'
 import type { Status as AllureStatus } from 'allure-js-commons'
 import { Stage as AllureStage } from 'allure-js-commons'
 
+// Mocha formats a hook's title as the literal quoted hook-type phrase (optionally
+// followed by ": fnName"), then a ` for "<test title>"` suffix (each-hooks, which run
+// in a specific test's context) or ` in "<suite title>"` suffix (all-hooks) naming the
+// context the hook ran in - see mocha's runner.js `setHookTitle`. Matching /all/i or
+// /each/i anywhere in the title would false-positive on a test/suite name that happens
+// to contain "all" or "each" (e.g. a test titled "should handle all cases", or a suite
+// named "All users"), misclassifying an ordinary before/after-each hook as suite-scoped
+// or vice versa. Anchoring to the start of the string ensures only the actual hook-type
+// phrase is matched, never the name that follows it.
+const ALL_HOOK_PATTERN = /^"(?:before|after)\s+all"/i
+const EACH_HOOK_PATTERN = /^"(?:before|after)\s+each"/i
+const AFTER_ALL_HOOK_PATTERN = /^"after\s+all"/i
+
 export class AllureReportState {
     private _scopesStack: string[] = []
     private _scopeKindsStack: Array<'suite' | 'test'> = []
@@ -240,7 +253,7 @@ export class AllureReportState {
     private _hasAttachableScope(hookName: string): boolean {
         const kind = this._scopeKindsStack[this._scopeKindsStack.length - 1]
         if (kind === 'suite') {
-            return /all/i.test(hookName)
+            return ALL_HOOK_PATTERN.test(hookName)
         }
         if (kind === 'test') {
             return Boolean(this._currentTestUuid)
@@ -251,9 +264,9 @@ export class AllureReportState {
     private async _startHook(message: WDIOHookStartMessage): Promise<void> {
         const { name, type, start } = message.data
 
-        const isAllHook = /all/i.test(name)
+        const isAllHook = ALL_HOOK_PATTERN.test(name)
 
-        if (/after all/i.test(name) && this._currentTestUuid) {
+        if (AFTER_ALL_HOOK_PATTERN.test(name) && this._currentTestUuid) {
             await this._writeLastTest()
         }
         // Only an "all"-scoped hook needs the suite scope exposed - closing the dangling
@@ -418,7 +431,7 @@ export class AllureReportState {
             return
         }
         const startIdx = this._pendingHookMessages.findIndex((m) =>
-            m.type === 'allure:hook:start' && m.data.type === kind && typeof m.data.name === 'string' && (scope === 'each' ? /each/i.test(m.data.name) : /all/i.test(m.data.name))
+            m.type === 'allure:hook:start' && m.data.type === kind && typeof m.data.name === 'string' && (scope === 'each' ? EACH_HOOK_PATTERN.test(m.data.name) : ALL_HOOK_PATTERN.test(m.data.name))
         )
         if (startIdx === -1) {
             return

--- a/packages/wdio-allure-reporter/src/state.ts
+++ b/packages/wdio-allure-reporter/src/state.ts
@@ -15,6 +15,8 @@ import { Stage as AllureStage } from 'allure-js-commons'
 
 export class AllureReportState {
     private _scopesStack: string[] = []
+    private _scopeKindsStack: Array<'suite' | 'test'> = []
+    private _testScopePendingClose: boolean = false
     private _executablesStack: string[] = []
     private _fixturesStack: string[] = []
     private _currentTestUuid?: string
@@ -113,13 +115,15 @@ export class AllureReportState {
         return m?.data?.name
     }
 
-    private async _openScope(): Promise<void> {
+    private async _openScope(kind: 'suite' | 'test'): Promise<void> {
         const scopeUuid = this.allureRuntime.startScope()
         this._scopesStack.push(scopeUuid)
+        this._scopeKindsStack.push(kind)
     }
 
     private async _closeScope(): Promise<void> {
         const scopeUuid = this._scopesStack.pop()
+        this._scopeKindsStack.pop()
         if (scopeUuid) {
             await this.allureRuntime.writeScope(scopeUuid)
         }
@@ -133,14 +137,28 @@ export class AllureReportState {
         this._currentTestUuid = undefined
     }
 
+    // A test's own scope stays open past its test:end - Mocha fires a test's "after each"
+    // hook(s) only after that test's pass/fail/test:end events, so the scope needs to still
+    // be there for such a hook to attach to (see _endTest). Once marked pending-close, that
+    // scope is orphaned and must be closed before a new suite/test scope is opened, or before
+    // a suite-level "after all" hook can reach the suite scope underneath it.
+    private async _closeDanglingTestScope(): Promise<void> {
+        if (this._testScopePendingClose) {
+            await this._closeScope()
+            this._testScopePendingClose = false
+        }
+    }
+
     private async _startSuite(): Promise<void> {
         if (this._currentTestUuid) {
             await this._writeLastTest()
         }
-        await this._openScope()
+        await this._closeDanglingTestScope()
+        await this._openScope('suite')
     }
 
     private async _endSuite(write: boolean = false): Promise<void> {
+        await this._closeDanglingTestScope()
         await this._closeScope()
         if (write) {
             await this._writeLastTest()
@@ -151,7 +169,8 @@ export class AllureReportState {
         if (this._currentTestUuid) {
             await this._writeLastTest()
         }
-        await this._openScope()
+        await this._closeDanglingTestScope()
+        await this._openScope('test')
 
         const { name, start } = message.data
         const testUuid = this.allureRuntime.startTest(
@@ -193,7 +212,8 @@ export class AllureReportState {
         }
 
         await this._closeOpenedSteps(status, stop, statusDetails)
-        await this._closeScope()
+        // The test's own scope is intentionally left open here - see _closeDanglingTestScope.
+        this._testScopePendingClose = true
 
         this.allureRuntime.updateTest(testUuid, r => {
             r.status = status
@@ -208,34 +228,63 @@ export class AllureReportState {
 
     }
 
+    // A suite-scoped hook ("before all"/"after all") may only attach to a suite scope - it
+    // conceptually belongs to the whole suite, not to any one test, and attaching it to a
+    // test's own scope would hide it from every other test. Any other hook may attach to a
+    // test scope as long as that test hasn't been fully finalized yet (_currentTestUuid is
+    // only cleared by _writeLastTest) - this covers both an ordinary running test and a test
+    // that just ended and is merely pending close (see _closeDanglingTestScope), which is
+    // exactly when a trailing "after each" hook needs to attach. Anything else (no scope open
+    // at all, or a mismatch between the hook's own scope and the currently open one) has
+    // nowhere safe to attach to yet and is queued as a pending hook to be replayed later.
+    private _hasAttachableScope(hookName: string): boolean {
+        const kind = this._scopeKindsStack[this._scopeKindsStack.length - 1]
+        if (kind === 'suite') {
+            return /all/i.test(hookName)
+        }
+        if (kind === 'test') {
+            return Boolean(this._currentTestUuid)
+        }
+        return false
+    }
+
     private async _startHook(message: WDIOHookStartMessage): Promise<void> {
         const { name, type, start } = message.data
+
+        const isAllHook = /all/i.test(name)
 
         if (/after all/i.test(name) && this._currentTestUuid) {
             await this._writeLastTest()
         }
+        // Only an "all"-scoped hook needs the suite scope exposed - closing the dangling
+        // test scope here for an "each"-scoped hook would destroy the very scope it needs
+        // to attach to (see _closeDanglingTestScope).
+        if (isAllHook) {
+            await this._closeDanglingTestScope()
+        }
 
-        if (!this._currentTestUuid) {
+        const testScopeUuid = this._scopesStack[this._scopesStack.length - 1]
+        if (!testScopeUuid || !this._hasAttachableScope(name)) {
             this._pendingHookMessages.push(message)
             this._isCapturingPendingHook = true
             return
         }
 
-        const testScopeUuid = this._scopesStack[this._scopesStack.length - 1]
-        if (testScopeUuid) {
-            const hookUuid = this.allureRuntime.startFixture(testScopeUuid, type, { name, start })
-            if (hookUuid) {
-                this._fixturesStack.push(hookUuid)
-                this._openHookSteps.set(hookUuid, 0)
-                this._hookMeta.set(hookUuid, { name, type })
-            }
+        const hookUuid = this.allureRuntime.startFixture(testScopeUuid, type, { name, start })
+        if (hookUuid) {
+            this._fixturesStack.push(hookUuid)
+            this._openHookSteps.set(hookUuid, 0)
+            this._hookMeta.set(hookUuid, { name, type })
         }
     }
 
     private async _endHook(message: WDIOHookEndMessage): Promise<void> {
         const { status, statusDetails, duration, stop } = message.data
 
-        if (!this._currentTestUuid) {
+        // Mirrors _startHook: if there's no matching open fixture, the corresponding
+        // hook:start must have been queued as pending (no scope was open yet), so queue
+        // this end message alongside it rather than assuming a current test exists.
+        if (this._fixturesStack.length === 0) {
             this._pendingHookMessages.push(message)
             this._isCapturingPendingHook = false
             return
@@ -304,21 +353,11 @@ export class AllureReportState {
                 continue
 
             case 'allure:hook:start':
-                if (!this._currentTestUuid) {
-                    this._pendingHookMessages.push(message)
-                    this._isCapturingPendingHook = true
-                    continue
-                }
                 await this._startHook(message)
                 continue
 
             case 'allure:hook:end':
-                if (!this._currentTestUuid) {
-                    this._pendingHookMessages.push(message)
-                    this._isCapturingPendingHook = false
-                    continue
-                }
-                if (this._fixturesStack.length === 0 && this._pendingHookMessages.length > 0 && !this.currentFeature) {
+                if (this._fixturesStack.length === 0 && this._currentTestUuid && this._pendingHookMessages.length > 0 && !this.currentFeature) {
                     this._pendingHookMessages.push(message)
                     this._isCapturingPendingHook = false
                     const testName = this._currentTestName ?? 'unknown test'

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
@@ -630,6 +630,39 @@ describe('hooks handling default', () => {
             expect(c.children).toHaveLength(1)
         }
     })
+
+    it('does not misclassify before-each/after-each hooks whose title mentions "all" via the suite/test name', async () => {
+        const reporter = new AllureReporter({ outputDir })
+        reporter.onRunnerStart(runnerStart())
+        // Mocha formats an "each" hook's title as `"before each" hook for "<test title>"` -
+        // a test named to contain the word "all" must not make the hook look suite-scoped.
+        reporter.onSuiteStart({ cid: cid(), title: 'All users' } as any)
+
+        for (const n of [1, 2, 3]) {
+            reporter.onTestStart({ ...testStart(), title: `should handle all cases ${n}` } as any)
+            reporter.onHookStart({ title: `"before each" hook for "should handle all cases ${n}"`, parent: 'All users' } as HookStats)
+            reporter.addStep(`before-each-step-${n}`)
+            reporter.onHookEnd({ title: `"before each" hook for "should handle all cases ${n}"`, parent: 'All users' } as HookStats)
+            reporter.onTestPass(testPassed())
+            reporter.onHookStart({ title: `"after each" hook for "should handle all cases ${n}"`, parent: 'All users' } as HookStats)
+            reporter.addStep(`after-each-step-${n}`)
+            reporter.onHookEnd({ title: `"after each" hook for "should handle all cases ${n}"`, parent: 'All users' } as HookStats)
+        }
+
+        reporter.onSuiteEnd(suiteEnd())
+        await reporter.onRunnerEnd(runnerEnd())
+
+        const { results, containers } = getResults(outputDir)
+        expect(results).toHaveLength(3)
+
+        const beforeEachContainers = containers.filter((c: any) => /before each/.test(c.name))
+        const afterEachContainers = containers.filter((c: any) => /after each/.test(c.name))
+        expect(beforeEachContainers).toHaveLength(3)
+        expect(afterEachContainers).toHaveLength(3)
+        for (const c of [...beforeEachContainers, ...afterEachContainers]) {
+            expect(c.children).toHaveLength(1)
+        }
+    })
 })
 
 describe('test step naming', () => {

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
@@ -535,6 +535,101 @@ describe('hooks handling default', () => {
         expect(beforeCount).toBeGreaterThanOrEqual(1)
         expect(afterCount).toBeGreaterThanOrEqual(1)
     })
+
+    it('attaches a root-level "before all" hook (fired before any suite exists) to the first test', async () => {
+        reporter.onRunnerStart(runnerStart())
+
+        reporter.onHookStart({ cid: cid(), title: '"before all" hook in "{root}"', parent: '' } as HookStats)
+        reporter.addStep('root-before-all-step')
+        reporter.onHookEnd({ cid: cid(), title: '"before all" hook in "{root}"', parent: '' } as HookStats)
+
+        reporter.onSuiteStart(suiteStart())
+        reporter.onTestStart(testStart())
+        reporter.onTestPass(testPassed())
+        reporter.onSuiteEnd(suiteEnd())
+        await reporter.onRunnerEnd(runnerEnd())
+
+        const { results, containers } = getResults(outputDir)
+        expect(results).toHaveLength(1)
+        expect(containers).toHaveLength(1)
+        expect(containers[0].befores[0].steps[0]).toEqual(expect.objectContaining({ name: 'root-before-all-step' }))
+    })
+
+    it('attaches a before-all hook step to every test in the suite, not just one', async () => {
+        const reporter = new AllureReporter({ outputDir })
+        reporter.onRunnerStart(runnerStart())
+        reporter.onSuiteStart({ cid: cid(), title: 'My Login application' } as any)
+
+        reporter.onHookStart({ title: '"before all" hook for "My Login application"', parent: 'My Login application' } as HookStats)
+        reporter.addStep('Start login')
+        reporter.onHookEnd({ title: '"before all" hook for "My Login application"', parent: 'My Login application' } as HookStats)
+
+        reporter.onTestStart({ ...testStart(), title: 'test 1' } as any)
+        reporter.onTestPass(testPassed())
+
+        reporter.onTestStart({ ...testStart(), title: 'test 2' } as any)
+        reporter.onTestPass(testPassed())
+
+        reporter.onTestStart({ ...testStart(), title: 'test 3' } as any)
+        reporter.onTestPass(testPassed())
+
+        reporter.onSuiteEnd(suiteEnd())
+        await reporter.onRunnerEnd(runnerEnd())
+
+        const { results, containers } = getResults(outputDir)
+        expect(results).toHaveLength(3)
+        expect(containers).toHaveLength(1)
+
+        const container = containers[0]
+        expect(container.children).toHaveLength(3)
+        expect(container.children.sort()).toEqual(results.map((r: any) => r.uuid).sort())
+        expect(container.befores[0].steps[0]).toEqual(expect.objectContaining({ name: 'Start login' }))
+    })
+
+    it('keeps before-all/after-all fixtures shared but before-each/after-each fixtures isolated per test', async () => {
+        const reporter = new AllureReporter({ outputDir })
+        reporter.onRunnerStart(runnerStart())
+        reporter.onSuiteStart(suiteStart())
+
+        reporter.onHookStart({ title: '"before all" hook', parent: 'Login' } as HookStats)
+        reporter.addStep('before-all-step')
+        reporter.onHookEnd({ title: '"before all" hook', parent: 'Login' } as HookStats)
+
+        for (const n of [1, 2, 3]) {
+            reporter.onTestStart({ ...testStart(), title: `test ${n}` } as any)
+            reporter.onHookStart({ title: '"before each" hook', parent: 'Login' } as HookStats)
+            reporter.addStep(`before-each-step-${n}`)
+            reporter.onHookEnd({ title: '"before each" hook', parent: 'Login' } as HookStats)
+            reporter.onTestPass(testPassed())
+            reporter.onHookStart({ title: '"after each" hook', parent: 'Login' } as HookStats)
+            reporter.addStep(`after-each-step-${n}`)
+            reporter.onHookEnd({ title: '"after each" hook', parent: 'Login' } as HookStats)
+        }
+
+        reporter.onHookStart({ title: '"after all" hook', parent: 'Login' } as HookStats)
+        reporter.addStep('after-all-step')
+        reporter.onHookEnd({ title: '"after all" hook', parent: 'Login' } as HookStats)
+
+        reporter.onSuiteEnd(suiteEnd())
+        await reporter.onRunnerEnd(runnerEnd())
+
+        const { results, containers } = getResults(outputDir)
+        expect(results).toHaveLength(3)
+        const testUuids = results.map((r: any) => r.uuid).sort()
+
+        const beforeAllContainer = containers.find((c: any) => c.name === '"before all" hook')
+        const afterAllContainer = containers.find((c: any) => c.name === '"after all" hook')
+        expect(beforeAllContainer.children.sort()).toEqual(testUuids)
+        expect(afterAllContainer.children.sort()).toEqual(testUuids)
+
+        const beforeEachContainers = containers.filter((c: any) => c.name === '"before each" hook')
+        const afterEachContainers = containers.filter((c: any) => c.name === '"after each" hook')
+        expect(beforeEachContainers).toHaveLength(3)
+        expect(afterEachContainers).toHaveLength(3)
+        for (const c of [...beforeEachContainers, ...afterEachContainers]) {
+            expect(c.children).toHaveLength(1)
+        }
+    })
 })
 
 describe('test step naming', () => {

--- a/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
+++ b/packages/wdio-allure-reporter/tests/allureFeatures.test.ts
@@ -619,6 +619,8 @@ describe('hooks handling default', () => {
 
         const beforeAllContainer = containers.find((c: any) => c.name === '"before all" hook')
         const afterAllContainer = containers.find((c: any) => c.name === '"after all" hook')
+        expect(beforeAllContainer).toBeDefined()
+        expect(afterAllContainer).toBeDefined()
         expect(beforeAllContainer.children.sort()).toEqual(testUuids)
         expect(afterAllContainer.children.sort()).toEqual(testUuids)
 


### PR DESCRIPTION
#15389
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Fixes a bug in @wdio/allure-reporter where a suite-level before()/after() (Mocha "before all"/"after all") hook's Allure step data was attached to only one arbitrary test in the suite instead of every test, and later tests received no "Set up"/"Tear down" section at all.

Root cause: AllureReportState decided whether a hook could attach directly to the current Allure scope based solely on whether a test was "currently running." A suite-level before() fires before any test in the suite starts, so it was always routed into a "pending hook" queue and replayed onto whichever single test started next — then discarded, so subsequent tests got nothing.


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
