### PR TITLE
chore(deps): update wdio-testingbot-service dependencies

### DIFF
--- a/packages/wdio-testingbot-service/package.json
+++ b/packages/wdio-testingbot-service/package.json
@@ -34,11 +34,11 @@
   "dependencies": {
     "@wdio/logger": "workspace:*",
     "@wdio/types": "workspace:*",
-    "testingbot-tunnel-launcher": "^1.1.7",
+    "testingbot-tunnel-launcher": "^1.1.18",
     "webdriverio": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^20.1.0",
+    "@types/node": "^26.1.1",
     "@wdio/globals": "workspace:*"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,7 +353,7 @@ importers:
         version: 3.4.17
       vite:
         specifier: ^5.1.3
-        version: 5.4.21(@types/node@25.9.3)(terser@5.43.1)
+        version: 5.4.21(@types/node@26.1.1)(terser@5.43.1)
       webdriver:
         specifier: workspace:*
         version: link:../packages/webdriver
@@ -473,7 +473,7 @@ importers:
         version: 10.0.10
       '@vitejs/plugin-vue':
         specifier: ^5.0.3
-        version: 5.2.4(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3))
+        version: 5.2.4(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3))
       expect-webdriverio:
         specifier: ^5.6.5
         version: 5.6.8(@wdio/globals@9.29.1)(@wdio/logger@9.29.1)(webdriverio@9.29.1(puppeteer-core@24.34.0))
@@ -485,7 +485,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^5.0.12
-        version: 5.4.21(@types/node@25.9.3)(terser@5.43.1)
+        version: 5.4.21(@types/node@26.1.1)(terser@5.43.1)
       vue-tsc:
         specifier: ^2.0.17
         version: 2.2.10(typescript@5.9.3)
@@ -535,7 +535,7 @@ importers:
         version: 4.2.0
       inquirer:
         specifier: ^12.7.0
-        version: 12.7.0(@types/node@25.9.3)
+        version: 12.7.0(@types/node@26.1.1)
       normalize-package-data:
         specifier: ^7.0.0
         version: 7.0.0
@@ -735,20 +735,20 @@ importers:
         version: 0.5.21
       vite:
         specifier: ^5.4.10
-        version: 5.4.21(@types/node@25.9.3)(terser@5.43.1)
+        version: 5.4.21(@types/node@26.1.1)(terser@5.43.1)
       vite-plugin-istanbul:
         specifier: ^6.0.0
-        version: 6.0.2(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1))
+        version: 6.0.2(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1))
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.6.0(rollup@4.53.3)(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1))
+        version: 1.6.0(rollup@4.53.3)(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1))
       webdriver:
         specifier: ^9.0.0
         version: 9.16.2
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.2
-        version: 4.0.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1))
+        version: 4.0.2(svelte@4.2.20)(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1))
       '@types/istanbul-lib-coverage':
         specifier: ^2.0.6
         version: 2.0.6
@@ -1075,7 +1075,7 @@ importers:
         version: link:../wdio-logger
       '@wdio/runner':
         specifier: ^9.16.2
-        version: 9.16.2(expect-webdriverio@5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.28.0(puppeteer-core@24.34.0)))(webdriverio@9.28.0(puppeteer-core@24.34.0))
+        version: 9.16.2(expect-webdriverio@5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.29.1(puppeteer-core@24.34.0)))(webdriverio@9.29.1(puppeteer-core@24.34.0))
       '@wdio/types':
         specifier: workspace:*
         version: link:../wdio-types
@@ -1469,15 +1469,15 @@ importers:
         specifier: workspace:*
         version: link:../wdio-types
       testingbot-tunnel-launcher:
-        specifier: ^1.1.7
+        specifier: ^1.1.18
         version: 1.1.18
       webdriverio:
         specifier: workspace:*
         version: link:../webdriverio
     devDependencies:
       '@types/node':
-        specifier: ^20.1.0
-        version: 20.19.43
+        specifier: ^26.1.1
+        version: 26.1.1
       '@wdio/globals':
         specifier: workspace:*
         version: link:../wdio-globals
