### PR TITLE
fix(webdriver): make WebDriver Bidi response timeout configurable

### DIFF
--- a/packages/wdio-browser-runner/package.json
+++ b/packages/wdio-browser-runner/package.json
@@ -97,7 +97,8 @@
     "source-map-support": "^0.5.21",
     "vite": "^5.4.10",
     "vite-plugin-istanbul": "^6.0.0",
-    "vite-plugin-top-level-await": "^1.4.1"
+    "vite-plugin-top-level-await": "^1.4.1",
+    "webdriver": "workspace:*"
   },
   "peerDependencies": {
     "expect-webdriverio": "^5.6.5",

--- a/packages/wdio-browser-runner/src/browser/driver.ts
+++ b/packages/wdio-browser-runner/src/browser/driver.ts
@@ -81,7 +81,7 @@ export default class ProxyDriver {
             ? params.capabilities.alwaysMatch?.webSocketUrl
             : params.capabilities!.webSocketUrl
         if (webSocketUrl) {
-            Object.assign(bidiPrototype, initiateBidi(webSocketUrl as unknown as string))
+            Object.assign(bidiPrototype, initiateBidi(webSocketUrl as unknown as string, undefined, undefined, params.bidiResponseTimeout))
         }
 
         /**

--- a/packages/wdio-browser-runner/src/browser/setup.ts
+++ b/packages/wdio-browser-runner/src/browser/setup.ts
@@ -30,7 +30,8 @@ globalThis.prompt = showPopupWarning('prompt', null, 'your value')
  */
 const browser = await remote({
     automationProtocol: automationProtocolPath as any,
-    capabilities: window.__wdioEnv__.capabilities
+    capabilities: window.__wdioEnv__.capabilities,
+    bidiResponseTimeout: window.__wdioEnv__.config.bidiResponseTimeout
 })
 _setGlobal('browser', browser, window.__wdioEnv__.injectGlobals)
 _setGlobal('driver', browser, window.__wdioEnv__.injectGlobals)

--- a/packages/wdio-types/src/Options.ts
+++ b/packages/wdio-types/src/Options.ts
@@ -97,6 +97,12 @@ export interface WebDriver extends Connection {
      */
     connectionRetryCount?: number
     /**
+     * Timeout (in ms) for a WebDriver Bidi command to receive a response from the browser.
+     *
+     * @default 180000
+     */
+    bidiResponseTimeout?: number
+    /**
      * Specify custom headers to pass into every request.
      */
     headers?: {

--- a/packages/webdriver/README.md
+++ b/packages/webdriver/README.md
@@ -143,6 +143,12 @@ Count of request retries to the Selenium server.
 Type: `Number`<br />
 Default: *3*
 
+### bidiResponseTimeout
+Timeout (in ms) for a WebDriver Bidi command to receive a response from the browser. Increase this if you run commands, e.g. `execute`, that legitimately take longer than the default to resolve.
+
+Type: `Number`<br />
+Default: *180000*
+
 ### agent
 
 Allows you to use a custom` http`/`https`/`http2` [agent](https://www.npmjs.com/package/got#agent) to make requests.

--- a/packages/webdriver/src/bidi/core.ts
+++ b/packages/webdriver/src/bidi/core.ts
@@ -14,7 +14,7 @@ const SCRIPT_PREFIX = '/* __wdio script__ */'
 const SCRIPT_SUFFIX = '/* __wdio script end__ */'
 
 const log = logger('webdriver')
-const RESPONSE_TIMEOUT = 1000 * 60
+export const DEFAULT_RESPONSE_TIMEOUT = 1000 * 180
 
 export class BidiCore {
     #id = 0
@@ -23,6 +23,7 @@ export class BidiCore {
     #resolveWaitForConnected: (value: boolean) => void
     #webSocketUrl: string
     #clientOptions: ClientOptions | undefined
+    #responseTimeout: number
     #pendingCommands: Map<number, (value: CommandResponse) => void> = new Map()
 
     client: Client | undefined
@@ -31,9 +32,18 @@ export class BidiCore {
      */
     private _isConnected = false
 
-    constructor (webSocketUrl: string, opts?: ClientOptions) {
+    constructor (
+        webSocketUrl: string,
+        opts?: ClientOptions,
+        responseTimeout = DEFAULT_RESPONSE_TIMEOUT
+    ) {
+        if (!Number.isFinite(responseTimeout) || responseTimeout <= 0) {
+            throw new TypeError('The option "bidiResponseTimeout" needs to be a positive number')
+        }
+
         this.#webSocketUrl = webSocketUrl
         this.#clientOptions = opts
+        this.#responseTimeout = responseTimeout
         this.#resolveWaitForConnected = () => {}
         this.#waitForConnected = new Promise((resolve) => {
             this.#resolveWaitForConnected = resolve
@@ -153,9 +163,12 @@ export class BidiCore {
         const failError = new Error(`WebDriver Bidi command "${params.method}" failed`)
         const payload = await new Promise<CommandResponse | ErrorResponse>((resolve, reject) => {
             const t = setTimeout(() => {
-                reject(new Error(`Command ${params.method} with id ${id} (with the following parameter: ${JSON.stringify(params.params)}) timed out`))
+                reject(new Error(
+                    `Command ${params.method} with id ${id} timed out after ${this.#responseTimeout}ms! ` +
+                    'Consider increasing the "bidiResponseTimeout" option.'
+                ))
                 this.#pendingCommands.delete(id)
-            }, RESPONSE_TIMEOUT)
+            }, this.#responseTimeout)
             this.#pendingCommands.set(id, (payload) => {
                 clearTimeout(t)
                 resolve(payload)

--- a/packages/webdriver/src/constants.ts
+++ b/packages/webdriver/src/constants.ts
@@ -100,7 +100,7 @@ export const DEFAULTS: Options.Definition<Required<RemoteConfig>> = {
         type: 'number',
         default: DEFAULT_RESPONSE_TIMEOUT,
         validate: (timeout: number): boolean => {
-            if (timeout <= 0) {
+            if (!Number.isFinite(timeout) || timeout <= 0) {
                 throw new TypeError('The option "bidiResponseTimeout" needs to be a positive number')
             }
 

--- a/packages/webdriver/src/constants.ts
+++ b/packages/webdriver/src/constants.ts
@@ -1,6 +1,7 @@
 import type { Options } from '@wdio/types'
 
 import { environment } from './environment.js'
+import { DEFAULT_RESPONSE_TIMEOUT } from './bidi/core.js'
 import type { RemoteConfig } from './types.js'
 
 export const DEFAULTS: Options.Definition<Required<RemoteConfig>> = {
@@ -91,6 +92,20 @@ export const DEFAULTS: Options.Definition<Required<RemoteConfig>> = {
     connectionRetryCount: {
         type: 'number',
         default: 3
+    },
+    /**
+     * Timeout for a WebDriver Bidi command to receive a response from the browser
+     */
+    bidiResponseTimeout: {
+        type: 'number',
+        default: DEFAULT_RESPONSE_TIMEOUT,
+        validate: (timeout: number): boolean => {
+            if (timeout <= 0) {
+                throw new TypeError('The option "bidiResponseTimeout" needs to be a positive number')
+            }
+
+            return true
+        }
     },
     /**
      * Override default agent

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -57,7 +57,8 @@ export default class WebDriver {
             Object.assign(bidiPrototype, initiateBidi(
                 capabilities.webSocketUrl as unknown as string,
                 options.strictSSL,
-                options.headers
+                options.headers,
+                params.bidiResponseTimeout
             ))
         }
 
@@ -139,7 +140,8 @@ export default class WebDriver {
             Object.assign(bidiPrototype, initiateBidi(
                 webSocketUrl as string,
                 options.strictSSL,
-                options.headers
+                options.headers,
+                options.bidiResponseTimeout
             ))
         }
 

--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -460,12 +460,14 @@ export const getSessionError = (err: JSONWPCommandError, params: Partial<Options
  * @param socketUrl url to bidi interface
  * @param strictSSL
  * @param userHeaders
+ * @param responseTimeout timeout for a Bidi command to receive a response from the browser
  * @returns prototype with interface for bidi primitives
  */
 export function initiateBidi (
     socketUrl: string,
     strictSSL: boolean = true,
-    userHeaders?: Record<string, string>
+    userHeaders?: Record<string, string>,
+    responseTimeout?: number
 ): PropertyDescriptorMap {
     /**
      * don't connect and stale unit tests when the websocket url is set to a dummy value
@@ -489,7 +491,7 @@ export function initiateBidi (
     if (userHeaders) {
         bidiReqOpts.headers = userHeaders
     }
-    const handler = new BidiHandler(socketUrl, bidiReqOpts)
+    const handler = new BidiHandler(socketUrl, bidiReqOpts, responseTimeout)
     handler.connect().then((isConnected) => isConnected && log.info(`Connected to WebDriver Bidi interface at ${socketUrl}`))
 
     return {

--- a/packages/webdriver/tests/bidi.test.ts
+++ b/packages/webdriver/tests/bidi.test.ts
@@ -82,6 +82,18 @@ describe('BidiCore', () => {
                 .rejects.toMatchSnapshot()
         })
 
+        it('rejects a non-positive responseTimeout', () => {
+            expect(() => new BidiCore('ws://foo/bar', undefined, 0)).toThrow(
+                'The option "bidiResponseTimeout" needs to be a positive number'
+            )
+            expect(() => new BidiCore('ws://foo/bar', undefined, -1)).toThrow(
+                'The option "bidiResponseTimeout" needs to be a positive number'
+            )
+            expect(() => new BidiCore('ws://foo/bar', undefined, NaN)).toThrow(
+                'The option "bidiResponseTimeout" needs to be a positive number'
+            )
+        })
+
         it('sends and waits for result', async () => {
             const handler = new BidiCore('ws://foo/bar')
             await handler.connect()
@@ -116,9 +128,38 @@ describe('BidiCore', () => {
 
             const error = await promise.catch((err) => err)
             const errorMessage = 'WebDriver Bidi command "session.new" failed with error: foobar - I am an error!'
-            expect(error.stack).toContain(path.join('packages', 'webdriver', 'tests', 'bidi.test.ts:107:').slice(1))
+            expect(error.stack).toContain(path.join('packages', 'webdriver', 'tests', 'bidi.test.ts:119:').slice(1))
             expect(error.stack).toContain(errorMessage)
             expect(error.message).toBe(errorMessage)
+        })
+
+        it('times out if the browser does not respond in time', async () => {
+            vi.useFakeTimers()
+            const handler = new BidiCore('ws://foo/bar', undefined, 1000)
+            await handler.connect()
+
+            const promise = handler.send({ method: 'session.new', params: {} })
+            const error = promise.catch((err: Error) => err)
+            await vi.advanceTimersByTimeAsync(1000)
+            expect((await error).message).toContain('timed out after 1000ms')
+
+            /**
+             * a late response should not resolve the already rejected command
+             */
+            handler.__handleResponse.call(this as any, Buffer.from(JSON.stringify({ id: 1, result: 'foobar' })))
+            vi.useRealTimers()
+        })
+
+        it('does not time out before the configured response timeout', async () => {
+            vi.useFakeTimers()
+            const handler = new BidiCore('ws://foo/bar', undefined, 100000)
+            await handler.connect()
+
+            const promise = handler.send({ method: 'session.new', params: {} })
+            await vi.advanceTimersByTimeAsync(90000)
+            handler.__handleResponse.call(this as any, Buffer.from(JSON.stringify({ id: 1, result: 'foobar' })))
+            await expect(promise).resolves.toEqual({ id: 1, result: 'foobar' })
+            vi.useRealTimers()
         })
 
         it('should pass custom headers to Bidi Core', async () => {

--- a/packages/webdriver/tests/constants.test.ts
+++ b/packages/webdriver/tests/constants.test.ts
@@ -13,6 +13,8 @@ test('should do correct type check for "path"', () => {
 test('should do correct type check for "bidiResponseTimeout"', () => {
     expect(() => DEFAULTS.bidiResponseTimeout?.validate!(0)).toThrow()
     expect(() => DEFAULTS.bidiResponseTimeout?.validate!(-1)).toThrow()
+    expect(() => DEFAULTS.bidiResponseTimeout?.validate!(NaN)).toThrow()
+    expect(() => DEFAULTS.bidiResponseTimeout?.validate!(Infinity)).toThrow()
     expect(() => DEFAULTS.bidiResponseTimeout?.validate!(1000)).not.toThrow()
 })
 

--- a/packages/webdriver/tests/constants.test.ts
+++ b/packages/webdriver/tests/constants.test.ts
@@ -10,6 +10,12 @@ test('should do correct type check for "path"', () => {
     expect(() => DEFAULTS.path?.validate!('/123')).not.toThrow()
 })
 
+test('should do correct type check for "bidiResponseTimeout"', () => {
+    expect(() => DEFAULTS.bidiResponseTimeout?.validate!(0)).toThrow()
+    expect(() => DEFAULTS.bidiResponseTimeout?.validate!(-1)).toThrow()
+    expect(() => DEFAULTS.bidiResponseTimeout?.validate!(1000)).not.toThrow()
+})
+
 test('should return the passed-in request options', () => {
     const requestOptions = {
         uri: { pathname: '/wd/hub/session' }

--- a/packages/webdriver/tests/index.test.ts
+++ b/packages/webdriver/tests/index.test.ts
@@ -25,6 +25,7 @@ vi.mock('fetch')
 vi.mock('../src/bidi/core.js', () => {
     let initCount = 0
     return {
+        DEFAULT_RESPONSE_TIMEOUT: 1000 * 180,
         BidiCore: class BidiHandlerMock {
             connect = vi.fn().mockResolvedValue({})
             constructor () {
@@ -186,7 +187,31 @@ describe('WebDriver', () => {
                 headers
             })
 
-            expect(utils.initiateBidi).toHaveBeenCalledWith(webSocketUrl, strictSSL, headers)
+            expect(utils.initiateBidi).toHaveBeenCalledWith(
+                webSocketUrl,
+                strictSSL,
+                headers,
+                DEFAULTS.bidiResponseTimeout.default
+            )
+        })
+
+        it('should pass a custom "bidiResponseTimeout" to "initiateBidi"', async () => {
+            const webSocketUrl = 'ws://foo/bar'
+
+            vi.spyOn(utils, 'initiateBidi')
+            vi.mocked(fetch).mockResolvedValueOnce(Response.json({ value: { webSocketUrl } }))
+            await WebDriver.newSession({
+                path: '/',
+                capabilities: { browserName: 'firefox' },
+                bidiResponseTimeout: 300000
+            })
+
+            expect(utils.initiateBidi).toHaveBeenCalledWith(
+                webSocketUrl,
+                undefined,
+                undefined,
+                300000
+            )
         })
     })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,8 +745,8 @@ importers:
         specifier: ^1.4.1
         version: 1.6.0(rollup@4.53.3)(vite@5.4.21(@types/node@25.3.5)(terser@5.43.1))
       webdriver:
-        specifier: ^9.0.0
-        version: 9.16.2
+        specifier: workspace:*
+        version: link:../webdriver
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.2
@@ -998,7 +998,7 @@ importers:
         version: link:../wdio-logger
       '@wdio/runner':
         specifier: ^9.16.2
-        version: 9.16.2(expect-webdriverio@5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.24.0(puppeteer-core@24.34.0)))(webdriverio@9.24.0(puppeteer-core@24.34.0))
+        version: 9.16.2(expect-webdriverio@5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.30.0(puppeteer-core@24.34.0)))(webdriverio@9.30.0(puppeteer-core@24.34.0))
       '@wdio/types':
         specifier: workspace:*
         version: link:../wdio-types
@@ -5308,11 +5308,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@puppeteer/browsers@2.13.0':
-    resolution: {integrity: sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   '@puppeteer/browsers@2.13.2':
     resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
     engines: {node: '>=18'}
@@ -6741,10 +6736,6 @@ packages:
     resolution: {integrity: sha512-a7zDSNzpGgkb6mWrg9GWPmvh/sZFzaf86/iBjCv+n2DTY0+8v8NLruRQmWuCaQAlLVhM3XAqmB+fWLqxDhdvOA==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/config@9.24.0':
-    resolution: {integrity: sha512-rcHu0eG16rSEmHL0sEKDcr/vYFmGhQ5GOlmlx54r+1sgh6sf136q+kth4169s16XqviWGW3LjZbUfpTK29pGtw==}
-    engines: {node: '>=18.20.0'}
-
   '@wdio/config@9.30.0':
     resolution: {integrity: sha512-pH/Y1F4QVIsx33xyli8+9HCr4HRuOeUk8j/lqNBuuUzbvduYRCLmNkZqxRsLnRth8wrlPdzA8Hq+PPLwJWrceA==}
     engines: {node: '>=18.20.0'}
@@ -6785,9 +6776,6 @@ packages:
   '@wdio/protocols@9.16.2':
     resolution: {integrity: sha512-h3k97/lzmyw5MowqceAuY3HX/wGJojXHkiPXA3WlhGPCaa2h4+GovV2nJtRvknCKsE7UHA1xB5SWeI8MzloBew==}
 
-  '@wdio/protocols@9.24.0':
-    resolution: {integrity: sha512-ozQKYddBLT4TRvU9J+fGrhVUtx3iDAe+KNCJcTDMFMxNSdDMR2xFQdNp8HLHypspk58oXTYCvz6ZYjySthhqsw==}
-
   '@wdio/protocols@9.30.0':
     resolution: {integrity: sha512-VDKCTw3GVdqUw1+fXAY4FUOSt+a3/r7T2O34d5HAaZLfI6QHacsU7/N0Sv3w/QgWU6yj3WkXElXq1oSWF1XcBw==}
 
@@ -6810,20 +6798,12 @@ packages:
     resolution: {integrity: sha512-P86FvM/4XQGpJKwlC2RKF3I21TglPvPOozJGG9HoL0Jmt6jRF20ggO/nRTxU0XiWkRdqESUTmfA87bdCO4GRkQ==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/types@9.24.0':
-    resolution: {integrity: sha512-PYYunNl8Uq1r8YMJAK6ReRy/V/XIrCSyj5cpCtR5EqCL6heETOORFj7gt4uPnzidfgbtMBcCru0LgjjlMiH1UQ==}
-    engines: {node: '>=18.20.0'}
-
   '@wdio/types@9.29.1':
     resolution: {integrity: sha512-jp8jgMv6TS35G96YzHZxw3PVN0Dz6xQ6tnMAicndAJ8Jt9AIXb0ywIse4TjaFywakO3dLoEhlyA3ZtR26vmt+w==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/utils@9.16.2':
     resolution: {integrity: sha512-bsRdEUXUTYvznXH/Z+p6HDzHSjMI6I6bnu8WXWTeDDDyqybWK5D8cbZvs8A/kMmGXoz1GZkSBHxy4Z5NTg8OQg==}
-    engines: {node: '>=18.20.0'}
-
-  '@wdio/utils@9.24.0':
-    resolution: {integrity: sha512-6WhtzC5SNCGRBTkaObX6A07Ofnnyyf+TQH/d/fuhZRqvBknrP4AMMZF+PFxGl1fwdySWdBn+gV2QLE+52Byowg==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/utils@9.30.0':
@@ -7219,14 +7199,6 @@ packages:
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
 
-  b4a@1.8.0:
-    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
-    peerDependencies:
-      react-native-b4a: '*'
-    peerDependenciesMeta:
-      react-native-b4a:
-        optional: true
-
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
     peerDependencies:
@@ -7304,15 +7276,6 @@ packages:
       bare-buffer:
         optional: true
 
-  bare-fs@4.5.5:
-    resolution: {integrity: sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==}
-    engines: {bare: '>=1.16.0'}
-    peerDependencies:
-      bare-buffer: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-
   bare-fs@4.7.4:
     resolution: {integrity: sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==}
     engines: {bare: '>=1.16.0'}
@@ -7348,17 +7311,6 @@ packages:
 
   bare-stream@2.7.0:
     resolution: {integrity: sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==}
-    peerDependencies:
-      bare-buffer: '*'
-      bare-events: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-      bare-events:
-        optional: true
-
-  bare-stream@2.8.0:
-    resolution: {integrity: sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==}
     peerDependencies:
       bare-buffer: '*'
       bare-events: '*'
@@ -9607,7 +9559,7 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -9617,7 +9569,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -14095,9 +14047,6 @@ packages:
   tar-fs@3.1.1:
     resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
 
-  tar-fs@3.1.2:
-    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
-
   tar-fs@3.1.3:
     resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
 
@@ -14111,9 +14060,6 @@ packages:
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
-
-  tar-stream@3.1.8:
-    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
 
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
@@ -14931,25 +14877,12 @@ packages:
     resolution: {integrity: sha512-T7QKqD+N0hfvrxq/am5wqdOuyOy7F2tGS7X2f/7jyhrxSPG6Q0cNkSt4gCwla+q3nDMivCP0QIPc7mAVSx5AYQ==}
     engines: {node: '>=18.20.0'}
 
-  webdriver@9.24.0:
-    resolution: {integrity: sha512-2R31Ey83NzMsafkl4hdFq6GlIBvOODQMkueLjeRqYAITu3QCYiq9oqBdnWA6CdePuV4dbKlYsKRX0mwMiPclDA==}
-    engines: {node: '>=18.20.0'}
-
   webdriver@9.30.0:
     resolution: {integrity: sha512-DisY5E8p5zAZyl8pee08p4Vlc91c94Am9oswZaNCgZH5Ewm//FoCZ+tHNppENqooCYjfa/upATbFqGOLuXQkrw==}
     engines: {node: '>=18.20.0'}
 
   webdriverio@9.16.2:
     resolution: {integrity: sha512-aRcfBZyY+OFqz2DI0ZYmMahGlH3h/clAXXOQSFN5QfrHG4Cjuo5xy3lq4tVfszjEJ813+wwC4HJLbgDmMrPXkA==}
-    engines: {node: '>=18.20.0'}
-    peerDependencies:
-      puppeteer-core: '>=22.x || <=24.x'
-    peerDependenciesMeta:
-      puppeteer-core:
-        optional: true
-
-  webdriverio@9.24.0:
-    resolution: {integrity: sha512-LTJt6Z/iDM0ne/4ytd3BykoPv9CuJ+CAILOzlwFeMGn4Mj02i4Bk2Rg9o/jeJ89f52hnv4OPmNjD0e8nzWAy5g==}
     engines: {node: '>=18.20.0'}
     peerDependencies:
       puppeteer-core: '>=22.x || <=24.x'
@@ -20036,21 +19969,6 @@ snapshots:
       - bare-buffer
       - supports-color
 
-  '@puppeteer/browsers@2.13.0':
-    dependencies:
-      debug: 4.4.3
-      extract-zip: 2.0.1
-      progress: 2.0.3
-      proxy-agent: 6.5.0
-      semver: 7.7.4
-      tar-fs: 3.1.2
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-      - supports-color
-
   '@puppeteer/browsers@2.13.2':
     dependencies:
       debug: 4.4.3
@@ -21874,21 +21792,6 @@ snapshots:
       - bare-buffer
       - supports-color
 
-  '@wdio/config@9.24.0':
-    dependencies:
-      '@wdio/logger': 9.18.0
-      '@wdio/types': 9.24.0
-      '@wdio/utils': 9.24.0
-      deepmerge-ts: 7.1.5
-      glob: 10.5.0
-      import-meta-resolve: 4.2.0
-      jiti: 2.6.1
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-      - supports-color
-
   '@wdio/config@9.30.0':
     dependencies:
       '@wdio/logger': 9.29.1
@@ -21926,10 +21829,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@wdio/globals@9.16.2(expect-webdriverio@5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.24.0(puppeteer-core@24.34.0)))(webdriverio@9.24.0(puppeteer-core@24.34.0))':
+  '@wdio/globals@9.16.2(expect-webdriverio@5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.30.0(puppeteer-core@24.34.0)))(webdriverio@9.30.0(puppeteer-core@24.34.0))':
     dependencies:
-      expect-webdriverio: 5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.24.0(puppeteer-core@24.34.0))
-      webdriverio: 9.24.0(puppeteer-core@24.34.0)
+      expect-webdriverio: 5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.30.0(puppeteer-core@24.34.0))
+      webdriverio: 9.30.0(puppeteer-core@24.34.0)
 
   '@wdio/globals@9.29.1(expect-webdriverio@5.6.5)(webdriverio@9.16.2(puppeteer-core@24.34.0))':
     dependencies:
@@ -21971,8 +21874,6 @@ snapshots:
 
   '@wdio/protocols@9.16.2': {}
 
-  '@wdio/protocols@9.24.0': {}
-
   '@wdio/protocols@9.30.0': {}
 
   '@wdio/repl@9.16.2':
@@ -21987,19 +21888,19 @@ snapshots:
       diff: 7.0.0
       object-inspect: 1.13.4
 
-  '@wdio/runner@9.16.2(expect-webdriverio@5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.24.0(puppeteer-core@24.34.0)))(webdriverio@9.24.0(puppeteer-core@24.34.0))':
+  '@wdio/runner@9.16.2(expect-webdriverio@5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.30.0(puppeteer-core@24.34.0)))(webdriverio@9.30.0(puppeteer-core@24.34.0))':
     dependencies:
       '@types/node': 20.19.27
       '@wdio/config': 9.16.2
       '@wdio/dot-reporter': 9.16.2
-      '@wdio/globals': 9.16.2(expect-webdriverio@5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.24.0(puppeteer-core@24.34.0)))(webdriverio@9.24.0(puppeteer-core@24.34.0))
+      '@wdio/globals': 9.16.2(expect-webdriverio@5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.30.0(puppeteer-core@24.34.0)))(webdriverio@9.30.0(puppeteer-core@24.34.0))
       '@wdio/logger': 9.16.2
       '@wdio/types': 9.16.2
       '@wdio/utils': 9.16.2
       deepmerge-ts: 7.1.5
-      expect-webdriverio: 5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.24.0(puppeteer-core@24.34.0))
+      expect-webdriverio: 5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.30.0(puppeteer-core@24.34.0))
       webdriver: 9.16.2
-      webdriverio: 9.24.0(puppeteer-core@24.34.0)
+      webdriverio: 9.30.0(puppeteer-core@24.34.0)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -22008,10 +21909,6 @@ snapshots:
       - utf-8-validate
 
   '@wdio/types@9.16.2':
-    dependencies:
-      '@types/node': 20.19.37
-
-  '@wdio/types@9.24.0':
     dependencies:
       '@types/node': 20.19.37
 
@@ -22037,28 +21934,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
-      - supports-color
-
-  '@wdio/utils@9.24.0':
-    dependencies:
-      '@puppeteer/browsers': 2.13.0
-      '@wdio/logger': 9.18.0
-      '@wdio/types': 9.24.0
-      decamelize: 6.0.1
-      deepmerge-ts: 7.1.5
-      edgedriver: 6.3.0
-      geckodriver: 6.1.1
-      get-port: 7.1.0
-      import-meta-resolve: 4.2.0
-      locate-app: 2.5.0
-      mitt: 3.0.1
-      safaridriver: 1.0.1
-      split2: 4.2.0
-      wait-port: 1.1.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
       - supports-color
 
   '@wdio/utils@9.30.0':
@@ -22488,8 +22363,6 @@ snapshots:
 
   b4a@1.6.7: {}
 
-  b4a@1.8.0: {}
-
   b4a@1.8.1: {}
 
   babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.99.9(@swc/core@1.15.8)):
@@ -22562,16 +22435,6 @@ snapshots:
       - bare-abort-controller
     optional: true
 
-  bare-fs@4.5.5:
-    dependencies:
-      bare-events: 2.8.2
-      bare-path: 3.0.0
-      bare-stream: 2.8.0(bare-events@2.8.2)
-      bare-url: 2.3.2
-      fast-fifo: 1.3.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-
   bare-fs@4.7.4:
     dependencies:
       bare-events: 2.9.1
@@ -22583,11 +22446,13 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  bare-os@3.6.2: {}
+  bare-os@3.6.2:
+    optional: true
 
   bare-path@3.0.0:
     dependencies:
       bare-os: 3.6.2
+    optional: true
 
   bare-path@3.1.1: {}
 
@@ -22610,18 +22475,10 @@ snapshots:
       - bare-abort-controller
     optional: true
 
-  bare-stream@2.8.0(bare-events@2.8.2):
-    dependencies:
-      streamx: 2.23.0
-      teex: 1.0.1
-    optionalDependencies:
-      bare-events: 2.8.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-
   bare-url@2.3.2:
     dependencies:
       bare-path: 3.0.0
+    optional: true
 
   bare-url@2.4.6:
     dependencies:
@@ -24850,16 +24707,6 @@ snapshots:
       expect: 30.2.0
       jest-matcher-utils: 30.2.0
       webdriverio: link:packages/webdriverio
-
-  expect-webdriverio@5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.24.0(puppeteer-core@24.34.0)):
-    dependencies:
-      '@vitest/snapshot': 4.0.16
-      '@wdio/globals': link:packages/wdio-globals
-      '@wdio/logger': link:packages/wdio-logger
-      deep-eql: 5.0.2
-      expect: 30.2.0
-      jest-matcher-utils: 30.2.0
-      webdriverio: 9.24.0(puppeteer-core@24.34.0)
 
   expect-webdriverio@5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@9.30.0(puppeteer-core@24.34.0)):
     dependencies:
@@ -30631,6 +30478,7 @@ snapshots:
       text-decoder: 1.2.3
     transitivePeerDependencies:
       - bare-abort-controller
+    optional: true
 
   streamx@2.28.0:
     dependencies:
@@ -30907,18 +30755,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
 
-  tar-fs@3.1.2:
-    dependencies:
-      pump: 3.0.4
-      tar-stream: 3.1.8
-    optionalDependencies:
-      bare-fs: 4.5.5
-      bare-path: 3.0.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-
   tar-fs@3.1.3:
     dependencies:
       pump: 3.0.4
@@ -30956,17 +30792,6 @@ snapshots:
       streamx: 2.22.1
     transitivePeerDependencies:
       - bare-abort-controller
-
-  tar-stream@3.1.8:
-    dependencies:
-      b4a: 1.8.0
-      bare-fs: 4.5.5
-      fast-fifo: 1.3.2
-      streamx: 2.23.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
 
   tar-stream@3.2.0:
     dependencies:
@@ -31875,27 +31700,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriver@9.24.0:
-    dependencies:
-      '@types/node': 20.19.37
-      '@types/ws': 8.18.1
-      '@wdio/config': 9.24.0
-      '@wdio/logger': 9.18.0
-      '@wdio/protocols': 9.24.0
-      '@wdio/types': 9.24.0
-      '@wdio/utils': 9.24.0
-      deepmerge-ts: 7.1.5
-      https-proxy-agent: 7.0.6
-      undici: 6.27.0
-      ws: 8.21.1
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - bufferutil
-      - react-native-b4a
-      - supports-color
-      - utf-8-validate
-
   webdriver@9.30.0:
     dependencies:
       '@types/node': 20.19.43
@@ -31950,43 +31754,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  webdriverio@9.24.0(puppeteer-core@24.34.0):
-    dependencies:
-      '@types/node': 20.19.37
-      '@types/sinonjs__fake-timers': 8.1.5
-      '@wdio/config': 9.24.0
-      '@wdio/logger': 9.18.0
-      '@wdio/protocols': 9.24.0
-      '@wdio/repl': 9.16.2
-      '@wdio/types': 9.24.0
-      '@wdio/utils': 9.24.0
-      archiver: 7.0.1
-      aria-query: 5.3.2
-      cheerio: 1.2.0
-      css-shorthand-properties: 1.1.2
-      css-value: 0.0.1
-      grapheme-splitter: 1.0.4
-      htmlfy: 0.8.1
-      is-plain-obj: 4.1.0
-      jszip: 3.10.1
-      lodash.clonedeep: 4.5.0
-      lodash.zip: 4.2.0
-      query-selector-shadow-dom: 1.0.1
-      resq: 1.11.0
-      rgb2hex: 0.2.5
-      serialize-error: 12.0.0
-      urlpattern-polyfill: 10.1.0
-      webdriver: 9.24.0
-    optionalDependencies:
-      puppeteer-core: 24.34.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - bufferutil
-      - react-native-b4a
       - supports-color
       - utf-8-validate
 

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -119,6 +119,13 @@ Maximum count of request retries to the Selenium server.
 Type: `Number`<br />
 Default: `3`
 
+### bidiResponseTimeout
+
+Timeout (in ms) for a WebDriver Bidi command to receive a response from the browser. Increase this if you run commands, e.g. [`execute`](/docs/api/browser/execute), that legitimately take longer than the default to resolve, otherwise WebdriverIO gives up waiting before the browser is done.
+
+Type: `Number`<br />
+Default: `180000`
+
 ### agent
 
 Allows you to use a custom` http`/`https`/`http2` [agent](https://www.npmjs.com/package/got#agent) to make requests.


### PR DESCRIPTION
## Proposed changes
#15460
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
The `webdriver` package's WebDriver Bidi transport had a hardcoded, unconfigurable 60-second client-side timeout for every Bidi command (`RESPONSE_TIMEOUT` in `bidi/core.ts`). This meant that any command that legitimately takes longer than 60s to resolve on the browser side  for example, `script.callFunction` calls waiting on a slow render or a large DOM update would be killed by the transport itself, even when the caller had configured its own, much larger timeout (e.g. `scriptTimeout`, or a test framework's own wait timeout). When the browser's real response arrived after the fact, the client had already discarded the pending command, producing a second, unrelated-looking `Couldn't resolve command with id N` error
## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
