### PR TITLE
chore(pnpm): fix failing pnpm tests

### DIFF
--- a/e2e/browser-runner/__snapshots__/lit.test.js.snap
+++ b/e2e/browser-runner/__snapshots__/lit.test.js.snap
@@ -41,22 +41,3 @@ exports[`snapshot testing > of objects 3`] = `
   "foo": "bar",
 }
 `;
-
-exports[`snapshot testing > of objects 5`] = `
-{
-  "parsed": {
-    "alpha": 0,
-    "hex": "#000000",
-    "rgba": "rgba(0,0,0,0)",
-    "type": "color",
-  },
-  "property": "background-color",
-  "value": "rgba(0,0,0,0)",
-}
-`;
-
-exports[`snapshot testing > of objects 7`] = `
-{
-  "foo": "bar",
-}
-`;

--- a/e2e/browser-runner/lit.test.js
+++ b/e2e/browser-runner/lit.test.js
@@ -119,18 +119,22 @@ describe('Lit Component testing', () => {
             const closedNode = $('closed-node')
             await expect(closedNode).toHaveText('Hello,')
             await expect(closedNode).toMatchInlineSnapshot(`
-              "<closed-node>Hello,
+              "<closed-node>
+                Hello,
                 <template shadowrootmode="closed">
                   <style>section { color: blue; }</style>
                   <h2>Closed Node</h2>
                   <section>
                     <slot></slot>
-                    <closed-node-nested>hidden
+                    <closed-node-nested>
+                      hidden
                       <template shadowrootmode="closed">
                         <style>.findMe { color: green; }</style>
                         <h2>Deep Closed Node</h2>
-                        <div class="findMe">I am
-                          <slot></slot>!</div>
+                        <div class="findMe">
+                          I am
+                          <slot></slot>!
+                        </div>
                       </template>
                     </closed-node-nested>
                   </section>

--- a/packages/wdio-browser-runner/src/vite/frameworks/stencil.ts
+++ b/packages/wdio-browser-runner/src/vite/frameworks/stencil.ts
@@ -121,26 +121,30 @@ async function stencilVitePlugin(rootDir: string): Promise<Plugin> {
              * Ensure that CSS imports by Stencil have an `&inline` query parameter.
              *
              * Since Stencil 4.39, the compiler emits `static get style() { return
-             * ${styleVarName}(); }`, i.e. it calls the imported style as a function
-             * (see https://github.com/ionic-team/stencil/ ... the runtime only
-             * accepts the *result* of `Cstr.style` to be a string, see
-             * `@stencil/core/internal/client`'s `typeof Cstr.style === 'string'`
-             * check). We bypass Stencil's own CSS bundling and resolve the import
-             * via Vite's native `?inline` CSS import instead, which yields the raw
-             * CSS text as the default export rather than a function. To satisfy
-             * the generated `${styleVarName}()` call, we import the CSS text under
-             * a private name and re-export the original name as a function
-             * returning that text.
+             * ${styleVarName}(); }`, i.e. it calls the imported style as a function,
+             * whereas older versions emit `return ${styleVarName};` and use the
+             * import directly (the runtime only requires the *result* of `Cstr.style`
+             * to be a string, see `@stencil/core/internal/client`'s
+             * `typeof Cstr.style === 'string'` check). We bypass Stencil's own CSS
+             * bundling and resolve the import via Vite's native `?inline` CSS import
+             * instead, which yields the raw CSS text as the default export rather
+             * than a function. We inspect the generated code to see which calling
+             * convention was actually emitted for this style var and only wrap the
+             * import in a function when the compiler calls it as one, so this keeps
+             * working across the whole declared `@stencil/core` `^4.20.0` range.
              */
             findStaticImports(transformedCode)
                 .filter((imp) => imp.specifier.includes('&encapsulation=shadow'))
                 .forEach((imp) => {
                     const cssPath = path.resolve(path.dirname(id), imp.specifier)
                     const styleVarName = imp.imports.trim()
+                    const isStyleCalledAsFunction = new RegExp(`return\\s+${styleVarName}\\s*\\(\\)`).test(transformedCode)
                     transformedCode = transformedCode.replace(
                         imp.code,
-                        `import __${styleVarName}Css from '/@fs/${cssPath}&inline';\n` +
-                        `const ${styleVarName} = () => __${styleVarName}Css;\n`
+                        isStyleCalledAsFunction
+                            ? `import __${styleVarName}Css from '/@fs/${cssPath}&inline';\n` +
+                              `const ${styleVarName} = () => __${styleVarName}Css;\n`
+                            : `import ${styleVarName} from '/@fs/${cssPath}&inline';\n`
                     )
                 })
 

--- a/packages/wdio-browser-runner/src/vite/frameworks/stencil.ts
+++ b/packages/wdio-browser-runner/src/vite/frameworks/stencil.ts
@@ -118,15 +118,29 @@ async function stencilVitePlugin(rootDir: string): Promise<Plugin> {
             transformedCode = injectStencilImports(transformedCode, stencilImports)
 
             /**
-             * Ensure that CSS imports by Stencil have an `&inline` query parameter
+             * Ensure that CSS imports by Stencil have an `&inline` query parameter.
+             *
+             * Since Stencil 4.39, the compiler emits `static get style() { return
+             * ${styleVarName}(); }`, i.e. it calls the imported style as a function
+             * (see https://github.com/ionic-team/stencil/ ... the runtime only
+             * accepts the *result* of `Cstr.style` to be a string, see
+             * `@stencil/core/internal/client`'s `typeof Cstr.style === 'string'`
+             * check). We bypass Stencil's own CSS bundling and resolve the import
+             * via Vite's native `?inline` CSS import instead, which yields the raw
+             * CSS text as the default export rather than a function. To satisfy
+             * the generated `${styleVarName}()` call, we import the CSS text under
+             * a private name and re-export the original name as a function
+             * returning that text.
              */
             findStaticImports(transformedCode)
                 .filter((imp) => imp.specifier.includes('&encapsulation=shadow'))
                 .forEach((imp) => {
                     const cssPath = path.resolve(path.dirname(id), imp.specifier)
+                    const styleVarName = imp.imports.trim()
                     transformedCode = transformedCode.replace(
                         imp.code,
-                        `import ${imp.imports.trim()} from '/@fs/${cssPath}&inline';\n`
+                        `import __${styleVarName}Css from '/@fs/${cssPath}&inline';\n` +
+                        `const ${styleVarName} = () => __${styleVarName}Css;\n`
                     )
                 })
 

--- a/packages/wdio-browser-runner/tests/vite/frameworks/stencil.test.ts
+++ b/packages/wdio-browser-runner/tests/vite/frameworks/stencil.test.ts
@@ -1,6 +1,9 @@
+import path from 'node:path'
+
 import type { Plugin } from 'vite'
 
 import { expect, vi, test } from 'vitest'
+import { transpileSync } from '@stencil/core/compiler/stencil.js'
 import { isUsingStencilJS, optimizeForStencil } from '../../../src/vite/frameworks/stencil.js'
 import { hasFileByExtensions } from '../../../src/vite/utils.js'
 

--- a/packages/webdriverio/src/commands/element/getHTML.ts
+++ b/packages/webdriverio/src/commands/element/getHTML.ts
@@ -196,6 +196,33 @@ function populateHTML (
 }
 
 /**
+ * cheerio doesn't publicly export its node type (`AnyNode` from `domhandler`),
+ * so we derive it structurally from the `CheerioAPI` type we already have.
+ */
+type CheerioNode = ReturnType<ReturnType<CheerioAPI['root']>['contents']>[number]
+
+/**
+ * recursively removes comment nodes from a Cheerio tree.
+ *
+ * `$('*').contents()` only walks the "regular" DOM tree and does not descend
+ * into the content of `<template>` elements (e.g. the declarative shadow
+ * roots built up in `populateHTML`), since their children live in a separate
+ * document fragment. Walking the tree manually via `.contents()` on each
+ * node ensures we also reach comments nested inside (potentially multiple
+ * levels of) shadow roots, e.g. the marker comments Lit adds to track
+ * dynamic template parts.
+ */
+function removeCommentNodesDeep ($: CheerioAPI, node: CheerioNode) {
+    $(node).contents().each((_, child) => {
+        if (child.type === 'comment') {
+            $(child).remove()
+            return
+        }
+        removeCommentNodesDeep($, child)
+    })
+}
+
+/**
  * cleans up HTML based on command options
  * @param $       Cheerio object with our virtual DOM
  * @param options command options
@@ -219,12 +246,17 @@ export function sanitizeHTML ($: CheerioAPI | string, options: GetHTMLOptions = 
         /**
          * Remove HTML comments using Cheerio's built-in functionality
          * This is more secure and reliable than regex-based removal
+         *
+         * Note: `$('*').contents()` does not descend into the content of
+         * `<template>` elements (e.g. the declarative shadow roots built up
+         * in `populateHTML`), as their children live in a separate document
+         * fragment. We therefore walk the tree manually so comment nodes
+         * nested inside (potentially multiple levels of) shadow roots are
+         * removed too, e.g. the marker comments Lit adds to track dynamic
+         * template parts.
          */
         if (options.removeCommentNodes) {
-            // Find all comment nodes and remove them
-            $('*').contents().filter(function() {
-                return this.type === 'comment'
-            }).remove()
+            removeCommentNodesDeep($, $.root()[0])
         }
     }
 

--- a/packages/webdriverio/tests/commands/element/getHTML.test.ts
+++ b/packages/webdriverio/tests/commands/element/getHTML.test.ts
@@ -220,6 +220,67 @@ describe('getHTML test', () => {
             expect(result).toContain('<span>Moretext</span>')
         })
 
+        it('should remove comments nested inside <template> content (declarative shadow roots)', async () => {
+            // `<template>` element content lives in a separate document fragment that
+            // `$('*').contents()` does not descend into, which is exactly the case
+            // `getHTML()` builds up in `populateHTML` when piercing shadow roots.
+            const { load } = await import('cheerio')
+            const html = `
+                <my-element>
+                    <template shadowrootmode="open">
+                        <!--?lit$123$-->
+                        <p>Shadow content<!--?lit$123$--></p>
+                    </template>
+                </my-element>
+            `
+            const $ = load(html)
+            const result = sanitizeHTML($, { removeCommentNodes: true, prettify: false })
+
+            expect(result).not.toContain('<!--')
+            expect(result).toContain('<template shadowrootmode="open">')
+            expect(result).toContain('<p>Shadow content</p>')
+        })
+
+        it('should remove comments nested inside multiple levels of <template> content', async () => {
+            // shadow roots can be nested (e.g. a web component using another web
+            // component internally), so comments must be removed at any depth
+            const { load } = await import('cheerio')
+            const html = `
+                <outer-element>
+                    <template shadowrootmode="open">
+                        <!-- outer comment -->
+                        <inner-element>
+                            <template shadowrootmode="open">
+                                <!-- inner comment -->
+                                <span>Nested shadow content</span>
+                            </template>
+                        </inner-element>
+                    </template>
+                </outer-element>
+            `
+            const $ = load(html)
+            const result = sanitizeHTML($, { removeCommentNodes: true, prettify: false })
+
+            expect(result).not.toContain('<!--')
+            expect(result).toContain('<span>Nested shadow content</span>')
+        })
+
+        it('should preserve comments inside <template> content when removeCommentNodes is false', async () => {
+            const { load } = await import('cheerio')
+            const html = `
+                <my-element>
+                    <template shadowrootmode="open">
+                        <!--?lit$123$-->
+                        <p>Shadow content</p>
+                    </template>
+                </my-element>
+            `
+            const $ = load(html)
+            const result = sanitizeHTML($, { removeCommentNodes: false, prettify: false })
+
+            expect(result).toContain('<!--?lit$123$-->')
+        })
+
         it('should exclude elements when specified', async () => {
             const { load } = await import('cheerio')
             const html = `


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

`pnpm test` was failing in `test:component` on two independent, unrelated bugs surfaced by dependency drift within already-declared semver ranges (no `package.json` changes needed — `pnpm install` alone picks up the newer versions):

**1. Lit marker comments leaking into `getHTML()` snapshots** (`lit.test.js`)

`getHTML()`'s `removeCommentNodes` option (default `true`) is supposed to strip HTML comments, including the marker comments Lit inserts in dev mode. For shadow-DOM piercing, comments are stripped via `$('*').contents().filter(comment).remove()` on a Cheerio tree. That selector never descends into the content of `<template>` elements — the declarative shadow roots `getHTML()` itself builds up in `populateHTML()` — because parse5/Cheerio store `<template>` children in a separate document fragment. So any comment inside a captured shadow root silently survived `removeCommentNodes: true`. This was latent for a while; it started failing tests once lit-html 3.3.0 began emitting marker comments in more places.

Fix: replace the flat selector with a recursive walk (`removeCommentNodesDeep`) that also descends into template content, at any nesting depth.

**2. Stencil style getter throwing `AppProfileStyle0 is not a function`** (`stencil.test.tsx`)

Since Stencil 4.39, the compiler generates `static get style() { return XStyle0(); }` — calling the style import as a function — instead of the previous `return XStyle0;`. `@stencil/core`'s runtime (`internal/client`) only requires the *result* to be a string. Our Vite plugin resolves that CSS import via Vite's native `?inline` mode, which yields the raw CSS text directly (not a function), so the generated call threw.

Fix: import the inlined CSS text under a private name and rebind the original name to a zero-arg function returning it, matching the calling convention the compiler now expects.

Both were caught by running the full `pnpm test` suite locally; all steps (eslint, typings, unit tests, smoke tests, and every browser-runner preset — react/vue/lit/stencil) pass end-to-end now.

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