@@ -6617,6 +6617,9 @@ packages:
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -7053,10 +7056,6 @@ packages:
     resolution: {integrity: sha512-a7zDSNzpGgkb6mWrg9GWPmvh/sZFzaf86/iBjCv+n2DTY0+8v8NLruRQmWuCaQAlLVhM3XAqmB+fWLqxDhdvOA==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/config@9.28.0':
-    resolution: {integrity: sha512-a2po2x0Gi0hNRCuqSYSAvgwC9RZsj1tH9mt4MeLk2hyJBQCyy9DjBBjwyd4AcnE11XhqVaIkMaIMBSRu2dJwLw==}
-    engines: {node: '>=18.20.0'}
-
   '@wdio/config@9.29.1':
     resolution: {integrity: sha512-8IXDiRG9wUUnpU6M/uzsVqIHJD/7o4y9RaOU2Jh/OdRJP/7rxwfGsa24Bv486rnMGdghztkwLCBJWG0jbeEtfw==}
     engines: {node: '>=18.20.0'}
@@ -7097,9 +7096,6 @@ packages:
   '@wdio/protocols@9.16.2':
     resolution: {integrity: sha512-h3k97/lzmyw5MowqceAuY3HX/wGJojXHkiPXA3WlhGPCaa2h4+GovV2nJtRvknCKsE7UHA1xB5SWeI8MzloBew==}
 
-  '@wdio/protocols@9.28.0':
-    resolution: {integrity: sha512-bO9NeMCrtwfWI7q77GwfD68NlRNijnmwicW1OQ6p+7D3kZWEicfdhfvojPhjjf+e9XzqMDnUDGD5ni1lGMUBsg==}
-
   '@wdio/protocols@9.29.1':
     resolution: {integrity: sha512-NFlBQOA4zDb4D/ETpVMqDgbJyEqdhGRsJWybLOXG7PGlPwfcrfmTMHC1+Boq4KODgpwbhCmI9zIk2JQmGYIttQ==}
 
@@ -7122,20 +7118,12 @@ packages:
     resolution: {integrity: sha512-P86FvM/4XQGpJKwlC2RKF3I21TglPvPOozJGG9HoL0Jmt6jRF20ggO/nRTxU0XiWkRdqESUTmfA87bdCO4GRkQ==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/types@9.28.0':
-    resolution: {integrity: sha512-75JPq39gifkPNqOSn5C4/A5ZSyXwF+dGr5jfsCubFN9Lk9dKBXfjdbWueSQNpJg0jmE6dVrbT7+9mnDNnO0HdQ==}
-    engines: {node: '>=18.20.0'}
-
   '@wdio/types@9.29.1':
     resolution: {integrity: sha512-jp8jgMv6TS35G96YzHZxw3PVN0Dz6xQ6tnMAicndAJ8Jt9AIXb0ywIse4TjaFywakO3dLoEhlyA3ZtR26vmt+w==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/utils@9.16.2':
     resolution: {integrity: sha512-bsRdEUXUTYvznXH/Z+p6HDzHSjMI6I6bnu8WXWTeDDDyqybWK5D8cbZvs8A/kMmGXoz1GZkSBHxy4Z5NTg8OQg==}
-    engines: {node: '>=18.20.0'}
-
-  '@wdio/utils@9.28.0':
-    resolution: {integrity: sha512-VDqUaXpR8oOZSs26dy06Y2LhmA8bldsXDHeZ36n8SfW+Bq0miG0RRxou7aqx7sifVbbsuxrbBPXvmK+40uAIbQ==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/utils@9.29.1':
@@ -14909,6 +14897,9 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   undici@6.27.0:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
@@ -15287,25 +15278,12 @@ packages:
     resolution: {integrity: sha512-T7QKqD+N0hfvrxq/am5wqdOuyOy7F2tGS7X2f/7jyhrxSPG6Q0cNkSt4gCwla+q3nDMivCP0QIPc7mAVSx5AYQ==}
     engines: {node: '>=18.20.0'}
 
-  webdriver@9.28.0:
-    resolution: {integrity: sha512-MmtC/n5rhOh/EYyYI1SbRBdEWctKaQouVeEAybv5SD/2bhTjg800q7mvGqHzhTXpqTPY5cdbOtT0PBdT89wz9w==}
-    engines: {node: '>=18.20.0'}
-
   webdriver@9.29.1:
     resolution: {integrity: sha512-uhxYap3qQXC9H2V8SDr7vcy0blZETeri4goLwbw1TFq4EZHF1Dv503Zc0PAjfkNQJCD4/rzAyr07+EX72kx1pg==}
     engines: {node: '>=18.20.0'}
 
   webdriverio@9.16.2:
     resolution: {integrity: sha512-aRcfBZyY+OFqz2DI0ZYmMahGlH3h/clAXXOQSFN5QfrHG4Cjuo5xy3lq4tVfszjEJ813+wwC4HJLbgDmMrPXkA==}
-    engines: {node: '>=18.20.0'}
-    peerDependencies:
-      puppeteer-core: '>=22.x || <=24.x'
-    peerDependenciesMeta:
-      puppeteer-core:
-        optional: true
-
-  webdriverio@9.28.0:
-    resolution: {integrity: sha512-ieFWi8dq57uZC6QMC2x6TllxKTRyInIMcOrVvwbHqVRYvJP8OLDtlH1bideGRIN0pgGHWStqplez2A95jS9bqA==}
     engines: {node: '>=18.20.0'}
     peerDependencies:
       puppeteer-core: '>=22.x || <=24.x'
@@ -19743,15 +19721,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/checkbox@4.1.9(@types/node@25.9.3)':
+  '@inquirer/checkbox@4.1.9(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.1.14(@types/node@25.9.3)
+      '@inquirer/core': 10.1.14(@types/node@26.1.1)
       '@inquirer/figures': 1.0.12
-      '@inquirer/type': 3.0.7(@types/node@25.9.3)
+      '@inquirer/type': 3.0.7(@types/node@26.1.1)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@inquirer/checkbox@4.3.2(@types/node@20.19.43)':
     dependencies:
@@ -19775,12 +19753,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/confirm@5.1.13(@types/node@25.9.3)':
+  '@inquirer/confirm@5.1.13(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.1.14(@types/node@25.9.3)
-      '@inquirer/type': 3.0.7(@types/node@25.9.3)
+      '@inquirer/core': 10.1.14(@types/node@26.1.1)
+      '@inquirer/type': 3.0.7(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@inquirer/confirm@5.1.21(@types/node@20.19.43)':
     dependencies:
@@ -19802,10 +19780,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/core@10.1.14(@types/node@25.9.3)':
+  '@inquirer/core@10.1.14(@types/node@26.1.1)':
     dependencies:
       '@inquirer/figures': 1.0.12
-      '@inquirer/type': 3.0.7(@types/node@25.9.3)
+      '@inquirer/type': 3.0.7(@types/node@26.1.1)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -19813,7 +19791,7 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@inquirer/core@10.3.2(@types/node@20.19.43)':
     dependencies:
@@ -19857,13 +19835,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/editor@4.2.14(@types/node@25.9.3)':
+  '@inquirer/editor@4.2.14(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.1.14(@types/node@25.9.3)
-      '@inquirer/type': 3.0.7(@types/node@25.9.3)
+      '@inquirer/core': 10.1.14(@types/node@26.1.1)
+      '@inquirer/type': 3.0.7(@types/node@26.1.1)
       external-editor: 3.1.0
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@inquirer/editor@4.2.23(@types/node@20.19.43)':
     dependencies:
@@ -19887,13 +19865,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/expand@4.0.16(@types/node@25.9.3)':
+  '@inquirer/expand@4.0.16(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.1.14(@types/node@25.9.3)
-      '@inquirer/type': 3.0.7(@types/node@25.9.3)
+      '@inquirer/core': 10.1.14(@types/node@26.1.1)
+      '@inquirer/type': 3.0.7(@types/node@26.1.1)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@inquirer/expand@4.0.23(@types/node@20.19.43)':
     dependencies:
@@ -19926,12 +19904,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/input@4.2.0(@types/node@25.9.3)':
+  '@inquirer/input@4.2.0(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.1.14(@types/node@25.9.3)
-      '@inquirer/type': 3.0.7(@types/node@25.9.3)
+      '@inquirer/core': 10.1.14(@types/node@26.1.1)
+      '@inquirer/type': 3.0.7(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@inquirer/input@4.3.1(@types/node@20.19.43)':
     dependencies:
@@ -19952,12 +19930,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/number@3.0.16(@types/node@25.9.3)':
+  '@inquirer/number@3.0.16(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.1.14(@types/node@25.9.3)
-      '@inquirer/type': 3.0.7(@types/node@25.9.3)
+      '@inquirer/core': 10.1.14(@types/node@26.1.1)
+      '@inquirer/type': 3.0.7(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@inquirer/number@3.0.23(@types/node@20.19.43)':
     dependencies:
@@ -19980,13 +19958,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/password@4.0.16(@types/node@25.9.3)':
+  '@inquirer/password@4.0.16(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.1.14(@types/node@25.9.3)
-      '@inquirer/type': 3.0.7(@types/node@25.9.3)
+      '@inquirer/core': 10.1.14(@types/node@26.1.1)
+      '@inquirer/type': 3.0.7(@types/node@26.1.1)
       ansi-escapes: 4.3.2
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@inquirer/password@4.0.23(@types/node@20.19.43)':
     dependencies:
@@ -20039,20 +20017,20 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/prompts@7.6.0(@types/node@25.9.3)':
+  '@inquirer/prompts@7.6.0(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/checkbox': 4.1.9(@types/node@25.9.3)
-      '@inquirer/confirm': 5.1.13(@types/node@25.9.3)
-      '@inquirer/editor': 4.2.14(@types/node@25.9.3)
-      '@inquirer/expand': 4.0.16(@types/node@25.9.3)
-      '@inquirer/input': 4.2.0(@types/node@25.9.3)
-      '@inquirer/number': 3.0.16(@types/node@25.9.3)
-      '@inquirer/password': 4.0.16(@types/node@25.9.3)
-      '@inquirer/rawlist': 4.1.4(@types/node@25.9.3)
-      '@inquirer/search': 3.0.16(@types/node@25.9.3)
-      '@inquirer/select': 4.2.4(@types/node@25.9.3)
+      '@inquirer/checkbox': 4.1.9(@types/node@26.1.1)
+      '@inquirer/confirm': 5.1.13(@types/node@26.1.1)
+      '@inquirer/editor': 4.2.14(@types/node@26.1.1)
+      '@inquirer/expand': 4.0.16(@types/node@26.1.1)
+      '@inquirer/input': 4.2.0(@types/node@26.1.1)
+      '@inquirer/number': 3.0.16(@types/node@26.1.1)
+      '@inquirer/password': 4.0.16(@types/node@26.1.1)
+      '@inquirer/rawlist': 4.1.4(@types/node@26.1.1)
+      '@inquirer/search': 3.0.16(@types/node@26.1.1)
+      '@inquirer/select': 4.2.4(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@inquirer/rawlist@3.0.1':
     dependencies:
@@ -20076,13 +20054,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/rawlist@4.1.4(@types/node@25.9.3)':
+  '@inquirer/rawlist@4.1.4(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.1.14(@types/node@25.9.3)
-      '@inquirer/type': 3.0.7(@types/node@25.9.3)
+      '@inquirer/core': 10.1.14(@types/node@26.1.1)
+      '@inquirer/type': 3.0.7(@types/node@26.1.1)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@inquirer/search@2.0.1':
     dependencies:
@@ -20100,14 +20078,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/search@3.0.16(@types/node@25.9.3)':
+  '@inquirer/search@3.0.16(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.1.14(@types/node@25.9.3)
+      '@inquirer/core': 10.1.14(@types/node@26.1.1)
       '@inquirer/figures': 1.0.12
-      '@inquirer/type': 3.0.7(@types/node@25.9.3)
+      '@inquirer/type': 3.0.7(@types/node@26.1.1)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@inquirer/search@3.2.2(@types/node@20.19.43)':
     dependencies:
@@ -20136,15 +20114,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/select@4.2.4(@types/node@25.9.3)':
+  '@inquirer/select@4.2.4(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 10.1.14(@types/node@25.9.3)
+      '@inquirer/core': 10.1.14(@types/node@26.1.1)
       '@inquirer/figures': 1.0.12
-      '@inquirer/type': 3.0.7(@types/node@25.9.3)
+      '@inquirer/type': 3.0.7(@types/node@26.1.1)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@inquirer/select@4.4.2(@types/node@20.19.43)':
     dependencies:
@@ -20168,9 +20146,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@inquirer/type@3.0.7(@types/node@25.9.3)':
+  '@inquirer/type@3.0.7(@types/node@26.1.1)':
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -21796,12 +21774,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1)))(svelte@4.2.20)(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@4.2.20)(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1)))(svelte@4.2.20)(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1))
+      '@sveltejs/vite-plugin-svelte': 4.0.2(svelte@4.2.20)(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1))
       debug: 4.4.1(supports-color@8.1.1)
       svelte: 4.2.20
-      vite: 5.4.21(@types/node@25.9.3)(terser@5.43.1)
+      vite: 5.4.21(@types/node@26.1.1)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21818,16 +21796,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1))':
+  '@sveltejs/vite-plugin-svelte@4.0.2(svelte@4.2.20)(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1)))(svelte@4.2.20)(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.2(svelte@4.2.20)(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1)))(svelte@4.2.20)(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1))
       debug: 4.4.1(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 4.2.20
-      vite: 5.4.21(@types/node@25.9.3)(terser@5.43.1)
-      vitefu: 1.0.7(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1))
+      vite: 5.4.21(@types/node@26.1.1)(terser@5.43.1)
+      vitefu: 1.0.7(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -22348,6 +22326,10 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/node@26.1.1':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/object-inspect@1.13.0': {}
@@ -22788,9 +22770,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3))':
     dependencies:
