### PR TITLE
fix(webdriverio): stop unrelated shadow roots leaking into scoped element lookups

### DIFF
--- a/e2e/wdio/headless/__fixtures__/shadowRootScope.html
+++ b/e2e/wdio/headless/__fixtures__/shadowRootScope.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Shadow Root Scope Repro</title>
+    <!--
+        Mirrors the reporter's setup: a declarative CLOSED shadow root defined via
+        <template shadowrootmode="closed"> inside <head>. Its registration happens
+        during parsing, before anything else on the page, and must never leak into
+        subsequent scoped lookups.
+    -->
+    <cs-native-frame-holder>
+        <template shadowrootmode="closed">
+            <span class="declarative-closed-inside">declarative closed shadow text</span>
+        </template>
+    </cs-native-frame-holder>
+</head>
+<body>
+    <!--
+        Mirrors the reported bug: an unrelated element elsewhere in the page has a
+        shadow root (closed, like the reporter's cs-native-frame-holder). It must
+        never leak into lookups scoped to unrelated parts of the page.
+    -->
+    <div id="unrelated-holder"></div>
+
+    <!--
+        The regression case found during review: a plain wrapper div (never itself
+        a shadow host) containing a custom element that DOES have a shadow root.
+        $('#wrapper').$('.inside-shadow') must find the element inside the nested
+        shadow root, and $('#wrapper').$('.plain-sibling') must still find the
+        plain light-DOM sibling.
+    -->
+    <div id="wrapper">
+        <my-widget></my-widget>
+        <span class="plain-sibling">plain sibling text</span>
+    </div>
+
+    <div id="target"><span data-testid="ift">target element</span></div>
+
+    <script>
+        class MyWidget extends HTMLElement {
+            connectedCallback() {
+                const shadow = this.attachShadow({ mode: 'open' })
+                shadow.innerHTML = '<span class="inside-shadow">inside shadow text</span>'
+            }
+        }
+        customElements.define('my-widget', MyWidget)
+
+        class ClosedHolder extends HTMLElement {
+            connectedCallback() {
+                const shadow = this.attachShadow({ mode: 'closed' })
+                shadow.innerHTML = '<span class="closed-inside">closed shadow text</span>'
+            }
+        }
+        customElements.define('closed-holder', ClosedHolder)
+        document.getElementById('unrelated-holder').appendChild(document.createElement('closed-holder'))
+    </script>
+</body>
+</html>

--- a/e2e/wdio/headless/shadowRootScope-repro.e2e.ts
+++ b/e2e/wdio/headless/shadowRootScope-repro.e2e.ts
@@ -1,0 +1,99 @@
+import url from 'node:url'
+import path from 'node:path'
+import { browser, $, expect } from '@wdio/globals'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+describe('shadow root scope resolution (regression repro)', () => {
+    before(async () => {
+        const resource = path.resolve(__dirname, '__fixtures__', 'shadowRootScope.html')
+        await browser.url(url.pathToFileURL(resource).href)
+    })
+
+    /**
+     * collect the `startNodes` of every `browsingContext.locateNodes` command
+     * issued while `fn` runs. The original bug is a *scope resolution* leak:
+     * unrelated shadow roots were sent as startNodes for scoped lookups. Its
+     * user-visible failure (lookups timing out) additionally requires those
+     * leaked references to be stale (e.g. after SPA navigation), which can't be
+     * reproduced deterministically — so we assert on the protocol payload
+     * itself, where the leak is always observable.
+     */
+    async function collectLocateStartNodes (fn: () => Promise<unknown>): Promise<{ sharedId?: string }[][]> {
+        const startNodes: { sharedId?: string }[][] = []
+        const listener = (command: { method: string, params: Record<string, unknown> }) => {
+            if (command.method === 'browsingContext.locateNodes' && Array.isArray(command.params.startNodes)) {
+                startNodes.push(command.params.startNodes as { sharedId?: string }[])
+            }
+        }
+        browser.on('bidiCommand', listener as never)
+        try {
+            await fn()
+        } finally {
+            browser.off('bidiCommand', listener as never)
+        }
+        return startNodes
+    }
+
+    it('does not leak an unrelated closed shadow root into an unrelated lookup (original reported bug)', async () => {
+        // '#target' is a plain element with no shadow-related descendants at all
+        // and is unrelated to the page's closed shadow roots (the declarative one
+        // in <head> and '#unrelated-holder's closed-holder).
+        const target = await $('#target')
+        await expect(target.$('[data-testid="ift"]')).toHaveText('target element')
+
+        const startNodes = await collectLocateStartNodes(
+            () => target.$('[data-testid="ift"]').getText()
+        )
+        expect(startNodes.length).toBeGreaterThan(0)
+        for (const nodes of startNodes) {
+            // the scope has no shadow descendants: its own element id must be the
+            // ONLY start node — before the fix this was a list of every shadow
+            // root registered anywhere on the page (and not the scope itself)
+            expect(nodes.map((node) => node.sharedId)).toEqual([target.elementId])
+        }
+    })
+
+    it('does not find an element outside of the queried scope', async () => {
+        // '[data-testid="ift"]' lives under '#target' — a lookup scoped to the
+        // unrelated '#unrelated-holder' must not surface it, no matter which
+        // startNodes the shadow root manager resolved for that scope
+        await expect($('#unrelated-holder').$('[data-testid="ift"]')).not.toExist()
+    })
+
+    it('sends the wrapper element itself alongside its nested shadow root as startNodes', async () => {
+        const wrapper = await $('#wrapper')
+        await expect(wrapper.$('.inside-shadow')).toExist()
+
+        const startNodes = await collectLocateStartNodes(
+            () => wrapper.$('.inside-shadow').getText()
+        )
+        expect(startNodes.length).toBeGreaterThan(0)
+        for (const nodes of startNodes) {
+            const ids = nodes.map((node) => node.sharedId)
+            // the wrapper's own element id must be included (so plain light-DOM
+            // descendants stay searchable) plus exactly the one shadow root
+            // genuinely contained under it — not the page's other shadow roots
+            expect(ids).toContain(wrapper.elementId)
+            expect(ids).toHaveLength(2)
+        }
+    })
+
+    it('pierces into a shadow host nested under a plain (non-host) wrapper div', async () => {
+        const insideShadow = await $('#wrapper').$('.inside-shadow')
+        await expect(insideShadow).toExist()
+        await expect(insideShadow).toHaveText('inside shadow text')
+    })
+
+    it('still finds a plain light-DOM sibling of a nested shadow host under the same wrapper', async () => {
+        const plainSibling = await $('#wrapper').$('.plain-sibling')
+        await expect(plainSibling).toExist()
+        await expect(plainSibling).toHaveText('plain sibling text')
+    })
+
+    it('getHTML({ pierceShadowRoot: true }) on the plain wrapper includes the nested shadow root content', async () => {
+        const html = await $('#wrapper').getHTML({ pierceShadowRoot: true })
+        expect(html).toContain('inside shadow text')
+        expect(html).toContain('shadowrootmode')
+    })
+})

--- a/e2e/wdio/wdio.conf.ts
+++ b/e2e/wdio/wdio.conf.ts
@@ -14,6 +14,7 @@ export const config: WebdriverIO.Config = {
         path.join(__dirname, 'headless', 'reloadSession.e2e.ts'),
         path.join(__dirname, 'headless', 'test.e2e.ts'),
         path.join(__dirname, 'headless', 'mocking.e2e.ts'),
+        path.join(__dirname, 'headless', 'shadowRootScope-repro.e2e.ts'),
     ],
 
     /**

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -118,7 +118,7 @@ export async function getHTML(
         const shadowRootManager = getShadowRootManager(browser)
         const contextManager = getContextManager(browser)
         const context = await contextManager.getCurrentContext()
-        const shadowRootElementPairs = shadowRootManager.getShadowElementPairsByContextId(context, (this as WebdriverIO.Element).elementId)
+        const shadowRootElementPairs = await shadowRootManager.getShadowElementPairsByContextId(context, (this as WebdriverIO.Element).elementId)
 
         /**
          * verify that shadow elements captured by the shadow root manager is still attached to the DOM

--- a/packages/webdriverio/src/scripts/elementsConnected.ts
+++ b/packages/webdriverio/src/scripts/elementsConnected.ts
@@ -1,0 +1,10 @@
+/**
+ * Check `isConnected` for many elements in a single round trip instead of one
+ * `execute()` call per element. Kept as a separate self-contained function because
+ * `browser.execute()` serializes only the passed function's own source text.
+ */
+export default function elementsConnected (
+    elements: HTMLElement[]
+): boolean[] {
+    return elements.map((element) => element.isConnected)
+}

--- a/packages/webdriverio/src/scripts/elementsContainedIn.ts
+++ b/packages/webdriverio/src/scripts/elementsContainedIn.ts
@@ -1,0 +1,27 @@
+/**
+ * Check DOM containment (crossing shadow boundaries via `.host`, like `elementContains.ts`)
+ * for many candidate elements in a single round trip instead of one `execute()` call per
+ * candidate. Kept as a separate self-contained function (rather than sharing a helper with
+ * `elementContains.ts`) because `browser.execute()` serializes only the passed function's
+ * own source text — it cannot reference helpers defined outside of it.
+ */
+export default function elementsContainedIn (
+    scope: HTMLElement,
+    elements: HTMLElement[]
+): boolean[] {
+    function isInDocument (element: HTMLElement) {
+        let currentElement: HTMLElement | ParentNode = element
+        while (currentElement && currentElement.parentNode) {
+            if (currentElement.parentNode === scope || (currentElement.parentNode as ShadowRoot).host === scope) {
+                return true
+            } else if (currentElement.parentNode instanceof DocumentFragment) {
+                currentElement = (currentElement.parentNode as ShadowRoot).host
+            } else {
+                currentElement = currentElement.parentNode
+            }
+        }
+        return false
+    }
+
+    return elements.map((element) => isInDocument(element))
+}

--- a/packages/webdriverio/src/session/shadowRoot.ts
+++ b/packages/webdriverio/src/session/shadowRoot.ts
@@ -323,9 +323,17 @@ export class ShadowRootManager extends SessionManager {
          * doesn't keep failing the batched check — and degrading every subsequent scoped
          * lookup to per-host round trips — forever. If *every* check failed, the scope
          * itself is probably the stale reference, so don't punish the hosts for it.
+         * `ShadowRootTree.remove()` deletes the whole subtree, so also skip pruning a
+         * stale host while any host nested under it just passed its containment check —
+         * removing the parent would silently drop the healthy child from the tree too.
          */
         if (staleHosts.length > 0 && staleHosts.length < hosts.length) {
+            const containedSet = new Set(containedHosts)
             for (const elementId of staleHosts) {
+                const staleHost = hosts.find((host) => host.element === elementId)
+                if (staleHost && staleHost.flat().some((descendant) => containedSet.has(descendant))) {
+                    continue
+                }
                 log.info(`Pruning stale shadow host ${elementId} from shadow tree of context ${contextId}`)
                 tree.remove(elementId)
             }

--- a/packages/webdriverio/src/session/shadowRoot.ts
+++ b/packages/webdriverio/src/session/shadowRoot.ts
@@ -5,6 +5,7 @@ import type { remote } from 'webdriver'
 
 import { SessionManager } from './session.js'
 import customElementWrapper from '../scripts/customElement.js'
+import { checkElementsContainedIn } from '../utils/elementChecks.js'
 
 const log = logger('webdriverio:ShadowRootManager')
 
@@ -228,7 +229,7 @@ export class ShadowRootManager extends SessionManager {
         throw new Error(`Invalid parameters for "${eventType}" event: ${args.join(', ')}`)
     }
 
-    getShadowElementsByContextId (contextId: string, scope?: string): string[] {
+    async getShadowElementsByContextId (contextId: string, scope?: string): Promise<string[]> {
         let tree = this.#shadowRoots.get(contextId)
         if (!tree) {
             return []
@@ -241,9 +242,20 @@ export class ShadowRootManager extends SessionManager {
          */
         if (scope) {
             const subTree = tree.find(scope)
-            if (subTree) {
-                tree = subTree
+            if (!subTree) {
+                /**
+                 * `scope` is a regular DOM element that isn't itself tracked as a shadow
+                 * host or root, e.g. `$(parent).$(child)` where `parent` is a plain
+                 * wrapper. It may still be a real DOM ancestor of one or more shadow
+                 * hosts further down the light DOM (the tree only tracks hosts/roots,
+                 * not every ancestor), so fall back to a DOM containment check instead
+                 * of assuming `scope` has no shadow descendants at all.
+                 */
+                const containedHosts = await this.#findContainedShadowHosts(contextId, scope)
+                const elements = containedHosts.flatMap((host) => host.getAllLookupScopes())
+                return [...new Set(elements).values()]
             }
+            tree = subTree
         } else {
             /**
              * ensure to include to document root if no scope is provided
@@ -262,7 +274,7 @@ export class ShadowRootManager extends SessionManager {
         ]
     }
 
-    getShadowElementPairsByContextId (contextId: string, scope?: string): [string, string | undefined][] {
+    async getShadowElementPairsByContextId (contextId: string, scope?: string): Promise<[string, string | undefined][]> {
         let tree = this.#shadowRoots.get(contextId)
         if (!tree) {
             return []
@@ -270,12 +282,74 @@ export class ShadowRootManager extends SessionManager {
 
         if (scope) {
             const subTree = tree.find(scope)
-            if (subTree) {
-                tree = subTree
+            if (!subTree) {
+                // see comment in getShadowElementsByContextId for why we check DOM containment
+                const containedHosts = await this.#findContainedShadowHosts(contextId, scope)
+                return containedHosts.flatMap((host) => host.flat().map((t): [string, string | undefined] => [t.element, t.shadowRoot]))
             }
+            tree = subTree
         }
 
         return tree.flat().map((tree) => [tree.element, tree.shadowRoot])
+    }
+
+    /**
+     * Find all tracked shadow hosts that are real DOM descendants of `scope`, even though
+     * `scope` itself isn't tracked in the shadow tree (e.g. a plain wrapper element around
+     * a web component). Hosts nested inside another contained host are excluded since
+     * they're already covered by that host's own (recursive) lookup scopes.
+     */
+    async #findContainedShadowHosts (contextId: string, scope: string): Promise<ShadowRootTree[]> {
+        const tree = this.#shadowRoots.get(contextId)
+        if (!tree) {
+            return []
+        }
+
+        const hosts = tree.flat().filter((t) => t.shadowRoot)
+        if (hosts.length === 0) {
+            return []
+        }
+
+        const staleHosts: string[] = []
+        const containmentResults = await checkElementsContainedIn(
+            this.#browser, scope, hosts.map((host) => host.element), contextId,
+            (elementId) => staleHosts.push(elementId)
+        )
+        const containedHosts = hosts.filter((_, i) => containmentResults[i])
+
+        /**
+         * Prune hosts whose containment check threw (likely GC'd/detached during SPA
+         * navigation without a usable `removeShadowRoot` event) so a single stale entry
+         * doesn't keep failing the batched check — and degrading every subsequent scoped
+         * lookup to per-host round trips — forever. If *every* check failed, the scope
+         * itself is probably the stale reference, so don't punish the hosts for it.
+         */
+        if (staleHosts.length > 0 && staleHosts.length < hosts.length) {
+            for (const elementId of staleHosts) {
+                log.info(`Pruning stale shadow host ${elementId} from shadow tree of context ${contextId}`)
+                tree.remove(elementId)
+            }
+        }
+
+        /**
+         * Drop hosts that are already covered by another contained host's own subtree,
+         * to avoid returning the same nested shadow root twice. `hosts`/`containedHosts`
+         * are in pre-order (parents before children, per `ShadowRootTree.flat()`), so a
+         * single forward pass suffices — track already-covered descendants and skip any
+         * host that's already in that set, instead of comparing every pair.
+         */
+        const covered = new Set<ShadowRootTree>()
+        const topLevelContained: ShadowRootTree[] = []
+        for (const host of containedHosts) {
+            if (covered.has(host)) {
+                continue
+            }
+            topLevelContained.push(host)
+            for (const descendant of host.flat()) {
+                covered.add(descendant)
+            }
+        }
+        return topLevelContained
     }
 
     getShadowRootModeById (contextId: string, element: string): ShadowRootMode | undefined {

--- a/packages/webdriverio/src/utils/elementChecks.ts
+++ b/packages/webdriverio/src/utils/elementChecks.ts
@@ -1,0 +1,110 @@
+import { ELEMENT_KEY } from 'webdriver'
+import logger from '@wdio/logger'
+
+import elementContains from '../scripts/elementContains.js'
+import elementsContainedIn from '../scripts/elementsContainedIn.js'
+import elementsConnected from '../scripts/elementsConnected.js'
+
+const log = logger('webdriverio')
+
+/**
+ * Run a boolean check for each of `elementIds` in a single batched round trip; if the
+ * batch itself fails outright (e.g. one reference is stale and poisons argument
+ * deserialization), fall back to checking each element individually so one bad
+ * reference doesn't hide every other result. Either way, a failure is logged instead
+ * of being silently swallowed, and a per-element failure resolves to `false`.
+ *
+ * Note: the browser-side scripts must stay separate, self-contained functions because
+ * `browser.execute()` serializes only the passed function's own source text — only
+ * this Node-side orchestration is shared between the different check types.
+ */
+async function runBatchedElementCheck (
+    elementIds: string[],
+    checkName: string,
+    contextId: string | undefined,
+    onElementCheckError: ((elementId: string) => void) | undefined,
+    batchCheck: () => Promise<boolean[]>,
+    perElementCheck: (elementId: string) => Promise<boolean>
+): Promise<boolean[]> {
+    if (elementIds.length === 0) {
+        return []
+    }
+
+    const inContext = contextId ? ` in context ${contextId}` : ''
+    try {
+        return await batchCheck()
+    } catch (err) {
+        log.warn(`Failed to batch-check element ${checkName}${inContext}: ${(err as Error).message}. Falling back to per-element checks.`)
+    }
+
+    return Promise.all(elementIds.map(async (elementId) => {
+        try {
+            return await perElementCheck(elementId)
+        } catch (err) {
+            /**
+             * this specific element is likely stale/detached; log so it's visible but
+             * don't fail the whole lookup for it
+             */
+            log.warn(`Failed to check element ${checkName} for element ${elementId}${inContext}: ${(err as Error).message}`)
+            onElementCheckError?.(elementId)
+            return false
+        }
+    }))
+}
+
+/**
+ * Check, for each of `elementIds`, whether it's a real DOM descendant of `scope`
+ * (crossing shadow boundaries via `.host`), in a single round trip with per-element
+ * fallback.
+ */
+export async function checkElementsContainedIn (
+    browser: WebdriverIO.Browser,
+    scope: string,
+    elementIds: string[],
+    contextId?: string,
+    onElementCheckError?: (elementId: string) => void
+): Promise<boolean[]> {
+    return runBatchedElementCheck(
+        elementIds,
+        `containment for scope ${scope}`,
+        contextId,
+        onElementCheckError,
+        () => browser.execute(
+            elementsContainedIn,
+            { [ELEMENT_KEY]: scope } as unknown as HTMLElement,
+            elementIds.map((elementId) => ({ [ELEMENT_KEY]: elementId })) as unknown as HTMLElement[]
+        ),
+        (elementId) => browser.execute(
+            elementContains,
+            { [ELEMENT_KEY]: scope } as unknown as HTMLElement,
+            { [ELEMENT_KEY]: elementId } as unknown as HTMLElement
+        )
+    )
+}
+
+/**
+ * Check, for each of `elementIds`, whether it's still connected to the live DOM,
+ * in a single round trip with per-element fallback. Stale references that can't be
+ * resolved at all count as not connected.
+ */
+export async function checkElementsConnected (
+    browser: WebdriverIO.Browser,
+    elementIds: string[],
+    contextId?: string,
+    onElementCheckError?: (elementId: string) => void
+): Promise<boolean[]> {
+    return runBatchedElementCheck(
+        elementIds,
+        'connectivity',
+        contextId,
+        onElementCheckError,
+        () => browser.execute(
+            elementsConnected,
+            elementIds.map((elementId) => ({ [ELEMENT_KEY]: elementId })) as unknown as HTMLElement[]
+        ),
+        (elementId) => browser.execute(
+            (el: Element) => el.isConnected,
+            { [ELEMENT_KEY]: elementId } as unknown as HTMLElement
+        )
+    )
+}

--- a/packages/webdriverio/src/utils/elementChecks.ts
+++ b/packages/webdriverio/src/utils/elementChecks.ts
@@ -32,7 +32,16 @@ async function runBatchedElementCheck (
 
     const inContext = contextId ? ` in context ${contextId}` : ''
     try {
-        return await batchCheck()
+        const result = await batchCheck()
+        /**
+         * guard against a driver returning a malformed batch result: downstream
+         * callers filter by index, so a short array would silently treat the
+         * missing tail as `false` and drop valid elements
+         */
+        if (!Array.isArray(result) || result.length !== elementIds.length) {
+            throw new Error(`expected ${elementIds.length} result(s) but got ${Array.isArray(result) ? result.length : typeof result}`)
+        }
+        return result
     } catch (err) {
         log.warn(`Failed to batch-check element ${checkName}${inContext}: ${(err as Error).message}. Falling back to per-element checks.`)
     }

--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -9,8 +9,8 @@ import type { ElementReference } from '@wdio/protocols'
 
 import * as browserCommands from '../commands/browser.js'
 import * as elementCommands from '../commands/element.js'
-import elementContains from '../scripts/elementContains.js'
 import querySelectorAllDeep from './thirdParty/querySelectorShadowDom.js'
+import { checkElementsContainedIn, checkElementsConnected } from './elementChecks.js'
 import { SCRIPT_PREFIX, SCRIPT_SUFFIX } from '../commands/constant.js'
 import { DEEP_SELECTOR, Key } from '../constants.js'
 import { findStrategy } from './findStrategy.js'
@@ -312,7 +312,7 @@ export async function findDeepElement(
     const contextManager = getContextManager(browser)
     const context = await contextManager.getCurrentContext()
 
-    const shadowRoots = shadowRootManager.getShadowElementsByContextId(
+    const shadowRoots = await shadowRootManager.getShadowElementsByContextId(
         context,
         (this as WebdriverIO.Element).elementId
     )
@@ -330,12 +330,21 @@ export async function findDeepElement(
     const locator = transformClassicToBidiSelector(using, value)
 
     /**
-     * look up selector within document and all shadow roots
+     * Look up selector within document/scope and all shadow roots found under it.
+     * When scoped to an element, always include the element itself alongside any
+     * shadow roots — otherwise a plain light-DOM descendant of a scope that also
+     * happens to contain (or be) a shadow host would never be searched, since
+     * shadow roots don't automatically get pierced from a plain startNode and vice
+     * versa. Extra candidates from the scope itself are safe: they're narrowed
+     * back down by the containment check below.
      */
-    const startNodes = shadowRoots.length > 0
-        ? shadowRoots.map((shadowRootNodeId) => ({ sharedId: shadowRootNodeId }))
-        : (this as WebdriverIO.Element).elementId
-            ? [{ sharedId: (this as WebdriverIO.Element).elementId }]
+    const startNodes = (this as WebdriverIO.Element).elementId
+        ? [
+            { sharedId: (this as WebdriverIO.Element).elementId },
+            ...shadowRoots.map((shadowRootNodeId) => ({ sharedId: shadowRootNodeId }))
+        ]
+        : shadowRoots.length > 0
+            ? shadowRoots.map((shadowRootNodeId) => ({ sharedId: shadowRootNodeId }))
             : undefined
     const deepElementResult = await browser.browsingContextLocateNodes({ locator, context, startNodes }).then(async (result) => {
         let nodes: ExtendedElementReference[] = result.nodes.filter((node) => Boolean(node.sharedId)).map((node) => ({
@@ -353,14 +362,16 @@ export async function findDeepElement(
              * to return references to elements in detached DOM trees.
              */
             if (shadowRoots.length > 0 && nodes.length > 0) {
-                for (const node of nodes) {
-                    try {
-                        const connected = await browser.execute((el: Element) => el.isConnected, node as unknown as HTMLElement)
-                        if (connected) { return node }
-                        shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
-                    } catch {
+                const connected = await checkElementsConnected(
+                    browser, nodes.map((node) => node[ELEMENT_KEY] as string), context)
+                nodes.forEach((node, i) => {
+                    if (!connected[i]) {
                         shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
                     }
+                })
+                const firstConnected = nodes.find((_, i) => connected[i])
+                if (firstConnected) {
+                    return firstConnected
                 }
                 log.warn(`All ${nodes.length} BiDi results for "${value}" are detached, removed stale entries from shadow root tree`)
                 return undefined
@@ -369,21 +380,15 @@ export async function findDeepElement(
         }
 
         /**
-         * determine if node is within tree of current element
+         * determine if node is within tree of current element (batched into a single
+         * round trip, with per-element fallback for stale references)
          */
-        const scopedNodes = await Promise.all(nodes.map(async (node) => {
-            try {
-                const isIn = await browser.execute(
-                    elementContains,
-                    { [ELEMENT_KEY]: (this as WebdriverIO.Element).elementId } as unknown as HTMLElement,
-                    node as unknown as HTMLElement
-                )
-                return [isIn, node]
-            } catch {
-                // Element reference may be stale from detached shadow root, skip
-                return [false, node]
-            }
-        })).then((elems) => elems.filter(([isIn]) => isIn).map(([, elem]) => elem)) as ExtendedElementReference[]
+        const containment = await checkElementsContainedIn(
+            browser,
+            (this as WebdriverIO.Element).elementId,
+            nodes.map((node) => node[ELEMENT_KEY] as string)
+        )
+        const scopedNodes = nodes.filter((_, i) => containment[i])
 
         /**
          * Validate that the first scoped node is connected to the live DOM.
@@ -392,14 +397,16 @@ export async function findDeepElement(
          * references for script execution, causing false "stale" detection.
          */
         if (shadowRoots.length > 0) {
-            for (const node of scopedNodes) {
-                try {
-                    const connected = await browser.execute((el: Element) => el.isConnected, node as unknown as HTMLElement)
-                    if (connected) { return node }
-                    shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
-                } catch {
+            const connected = await checkElementsConnected(
+                browser, scopedNodes.map((node) => node[ELEMENT_KEY] as string), context)
+            scopedNodes.forEach((node, i) => {
+                if (!connected[i]) {
                     shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
                 }
+            })
+            const firstConnected = scopedNodes.find((_, i) => connected[i])
+            if (firstConnected) {
+                return firstConnected
             }
             if (scopedNodes.length > 0) {
                 log.warn(`All ${scopedNodes.length} scoped BiDi results for "${value}" are detached, removed stale entries from shadow root tree`)
@@ -433,7 +440,7 @@ export async function findDeepElements(
     const contextManager = getContextManager(browser)
     const context = await contextManager.getCurrentContext()
 
-    const shadowRoots = shadowRootManager.getShadowElementsByContextId(
+    const shadowRoots = await shadowRootManager.getShadowElementsByContextId(
         context,
         (this as WebdriverIO.Element).elementId
     )
@@ -451,12 +458,21 @@ export async function findDeepElements(
     const locator = transformClassicToBidiSelector(using, value)
 
     /**
-     * look up selector within document and all shadow roots
+     * Look up selector within document/scope and all shadow roots found under it.
+     * When scoped to an element, always include the element itself alongside any
+     * shadow roots — otherwise a plain light-DOM descendant of a scope that also
+     * happens to contain (or be) a shadow host would never be searched, since
+     * shadow roots don't automatically get pierced from a plain startNode and vice
+     * versa. Extra candidates from the scope itself are safe: they're narrowed
+     * back down by the containment check below.
      */
-    const startNodes = shadowRoots.length > 0
-        ? shadowRoots.map((shadowRootNodeId) => ({ sharedId: shadowRootNodeId }))
-        : (this as WebdriverIO.Element).elementId
-            ? [{ sharedId: (this as WebdriverIO.Element).elementId }]
+    const startNodes = (this as WebdriverIO.Element).elementId
+        ? [
+            { sharedId: (this as WebdriverIO.Element).elementId },
+            ...shadowRoots.map((shadowRootNodeId) => ({ sharedId: shadowRootNodeId }))
+        ]
+        : shadowRoots.length > 0
+            ? shadowRoots.map((shadowRootNodeId) => ({ sharedId: shadowRootNodeId }))
             : undefined
     const deepElementResult = await browser.browsingContextLocateNodes({ locator, context, startNodes }).then(async (result) => {
         let nodes: ExtendedElementReference[] = result.nodes.filter((node) => Boolean(node.sharedId))
@@ -473,19 +489,14 @@ export async function findDeepElements(
              * from detached DOM trees (common in SPA client-side navigation).
              */
             if (shadowRoots.length > 0 && nodes.length > 0) {
-                const validNodes: ExtendedElementReference[] = []
-                for (const node of nodes) {
-                    try {
-                        const connected = await browser.execute((el: Element) => el.isConnected, node as unknown as HTMLElement)
-                        if (connected) {
-                            validNodes.push(node)
-                        } else {
-                            shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
-                        }
-                    } catch {
+                const connected = await checkElementsConnected(
+                    browser, nodes.map((node) => node[ELEMENT_KEY] as string), context)
+                nodes.forEach((node, i) => {
+                    if (!connected[i]) {
                         shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
                     }
-                }
+                })
+                const validNodes = nodes.filter((_, i) => connected[i])
                 if (validNodes.length > 0) { return validNodes }
                 // All BiDi results are detached, fall back to Classic WebDriver
                 return []
@@ -494,21 +505,15 @@ export async function findDeepElements(
         }
 
         /**
-         * determine if node is within tree of current element
+         * determine if node is within tree of current element (batched into a single
+         * round trip, with per-element fallback for stale references)
          */
-        const scopedNodes = await Promise.all(nodes.map(async (node) => {
-            try {
-                const isIn = await browser.execute(
-                    elementContains,
-                    { [ELEMENT_KEY]: (this as WebdriverIO.Element).elementId } as unknown as HTMLElement,
-                    node as unknown as HTMLElement
-                )
-                return [isIn, node]
-            } catch {
-                // Element reference may be stale from detached shadow root, skip
-                return [false, node]
-            }
-        })).then((elems) => elems.filter(([isIn]) => isIn).map(([, elem]) => elem))
+        const containment = await checkElementsContainedIn(
+            browser,
+            (this as WebdriverIO.Element).elementId,
+            nodes.map((node) => node[ELEMENT_KEY] as string)
+        )
+        const scopedNodes = nodes.filter((_, i) => containment[i])
 
         /**
          * Filter out detached scoped nodes. Only needed when shadow roots are
@@ -517,19 +522,14 @@ export async function findDeepElements(
          * causing false "stale" detection and an empty result.
          */
         if (shadowRoots.length > 0) {
-            const connectedScopedNodes: ExtendedElementReference[] = []
-            for (const node of scopedNodes) {
-                try {
-                    const connected = await browser.execute((el: Element) => el.isConnected, node as unknown as HTMLElement)
-                    if (connected) {
-                        connectedScopedNodes.push(node as ExtendedElementReference)
-                    } else {
-                        shadowRootManager.deleteShadowRoot((node as unknown as Record<string, string>)[ELEMENT_KEY], context)
-                    }
-                } catch {
-                    shadowRootManager.deleteShadowRoot((node as unknown as Record<string, string>)[ELEMENT_KEY], context)
+            const connected = await checkElementsConnected(
+                browser, scopedNodes.map((node) => node[ELEMENT_KEY] as string), context)
+            scopedNodes.forEach((node, i) => {
+                if (!connected[i]) {
+                    shadowRootManager.deleteShadowRoot(node[ELEMENT_KEY] as string, context)
                 }
-            }
+            })
+            const connectedScopedNodes = scopedNodes.filter((_, i) => connected[i])
             if (connectedScopedNodes.length > 0) { return connectedScopedNodes }
             if (scopedNodes.length > 0) {
                 return []

--- a/packages/webdriverio/tests/shadowRoot.test.ts
+++ b/packages/webdriverio/tests/shadowRoot.test.ts
@@ -452,6 +452,89 @@ describe('ShadowRootManager', () => {
         expect(executeMock.mock.calls[3][2]).toHaveLength(1)
     })
 
+    it('should fall back to per-element checks when the batched check returns a malformed result', async () => {
+        // batch resolves but returns 1 result for 2 hosts (buggy driver) — the
+        // helper must treat that as a batch failure and fall back per-element
+        const executeMock = vi.fn()
+            .mockResolvedValueOnce([true])   // malformed batch: wrong length
+            .mockResolvedValueOnce(true)     // per-host hostM → contained
+            .mockResolvedValueOnce(false)    // per-host hostN → not contained
+        const browser = { ...defaultBrowser, execute: executeMock } as any
+        const manager = getShadowRootManager(browser)
+
+        for (const [host, shadow] of [['hostM', 'shadowM'], ['hostN', 'shadowN']]) {
+            manager.handleLogEntry({
+                level: 'debug',
+                args: [
+                    { type: 'string', value: '[WDIO]' },
+                    { type: 'string', value: 'newShadowRoot' },
+                    { type: 'node', sharedId: host, value: {
+                        shadowRoot: { sharedId: shadow, value: { nodeType: 11, mode: 'open' } }
+                    } },
+                    { type: 'node', sharedId: 'docRoot' },
+                    { type: 'boolean', value: false },
+                    { type: 'node', sharedId: 'docRoot' }
+                ],
+                source: { context: 'malformedCtx' }
+            } as any)
+        }
+
+        const result = await manager.getShadowElementsByContextId('malformedCtx', 'wrapperDiv')
+        expect(result).toEqual(['shadowM'])
+        // 1 malformed batched call + 2 per-host fallback calls
+        expect(executeMock).toHaveBeenCalledTimes(3)
+    })
+
+    it('should not prune a stale host while a host nested under it passed its containment check', async () => {
+        // batch fails; per-host fallback: outer host throws (stale reference)
+        // but the inner host nested in its shadow root is alive and contained.
+        // Pruning the outer host would remove the healthy inner host with it.
+        const executeMock = vi.fn()
+            .mockRejectedValueOnce(new Error('stale host poisons batch'))  // 1st batch
+            .mockRejectedValueOnce(new Error('stale element reference'))   // per-host outerHost (pre-order first)
+            .mockResolvedValueOnce(true)                                   // per-host innerHost → contained
+            .mockImplementation((_script: unknown, _scope: unknown, elements: unknown[]) => (
+                Promise.resolve((elements as unknown[]).map(() => true))   // later batches succeed
+            ))
+        const browser = { ...defaultBrowser, execute: executeMock } as any
+        const manager = getShadowRootManager(browser)
+
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'outerHost', value: {
+                    shadowRoot: { sharedId: 'outerShadow', value: { nodeType: 11, mode: 'open' } }
+                } },
+                { type: 'node', sharedId: 'docRoot' }
+            ],
+            source: { context: 'nestedPruneCtx' }
+        } as any)
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'innerHost', value: {
+                    shadowRoot: { sharedId: 'innerShadow', value: { nodeType: 11, mode: 'open' } }
+                } },
+                { type: 'node', sharedId: 'outerShadow' },
+                { type: 'boolean', value: false },
+                { type: 'node', sharedId: 'docRoot' }
+            ],
+            source: { context: 'nestedPruneCtx' }
+        } as any)
+
+        const first = await manager.getShadowElementsByContextId('nestedPruneCtx', 'wrapperDiv')
+        expect(first).toEqual(['innerShadow'])
+
+        // outerHost must NOT have been pruned (its subtree holds the healthy
+        // innerHost) — both are still tracked on the next lookup
+        const second = await manager.getShadowElementsByContextId('nestedPruneCtx', 'wrapperDiv')
+        expect(second).toEqual(['outerShadow', 'innerShadow'])
+    })
+
     it('should not prune any host when every containment check fails (scope itself is likely stale)', async () => {
         const executeMock = vi.fn()
             .mockRejectedValueOnce(new Error('batch fails'))

--- a/packages/webdriverio/tests/shadowRoot.test.ts
+++ b/packages/webdriverio/tests/shadowRoot.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, vi, expect, beforeEach } from 'vitest'
+import logger from '@wdio/logger'
 
 import { getShadowRootManager, ShadowRootTree } from '../src/session/shadowRoot.js'
 
@@ -58,7 +59,7 @@ describe('ShadowRootManager', () => {
         expect(browser.scriptAddPreloadScript).toBeCalledTimes(0)
     })
 
-    it('should capture shadow root elements', () => {
+    it('should capture shadow root elements', async () => {
         const browser = { ...defaultBrowser } as any
         const manager = getShadowRootManager(browser)
         manager.handleLogEntry({
@@ -79,15 +80,15 @@ describe('ShadowRootManager', () => {
             ],
             source: { context: 'foobarContext' }
         } as any)
-        expect(manager.getShadowElementsByContextId('foobarContext')).toEqual(['barfoo', 'shadowFoobar'])
+        expect(await manager.getShadowElementsByContextId('foobarContext')).toEqual(['barfoo', 'shadowFoobar'])
         expect(manager.getShadowRootModeById('foobarContext', 'foobar')).toBe('closed')
-        expect(manager.getShadowElementPairsByContextId('foobarContext')).toEqual([
+        expect(await manager.getShadowElementPairsByContextId('foobarContext')).toEqual([
             ['barfoo', undefined],
             ['foobar', 'shadowFoobar']
         ])
     })
 
-    it('should ignore log entries that are not of interest', () => {
+    it('should ignore log entries that are not of interest', async () => {
         const browser = { ...defaultBrowser } as any
         const manager = getShadowRootManager(browser)
         manager.handleLogEntry({
@@ -100,7 +101,7 @@ describe('ShadowRootManager', () => {
             ],
             source: { context: 'foobarContext' }
         } as any)
-        expect(manager.getShadowElementsByContextId('foobarContext')).toEqual([])
+        expect(await manager.getShadowElementsByContextId('foobarContext')).toEqual([])
     })
 
     it('should throw if log entry is invalid', () => {
@@ -118,7 +119,7 @@ describe('ShadowRootManager', () => {
         } as any)).toThrow()
     })
 
-    it('should handle removeShadowRoot without sharedId gracefully', () => {
+    it('should handle removeShadowRoot without sharedId gracefully', async () => {
         const browser = { ...defaultBrowser } as any
         const manager = getShadowRootManager(browser)
         // First register a shadow root
@@ -140,7 +141,7 @@ describe('ShadowRootManager', () => {
             ],
             source: { context: 'spaContext' }
         } as any)
-        expect(manager.getShadowElementsByContextId('spaContext')).toContain('shadow1')
+        expect(await manager.getShadowElementsByContextId('spaContext')).toContain('shadow1')
 
         // removeShadowRoot without sharedId (element GC'd in SPA navigation)
         // should NOT throw
@@ -155,7 +156,7 @@ describe('ShadowRootManager', () => {
         } as any)).not.toThrow()
     })
 
-    it('should remove shadow root when removeShadowRoot has valid sharedId', () => {
+    it('should remove shadow root when removeShadowRoot has valid sharedId', async () => {
         const browser = { ...defaultBrowser } as any
         const manager = getShadowRootManager(browser)
         // Register a shadow root
@@ -177,7 +178,7 @@ describe('ShadowRootManager', () => {
             ],
             source: { context: 'removeContext' }
         } as any)
-        expect(manager.getShadowElementsByContextId('removeContext')).toContain('shadowA')
+        expect(await manager.getShadowElementsByContextId('removeContext')).toContain('shadowA')
 
         // removeShadowRoot with valid sharedId
         manager.handleLogEntry({
@@ -189,10 +190,10 @@ describe('ShadowRootManager', () => {
             ],
             source: { context: 'removeContext' }
         } as any)
-        expect(manager.getShadowElementsByContextId('removeContext')).not.toContain('shadowA')
+        expect(await manager.getShadowElementsByContextId('removeContext')).not.toContain('shadowA')
     })
 
-    it('should purge old shadow roots when document ID changes', () => {
+    it('should purge old shadow roots when document ID changes', async () => {
         const browser = { ...defaultBrowser } as any
         const manager = getShadowRootManager(browser)
         const handleLogEntry = manager.handleLogEntry.bind(manager)
@@ -211,7 +212,7 @@ describe('ShadowRootManager', () => {
             ]
         } as any)
 
-        let elements = manager.getShadowElementsByContextId('ctx1')
+        let elements = await manager.getShadowElementsByContextId('ctx1')
         expect(elements.length).toBeGreaterThan(0)
 
         // Register shadow root with NEW document B → should purge old entries
@@ -228,7 +229,7 @@ describe('ShadowRootManager', () => {
             ]
         } as any)
 
-        elements = manager.getShadowElementsByContextId('ctx1')
+        elements = await manager.getShadowElementsByContextId('ctx1')
         // Should only contain elements from document B, not document A
         const hasDocA = elements.some(e => e.includes('AAAA0000'))
         const hasDocB = elements.some(e => e.includes('BBBB0000'))
@@ -236,7 +237,7 @@ describe('ShadowRootManager', () => {
         expect(hasDocB).toBe(true)
     })
 
-    it('should not purge when document ID stays the same', () => {
+    it('should not purge when document ID stays the same', async () => {
         const browser = { ...defaultBrowser } as any
         const manager = getShadowRootManager(browser)
         const handleLogEntry = manager.handleLogEntry.bind(manager)
@@ -268,9 +269,283 @@ describe('ShadowRootManager', () => {
             ]
         } as any)
 
-        const elements = manager.getShadowElementsByContextId('ctx1')
+        const elements = await manager.getShadowElementsByContextId('ctx1')
         // Should have both elements since same document
         expect(elements.filter(e => e.includes('AAAA0000')).length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('should return [] when scope is unrelated to any shadow tree (regression test for the original bug)', async () => {
+        // batched containment check: report every candidate host as NOT contained
+        const executeMock = vi.fn().mockImplementation((_script: unknown, _scope: unknown, elements: unknown[]) => (
+            Promise.resolve(elements.map(() => false))
+        ))
+        const browser = { ...defaultBrowser, execute: executeMock } as any
+        const manager = getShadowRootManager(browser)
+
+        // register an unrelated closed shadow root elsewhere in the document
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'closedHost', value: {
+                    shadowRoot: { sharedId: 'closedShadowRoot', value: { nodeType: 11, mode: 'closed' } }
+                } },
+                { type: 'node', sharedId: 'docRoot' }
+            ],
+            source: { context: 'unrelatedCtx' }
+        } as any)
+
+        // scope is a regular DOM element with no shadow-host descendants at all
+        const result = await manager.getShadowElementsByContextId('unrelatedCtx', 'someUnrelatedElement')
+        expect(result).toEqual([])
+        expect(executeMock).toHaveBeenCalled()
+    })
+
+    it('should include a nested shadow host when scope is a plain DOM ancestor containing it', async () => {
+        // batched containment check: report every candidate host as contained
+        const executeMock = vi.fn().mockImplementation((_script: unknown, _scope: unknown, elements: unknown[]) => (
+            Promise.resolve(elements.map(() => true))
+        ))
+        const browser = { ...defaultBrowser, execute: executeMock } as any
+        const manager = getShadowRootManager(browser)
+
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'myWidget', value: {
+                    shadowRoot: { sharedId: 'myWidgetShadow', value: { nodeType: 11, mode: 'open' } }
+                } },
+                { type: 'node', sharedId: 'docRoot' }
+            ],
+            source: { context: 'wrapperCtx' }
+        } as any)
+
+        // 'wrapperDiv' is a plain container that is never itself registered as a tree
+        // node, but is confirmed (via the mocked DOM containment check) to contain
+        // 'myWidget' further down the light DOM
+        const result = await manager.getShadowElementsByContextId('wrapperCtx', 'wrapperDiv')
+        expect(result).toEqual(['myWidgetShadow'])
+
+        const pairs = await manager.getShadowElementPairsByContextId('wrapperCtx', 'wrapperDiv')
+        expect(pairs).toEqual([['myWidget', 'myWidgetShadow']])
+    })
+
+    it('should not duplicate a nested shadow host already covered by a contained ancestor host', async () => {
+        // batched containment check: report every candidate host as contained
+        const executeMock = vi.fn().mockImplementation((_script: unknown, _scope: unknown, elements: unknown[]) => (
+            Promise.resolve(elements.map(() => true))
+        ))
+        const browser = { ...defaultBrowser, execute: executeMock } as any
+        const manager = getShadowRootManager(browser)
+
+        // outer host with its own shadow root
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'outerHost', value: {
+                    shadowRoot: { sharedId: 'outerShadow', value: { nodeType: 11, mode: 'open' } }
+                } },
+                { type: 'node', sharedId: 'docRoot' }
+            ],
+            source: { context: 'nestedCtx' }
+        } as any)
+        // inner host nested inside outerHost's own shadow root
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'innerHost', value: {
+                    shadowRoot: { sharedId: 'innerShadow', value: { nodeType: 11, mode: 'open' } }
+                } },
+                { type: 'node', sharedId: 'outerShadow' },
+                { type: 'boolean', value: false },
+                { type: 'node', sharedId: 'docRoot' }
+            ],
+            source: { context: 'nestedCtx' }
+        } as any)
+
+        const result = await manager.getShadowElementsByContextId('nestedCtx', 'wrapperDiv')
+        // outerHost's own lookup scopes already recursively include innerShadow;
+        // innerHost must not be listed a second time as an independent contained host
+        expect(result).toEqual(['outerShadow', 'innerShadow'])
+        expect(new Set(result).size).toBe(result.length)
+    })
+
+    it('should check containment for multiple hosts in a single batched execute call', async () => {
+        const executeMock = vi.fn().mockImplementation((_script: unknown, _scope: unknown, elements: unknown[]) => (
+            Promise.resolve(elements.map(() => true))
+        ))
+        const browser = { ...defaultBrowser, execute: executeMock } as any
+        const manager = getShadowRootManager(browser)
+
+        // three independent (non-nested) hosts anywhere in the document
+        for (const [host, shadow] of [['hostA', 'shadowA'], ['hostB', 'shadowB'], ['hostC', 'shadowC']]) {
+            manager.handleLogEntry({
+                level: 'debug',
+                args: [
+                    { type: 'string', value: '[WDIO]' },
+                    { type: 'string', value: 'newShadowRoot' },
+                    { type: 'node', sharedId: host, value: {
+                        shadowRoot: { sharedId: shadow, value: { nodeType: 11, mode: 'open' } }
+                    } },
+                    { type: 'node', sharedId: 'docRoot' },
+                    { type: 'boolean', value: false },
+                    { type: 'node', sharedId: 'docRoot' }
+                ],
+                source: { context: 'batchCtx' }
+            } as any)
+        }
+
+        const result = await manager.getShadowElementsByContextId('batchCtx', 'wrapperDiv')
+        expect(result).toEqual(['shadowA', 'shadowB', 'shadowC'])
+        // a single round trip should check containment for all 3 hosts at once,
+        // instead of one execute() call per host
+        expect(executeMock).toHaveBeenCalledTimes(1)
+        expect(executeMock.mock.calls[0][2]).toHaveLength(3)
+    })
+
+    it('should prune a stale host after its per-host fallback check throws, so later batches recover', async () => {
+        // batch fails (stale host poisons it), per-host fallback: hostGood is
+        // contained, hostStale throws → hostStale must be pruned from the tree
+        // so the NEXT lookup's batch only contains hostGood and succeeds again
+        const executeMock = vi.fn()
+            .mockRejectedValueOnce(new Error('stale host poisons batch'))       // 1st batch
+            .mockResolvedValueOnce(true)                                        // per-host hostGood
+            .mockRejectedValueOnce(new Error('stale element reference'))        // per-host hostStale
+            .mockImplementation((_script: unknown, _scope: unknown, elements: unknown[]) => (
+                Promise.resolve((elements as unknown[]).map(() => true))        // 2nd batch succeeds
+            ))
+        const browser = { ...defaultBrowser, execute: executeMock } as any
+        const manager = getShadowRootManager(browser)
+
+        for (const [host, shadow] of [['hostGood', 'shadowGood'], ['hostStale', 'shadowStale']]) {
+            manager.handleLogEntry({
+                level: 'debug',
+                args: [
+                    { type: 'string', value: '[WDIO]' },
+                    { type: 'string', value: 'newShadowRoot' },
+                    { type: 'node', sharedId: host, value: {
+                        shadowRoot: { sharedId: shadow, value: { nodeType: 11, mode: 'open' } }
+                    } },
+                    { type: 'node', sharedId: 'docRoot' },
+                    { type: 'boolean', value: false },
+                    { type: 'node', sharedId: 'docRoot' }
+                ],
+                source: { context: 'pruneCtx' }
+            } as any)
+        }
+
+        const first = await manager.getShadowElementsByContextId('pruneCtx', 'wrapperDiv')
+        expect(first).toEqual(['shadowGood'])
+
+        // stale host was pruned: the next call goes back to a single successful
+        // batched round trip over the remaining host only
+        const second = await manager.getShadowElementsByContextId('pruneCtx', 'wrapperDiv')
+        expect(second).toEqual(['shadowGood'])
+        expect(executeMock).toHaveBeenCalledTimes(4)
+        expect(executeMock.mock.calls[3][2]).toHaveLength(1)
+    })
+
+    it('should not prune any host when every containment check fails (scope itself is likely stale)', async () => {
+        const executeMock = vi.fn()
+            .mockRejectedValueOnce(new Error('batch fails'))
+            .mockRejectedValueOnce(new Error('scope is stale'))
+            .mockRejectedValueOnce(new Error('scope is stale'))
+            .mockImplementation((_script: unknown, _scope: unknown, elements: unknown[]) => (
+                Promise.resolve((elements as unknown[]).map(() => true))
+            ))
+        const browser = { ...defaultBrowser, execute: executeMock } as any
+        const manager = getShadowRootManager(browser)
+
+        for (const [host, shadow] of [['hostX', 'shadowX'], ['hostY', 'shadowY']]) {
+            manager.handleLogEntry({
+                level: 'debug',
+                args: [
+                    { type: 'string', value: '[WDIO]' },
+                    { type: 'string', value: 'newShadowRoot' },
+                    { type: 'node', sharedId: host, value: {
+                        shadowRoot: { sharedId: shadow, value: { nodeType: 11, mode: 'open' } }
+                    } },
+                    { type: 'node', sharedId: 'docRoot' },
+                    { type: 'boolean', value: false },
+                    { type: 'node', sharedId: 'docRoot' }
+                ],
+                source: { context: 'staleScopeCtx' }
+            } as any)
+        }
+
+        const first = await manager.getShadowElementsByContextId('staleScopeCtx', 'staleWrapper')
+        expect(first).toEqual([])
+
+        // both hosts must still be tracked — a later lookup with a healthy scope
+        // sees both again
+        const second = await manager.getShadowElementsByContextId('staleScopeCtx', 'healthyWrapper')
+        expect(second).toEqual(['shadowX', 'shadowY'])
+    })
+
+    it('should only return scopes of hosts the containment check marks as contained (index alignment)', async () => {
+        // hostA is contained in the scope, hostB is not — a misaligned batch
+        // result would leak hostB's shadow root (or drop hostA's)
+        const executeMock = vi.fn().mockResolvedValue([true, false])
+        const browser = { ...defaultBrowser, execute: executeMock } as any
+        const manager = getShadowRootManager(browser)
+
+        for (const [host, shadow] of [['hostA', 'shadowA'], ['hostB', 'shadowB']]) {
+            manager.handleLogEntry({
+                level: 'debug',
+                args: [
+                    { type: 'string', value: '[WDIO]' },
+                    { type: 'string', value: 'newShadowRoot' },
+                    { type: 'node', sharedId: host, value: {
+                        shadowRoot: { sharedId: shadow, value: { nodeType: 11, mode: 'open' } }
+                    } },
+                    { type: 'node', sharedId: 'docRoot' },
+                    { type: 'boolean', value: false },
+                    { type: 'node', sharedId: 'docRoot' }
+                ],
+                source: { context: 'mixedCtx' }
+            } as any)
+        }
+
+        const elements = await manager.getShadowElementsByContextId('mixedCtx', 'wrapperDiv')
+        expect(elements).toEqual(['shadowA'])
+
+        const pairs = await manager.getShadowElementPairsByContextId('mixedCtx', 'wrapperDiv')
+        expect(pairs).toEqual([['hostA', 'shadowA']])
+    })
+
+    it('should fall back to per-host containment checks and log a warning when the batched check fails', async () => {
+        const executeMock = vi.fn()
+            .mockRejectedValueOnce(new Error('scope is stale'))
+            .mockResolvedValue(true)
+        const browser = { ...defaultBrowser, execute: executeMock } as any
+        const manager = getShadowRootManager(browser)
+        const warnSpy = vi.spyOn(logger('webdriverio'), 'warn')
+
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'myWidget', value: {
+                    shadowRoot: { sharedId: 'myWidgetShadow', value: { nodeType: 11, mode: 'open' } }
+                } },
+                { type: 'node', sharedId: 'docRoot' }
+            ],
+            source: { context: 'fallbackCtx' }
+        } as any)
+
+        const result = await manager.getShadowElementsByContextId('fallbackCtx', 'wrapperDiv')
+        expect(result).toEqual(['myWidgetShadow'])
+        // 1 failed batched call + 1 successful per-host fallback call
+        expect(executeMock).toHaveBeenCalledTimes(2)
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Falling back to per-element checks'))
     })
 
 })

--- a/packages/webdriverio/tests/utils/findDeepElement.test.ts
+++ b/packages/webdriverio/tests/utils/findDeepElement.test.ts
@@ -73,10 +73,9 @@ describe('findDeepElement - isConnected validation', () => {
                 { sharedId: 'node-detached-2' },
             ],
         })
-        // First node: detached, second: connected, third: never reached
+        // isConnected (batched): first detached, second connected, third detached
         browser.execute
-            .mockResolvedValueOnce(false)  // node-detached-1 → not connected
-            .mockResolvedValueOnce(true)   // node-connected → connected
+            .mockResolvedValueOnce([false, true, false])
 
         const result = await findDeepElement.call(browser, '[data-qa="my-btn"]')
 
@@ -84,8 +83,8 @@ describe('findDeepElement - isConnected validation', () => {
             [ELEMENT_KEY]: 'node-connected',
             locator: expect.objectContaining({ type: 'css', value: '[data-qa="my-btn"]' }),
         })
-        // Should have called execute twice (stopped at first connected)
-        expect(browser.execute).toHaveBeenCalledTimes(2)
+        // a single batched isConnected round trip covers all nodes
+        expect(browser.execute).toHaveBeenCalledTimes(1)
         // Should NOT fall back to Classic
         expect(browser.findElement).not.toHaveBeenCalled()
     })
@@ -101,8 +100,7 @@ describe('findDeepElement - isConnected validation', () => {
             ],
         })
         browser.execute
-            .mockResolvedValueOnce(false)  // node-stale-1 → not connected
-            .mockResolvedValueOnce(false)  // node-stale-2 → not connected
+            .mockResolvedValueOnce([false, false])  // batched isConnected: both detached
 
         const classicResult = { [ELEMENT_KEY]: 'classic-element' }
         browser.findElement.mockResolvedValue(classicResult)
@@ -125,8 +123,9 @@ describe('findDeepElement - isConnected validation', () => {
             ],
         })
         browser.execute
-            .mockRejectedValueOnce(new Error('no such element'))  // node-gc → stale/GC'd
-            .mockResolvedValueOnce(true)  // node-ok → connected
+            .mockRejectedValueOnce(new Error('no such element'))  // batched isConnected fails (stale node poisons it)
+            .mockRejectedValueOnce(new Error('no such element'))  // per-element fallback: node-gc → stale/GC'd
+            .mockResolvedValueOnce(true)                          // per-element fallback: node-ok → connected
 
         const result = await findDeepElement.call(browser, '.my-class')
 
@@ -173,13 +172,11 @@ describe('findDeepElement - isConnected validation', () => {
             ],
         })
 
-        // elementContains calls: both nodes are "in" the parent
+        // containment check (batched): both nodes are "in" the parent
         // isConnected calls: both nodes are detached
         browser.execute
-            .mockResolvedValueOnce(true)   // elementContains for scoped-node-1
-            .mockResolvedValueOnce(true)   // elementContains for scoped-node-2
-            .mockResolvedValueOnce(false)  // isConnected for scoped-node-1
-            .mockResolvedValueOnce(false)  // isConnected for scoped-node-2
+            .mockResolvedValueOnce([true, true])    // batched containment for both nodes
+            .mockResolvedValueOnce([false, false])  // batched isConnected: both detached
 
         const classicResult = { [ELEMENT_KEY]: 'fallback-element' }
         element.findElementFromElement.mockResolvedValue(classicResult)
@@ -209,10 +206,9 @@ describe('findDeepElement - isConnected validation', () => {
             ],
         })
 
-        // elementContains: option-1 is in select, option-2 is not (to test scoping)
+        // containment check (batched): option-1 is in select, option-2 is not (to test scoping)
         browser.execute
-            .mockResolvedValueOnce(true)   // elementContains for option-1
-            .mockResolvedValueOnce(false)  // elementContains for option-2
+            .mockResolvedValueOnce([true, false])
 
         const result = await findDeepElement.call(element, 'option')
 
@@ -221,9 +217,37 @@ describe('findDeepElement - isConnected validation', () => {
             [ELEMENT_KEY]: 'option-1',
             locator: expect.objectContaining({ type: 'css', value: 'option' }),
         })
-        // Only the elementContains calls, no isConnected calls
-        expect(browser.execute).toHaveBeenCalledTimes(2)
+        // Only the single batched containment call, no isConnected calls
+        expect(browser.execute).toHaveBeenCalledTimes(1)
         expect(element.findElementFromElement).not.toHaveBeenCalled()
+    })
+
+    it('should include both the scope element and its shadow roots as startNodes (scoped/element context)', async () => {
+        // regression test: a scope that contains a shadow host must still search
+        // its own plain light-DOM descendants alongside the shadow root(s)
+        mockGetShadowElementsByContextId.mockReturnValue(['shadow-1'])
+
+        const browser = createMockBrowser()
+        const element: any = {
+            isW3C: true,
+            isMobile: false,
+            elementId: 'wrapper-elem-id',
+            __browser: browser,
+            findElementFromElement: vi.fn(),
+        }
+
+        browser.browsingContextLocateNodes.mockResolvedValue({ nodes: [] })
+
+        await findDeepElement.call(element, '.child-selector')
+
+        expect(browser.browsingContextLocateNodes).toHaveBeenCalledWith(
+            expect.objectContaining({
+                startNodes: [
+                    { sharedId: 'wrapper-elem-id' },
+                    { sharedId: 'shadow-1' },
+                ],
+            })
+        )
     })
 
     it('should return first connected scoped node (scoped/element context)', async () => {
@@ -245,13 +269,11 @@ describe('findDeepElement - isConnected validation', () => {
             ],
         })
 
-        // elementContains: both are in parent
+        // containment check (batched): both are in parent
         // isConnected: first detached, second connected
         browser.execute
-            .mockResolvedValueOnce(true)   // elementContains for scoped-detached
-            .mockResolvedValueOnce(true)   // elementContains for scoped-connected
-            .mockResolvedValueOnce(false)  // isConnected for scoped-detached
-            .mockResolvedValueOnce(true)   // isConnected for scoped-connected
+            .mockResolvedValueOnce([true, true])   // batched containment for both nodes
+            .mockResolvedValueOnce([false, true])  // batched isConnected: first detached, second connected
 
         const result = await findDeepElement.call(element, '.child-selector')
 
@@ -261,6 +283,41 @@ describe('findDeepElement - isConnected validation', () => {
         })
         // Should NOT fall back to Classic since we found a connected node
         expect(element.findElementFromElement).not.toHaveBeenCalled()
+    })
+
+    it('should fall back to per-element containment checks when the batched check fails (scoped/element context)', async () => {
+        mockGetShadowElementsByContextId.mockReturnValue([])
+
+        const browser = createMockBrowser()
+        const element: any = {
+            isW3C: true,
+            isMobile: false,
+            elementId: 'parent-elem-id',
+            __browser: browser,
+            findElementFromElement: vi.fn(),
+        }
+
+        browser.browsingContextLocateNodes.mockResolvedValue({
+            nodes: [
+                { sharedId: 'node-in-scope' },
+                { sharedId: 'node-stale' },
+            ],
+        })
+
+        // batched containment throws, per-element fallback: first in scope, second stale
+        browser.execute
+            .mockRejectedValueOnce(new Error('stale element reference'))
+            .mockResolvedValueOnce(true)                                  // per-element check node-in-scope
+            .mockRejectedValueOnce(new Error('stale element reference'))  // per-element check node-stale
+
+        const result = await findDeepElement.call(element, '.child-selector')
+
+        expect(result).toEqual({
+            [ELEMENT_KEY]: 'node-in-scope',
+            locator: expect.objectContaining({ type: 'css', value: '.child-selector' }),
+        })
+        // 1 failed batched call + 2 per-element fallback calls
+        expect(browser.execute).toHaveBeenCalledTimes(3)
     })
 })
 
@@ -282,9 +339,7 @@ describe('findDeepElements - isConnected validation', () => {
             ],
         })
         browser.execute
-            .mockResolvedValueOnce(true)   // node-a → connected
-            .mockResolvedValueOnce(false)  // node-b → detached
-            .mockResolvedValueOnce(true)   // node-c → connected
+            .mockResolvedValueOnce([true, false, true])  // batched isConnected: node-b detached
 
         const result = await findDeepElements.call(browser, '[data-qa="items"]')
 
@@ -292,6 +347,8 @@ describe('findDeepElements - isConnected validation', () => {
             { [ELEMENT_KEY]: 'node-a', locator: expect.objectContaining({ type: 'css', value: '[data-qa="items"]' }) },
             { [ELEMENT_KEY]: 'node-c', locator: expect.objectContaining({ type: 'css', value: '[data-qa="items"]' }) },
         ])
+        // all nodes checked in a single batched isConnected round trip
+        expect(browser.execute).toHaveBeenCalledTimes(1)
         expect(browser.findElements).not.toHaveBeenCalled()
     })
 
@@ -306,8 +363,7 @@ describe('findDeepElements - isConnected validation', () => {
             ],
         })
         browser.execute
-            .mockResolvedValueOnce(false)
-            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce([false, false])  // batched isConnected: both detached
 
         const classicResults = [
             { [ELEMENT_KEY]: 'classic-1' },
@@ -332,8 +388,9 @@ describe('findDeepElements - isConnected validation', () => {
             ],
         })
         browser.execute
-            .mockRejectedValueOnce(new Error('no such element'))
-            .mockResolvedValueOnce(true)
+            .mockRejectedValueOnce(new Error('no such element'))  // batched isConnected fails (stale node poisons it)
+            .mockRejectedValueOnce(new Error('no such element'))  // per-element fallback: gc-node stale
+            .mockResolvedValueOnce(true)                          // per-element fallback: ok-node connected
 
         const result = await findDeepElements.call(browser, '.item')
 
@@ -381,12 +438,10 @@ describe('findDeepElements - isConnected validation', () => {
             ],
         })
 
-        // elementContains: both in parent; isConnected: both detached
+        // containment check (batched): both in parent; isConnected (batched): both detached
         browser.execute
-            .mockResolvedValueOnce(true)   // elementContains child-1
-            .mockResolvedValueOnce(true)   // elementContains child-2
-            .mockResolvedValueOnce(false)  // isConnected child-1
-            .mockResolvedValueOnce(false)  // isConnected child-2
+            .mockResolvedValueOnce([true, true])    // batched containment for both nodes
+            .mockResolvedValueOnce([false, false])  // batched isConnected: both detached
 
         const classicResults = [{ [ELEMENT_KEY]: 'classic-child' }]
         element.findElementsFromElement.mockResolvedValue(classicResults)
@@ -418,11 +473,9 @@ describe('findDeepElements - isConnected validation', () => {
             ],
         })
 
-        // elementContains: all options are within the select
+        // containment check (batched): all options are within the select
         browser.execute
-            .mockResolvedValueOnce(true)   // elementContains for option-1
-            .mockResolvedValueOnce(true)   // elementContains for option-2
-            .mockResolvedValueOnce(true)   // elementContains for option-3
+            .mockResolvedValueOnce([true, true, true])
 
         const result = await findDeepElements.call(element, 'option')
 
@@ -433,9 +486,40 @@ describe('findDeepElements - isConnected validation', () => {
             { [ELEMENT_KEY]: 'option-2', locator: expect.objectContaining({ type: 'css', value: 'option' }) },
             { [ELEMENT_KEY]: 'option-3', locator: expect.objectContaining({ type: 'css', value: 'option' }) },
         ])
-        // Only the elementContains calls, no isConnected calls
-        expect(browser.execute).toHaveBeenCalledTimes(3)
+        // Only the single batched containment call, no isConnected calls
+        expect(browser.execute).toHaveBeenCalledTimes(1)
         expect(element.findElementsFromElement).not.toHaveBeenCalled()
+    })
+
+    it('should keep only the nodes the batched containment check marks as contained (index alignment)', async () => {
+        mockGetShadowElementsByContextId.mockReturnValue([])
+
+        const browser = createMockBrowser()
+        const element: any = {
+            isW3C: true,
+            isMobile: false,
+            elementId: 'select-elem-id',
+            __browser: browser,
+            findElementsFromElement: vi.fn(),
+        }
+
+        browser.browsingContextLocateNodes.mockResolvedValue({
+            nodes: [
+                { sharedId: 'option-1' },
+                { sharedId: 'option-2' },
+                { sharedId: 'option-3' },
+            ],
+        })
+
+        // only the middle node is contained in the scope — a misaligned
+        // batch result would keep the wrong node(s)
+        browser.execute.mockResolvedValueOnce([false, true, false])
+
+        const result = await findDeepElements.call(element, 'option')
+
+        expect(result).toEqual([
+            { [ELEMENT_KEY]: 'option-2', locator: expect.objectContaining({ type: 'css', value: 'option' }) },
+        ])
     })
 
     it('should return connected scoped nodes only (scoped/element context)', async () => {
@@ -457,12 +541,10 @@ describe('findDeepElements - isConnected validation', () => {
             ],
         })
 
-        // elementContains: both in parent; isConnected: first connected, second detached
+        // containment check (batched): both in parent; isConnected (batched): first connected, second detached
         browser.execute
-            .mockResolvedValueOnce(true)   // elementContains child-ok
-            .mockResolvedValueOnce(true)   // elementContains child-stale
-            .mockResolvedValueOnce(true)   // isConnected child-ok
-            .mockResolvedValueOnce(false)  // isConnected child-stale
+            .mockResolvedValueOnce([true, true])   // batched containment for both nodes
+            .mockResolvedValueOnce([true, false])  // batched isConnected: child-ok connected, child-stale detached
 
         const result = await findDeepElements.call(element, '.child')
 


### PR DESCRIPTION
## Proposed changes
#15394 
Fixes a shadow root scope-resolution bug: $(parent).$(child) on a parent that isn't itself a tracked shadow host used every shadow root on the page as search start nodes instead of scoping to parent. If a leaked shadow root went stale (e.g. after SPA navigation), every later scoped lookup silently returned empty results until timeout.

Resolve unmatched scopes via DOM-containment check against tracked shadow hosts instead of falling back to the whole tree
Always include the scope element itself in startNodes alongside shadow roots, so plain light-DOM descendants stay searchable
Batch containment and isConnected checks into a single browser.execute() call each, with per-element fallback and stale-host pruning
Added e2e coverage that asserts on the BiDi locateNodes payload directly verified to fail on the pre-fix build and pass on the fixed one

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