-      vite: 5.4.21(@types/node@25.9.3)(terser@5.43.1)
+      vite: 5.4.21(@types/node@26.1.1)(terser@5.43.1)
       vue: 3.5.38(typescript@5.9.3)
 
   '@vitejs/plugin-vue@6.0.0(vite@5.4.21(@types/node@20.19.43)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3))':
@@ -23076,21 +23058,6 @@ snapshots:
       - bare-buffer
       - supports-color
 
-  '@wdio/config@9.28.0':
-    dependencies:
-      '@wdio/logger': 9.18.0
-      '@wdio/types': 9.28.0
-      '@wdio/utils': 9.28.0
-      deepmerge-ts: 7.1.5
-      glob: 10.5.0
-      import-meta-resolve: 4.2.0
-      jiti: 2.7.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-      - supports-color
-
   '@wdio/config@9.29.1':
     dependencies:
       '@wdio/logger': 9.29.1
@@ -23128,10 +23095,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@wdio/globals@9.16.2(expect-webdriverio@5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.28.0(puppeteer-core@24.34.0)))(webdriverio@9.28.0(puppeteer-core@24.34.0))':
+  '@wdio/globals@9.16.2(expect-webdriverio@5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.29.1(puppeteer-core@24.34.0)))(webdriverio@9.29.1(puppeteer-core@24.34.0))':
     dependencies:
-      expect-webdriverio: 5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.28.0(puppeteer-core@24.34.0))
-      webdriverio: 9.28.0(puppeteer-core@24.34.0)
+      expect-webdriverio: 5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.29.1(puppeteer-core@24.34.0))
+      webdriverio: 9.29.1(puppeteer-core@24.34.0)
 
   '@wdio/globals@9.16.2(expect-webdriverio@5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@packages+webdriverio))(webdriverio@9.16.2(puppeteer-core@24.34.0))':
     dependencies:
@@ -23178,8 +23145,6 @@ snapshots:
 
   '@wdio/protocols@9.16.2': {}
 
-  '@wdio/protocols@9.28.0': {}
-
   '@wdio/protocols@9.29.1': {}
 
   '@wdio/repl@9.16.2':
@@ -23194,19 +23159,19 @@ snapshots:
       diff: 7.0.0
       object-inspect: 1.13.4
 
-  '@wdio/runner@9.16.2(expect-webdriverio@5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.28.0(puppeteer-core@24.34.0)))(webdriverio@9.28.0(puppeteer-core@24.34.0))':
+  '@wdio/runner@9.16.2(expect-webdriverio@5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.29.1(puppeteer-core@24.34.0)))(webdriverio@9.29.1(puppeteer-core@24.34.0))':
     dependencies:
       '@types/node': 20.19.37
       '@wdio/config': 9.16.2
       '@wdio/dot-reporter': 9.16.2
-      '@wdio/globals': 9.16.2(expect-webdriverio@5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.28.0(puppeteer-core@24.34.0)))(webdriverio@9.28.0(puppeteer-core@24.34.0))
+      '@wdio/globals': 9.16.2(expect-webdriverio@5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.29.1(puppeteer-core@24.34.0)))(webdriverio@9.29.1(puppeteer-core@24.34.0))
       '@wdio/logger': 9.16.2
       '@wdio/types': 9.16.2
       '@wdio/utils': 9.16.2
       deepmerge-ts: 7.1.5
-      expect-webdriverio: 5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.28.0(puppeteer-core@24.34.0))
+      expect-webdriverio: 5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.29.1(puppeteer-core@24.34.0))
       webdriver: 9.16.2
-      webdriverio: 9.28.0(puppeteer-core@24.34.0)
+      webdriverio: 9.29.1(puppeteer-core@24.34.0)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -23215,10 +23180,6 @@ snapshots:
       - utf-8-validate
 
   '@wdio/types@9.16.2':
-    dependencies:
-      '@types/node': 20.19.43
-
-  '@wdio/types@9.28.0':
     dependencies:
       '@types/node': 20.19.43
 
@@ -23244,28 +23205,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
-      - supports-color
-
-  '@wdio/utils@9.28.0':
-    dependencies:
-      '@puppeteer/browsers': 2.13.2
-      '@wdio/logger': 9.18.0
-      '@wdio/types': 9.28.0
-      decamelize: 6.0.1
-      deepmerge-ts: 7.1.5
-      edgedriver: 6.3.0
-      geckodriver: 6.1.1
-      get-port: 7.2.0
-      import-meta-resolve: 4.2.0
-      locate-app: 2.5.0
-      mitt: 3.0.1
-      safaridriver: 1.0.1
-      split2: 4.2.0
-      wait-port: 1.1.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
       - supports-color
 
   '@wdio/utils@9.29.1':
@@ -26098,16 +26037,6 @@ snapshots:
       jest-matcher-utils: 30.4.1
       webdriverio: link:packages/webdriverio
 
-  expect-webdriverio@5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.28.0(puppeteer-core@24.34.0)):
-    dependencies:
-      '@vitest/snapshot': 4.1.8
-      '@wdio/globals': link:packages/wdio-globals
-      '@wdio/logger': link:packages/wdio-logger
-      deep-eql: 5.0.2
-      expect: 30.4.1
-      jest-matcher-utils: 30.4.1
-      webdriverio: 9.28.0(puppeteer-core@24.34.0)
-
   expect-webdriverio@5.6.8(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.29.1(puppeteer-core@24.34.0)):
     dependencies:
       '@vitest/snapshot': 4.1.8
@@ -27371,17 +27300,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  inquirer@12.7.0(@types/node@25.9.3):
+  inquirer@12.7.0(@types/node@26.1.1):
     dependencies:
-      '@inquirer/core': 10.1.14(@types/node@25.9.3)
-      '@inquirer/prompts': 7.6.0(@types/node@25.9.3)
-      '@inquirer/type': 3.0.7(@types/node@25.9.3)
+      '@inquirer/core': 10.1.14(@types/node@26.1.1)
+      '@inquirer/prompts': 7.6.0(@types/node@26.1.1)
+      '@inquirer/type': 3.0.7(@types/node@26.1.1)
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 4.0.4
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
 
   inquirer@12.9.6(@types/node@20.19.43):
     dependencies:
@@ -32818,6 +32747,8 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  undici-types@8.3.0: {}
+
   undici@6.27.0: {}
 
   undici@7.27.2: {}
@@ -33118,7 +33049,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-istanbul@6.0.2(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1)):
+  vite-plugin-istanbul@6.0.2(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1)):
     dependencies:
       '@istanbuljs/load-nyc-config': 1.1.0
       espree: 10.4.0
@@ -33126,17 +33057,17 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.4
       test-exclude: 6.0.0
-      vite: 5.4.21(@types/node@25.9.3)(terser@5.43.1)
+      vite: 5.4.21(@types/node@26.1.1)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-top-level-await@1.6.0(rollup@4.53.3)(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1)):
+  vite-plugin-top-level-await@1.6.0(rollup@4.53.3)(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.53.3)
       '@swc/core': 1.15.8
       '@swc/wasm': 1.15.8
       uuid: 10.0.0
-      vite: 5.4.21(@types/node@25.9.3)(terser@5.43.1)
+      vite: 5.4.21(@types/node@26.1.1)(terser@5.43.1)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
@@ -33161,13 +33092,13 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.43.1
 
-  vite@5.4.21(@types/node@25.9.3)(terser@5.43.1):
+  vite@5.4.21(@types/node@26.1.1)(terser@5.43.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.53.3
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       terser: 5.43.1
 
@@ -33175,9 +33106,9 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@20.19.43)(terser@5.43.1)
 
-  vitefu@1.0.7(vite@5.4.21(@types/node@25.9.3)(terser@5.43.1)):
+  vitefu@1.0.7(vite@5.4.21(@types/node@26.1.1)(terser@5.43.1)):
     optionalDependencies:
-      vite: 5.4.21(@types/node@25.9.3)(terser@5.43.1)
+      vite: 5.4.21(@types/node@26.1.1)(terser@5.43.1)
 
   vitest@3.2.7(@types/debug@4.1.12)(@types/node@20.19.43)(jsdom@26.1.0)(terser@5.43.1):
     dependencies:
@@ -33303,27 +33234,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriver@9.28.0:
-    dependencies:
-      '@types/node': 20.19.43
-      '@types/ws': 8.18.1
-      '@wdio/config': 9.28.0
-      '@wdio/logger': 9.18.0
-      '@wdio/protocols': 9.28.0
-      '@wdio/types': 9.28.0
-      '@wdio/utils': 9.28.0
-      deepmerge-ts: 7.1.5
-      https-proxy-agent: 7.0.6
-      undici: 6.27.0
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - bufferutil
-      - react-native-b4a
-      - supports-color
-      - utf-8-validate
-
   webdriver@9.29.1:
     dependencies:
       '@types/node': 20.19.43
@@ -33378,43 +33288,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  webdriverio@9.28.0(puppeteer-core@24.34.0):
-    dependencies:
-      '@types/node': 20.19.43
-      '@types/sinonjs__fake-timers': 8.1.5
-      '@wdio/config': 9.28.0
-      '@wdio/logger': 9.18.0
-      '@wdio/protocols': 9.28.0
-      '@wdio/repl': 9.16.2
-      '@wdio/types': 9.28.0
-      '@wdio/utils': 9.28.0
-      archiver: 7.0.1
-      aria-query: 5.3.2
-      cheerio: 1.2.0
-      css-shorthand-properties: 1.1.2
-      css-value: 0.0.1
-      grapheme-splitter: 1.0.4
-      htmlfy: 0.8.1
-      is-plain-obj: 4.1.0
-      jszip: 3.10.1
-      lodash.clonedeep: 4.5.0
-      lodash.zip: 4.2.0
-      query-selector-shadow-dom: 1.0.1
-      resq: 1.11.0
-      rgb2hex: 0.2.5
-      serialize-error: 12.0.0
-      urlpattern-polyfill: 10.1.0
-      webdriver: 9.28.0
-    optionalDependencies:
-      puppeteer-core: 24.34.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - bufferutil
-      - react-native-b4a
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes

Update eligible external dependencies for `packages/wdio-testingbot-service` to their latest stable Node 18.20-compatible versions and regenerate the pnpm lockfile. Targeted tests, typecheck, build, lint, and frozen-lockfile validation pass.

## Types of changes

- [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported

### Reviewers: @webdriverio/project-committers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fc97232-753d-4ec7-b99b-826238fb7a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fc97232-753d-4ec7-b99b-826238fb7a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

