### PR TITLE
feat(cli/repl): support TS files

### DIFF
--- a/packages/wdio-cli/src/commands/run.ts
+++ b/packages/wdio-cli/src/commands/run.ts
@@ -6,7 +6,7 @@ import type { Argv } from 'yargs'
 import Launcher from '../launcher.js'
 import Watcher from '../watcher.js'
 import { coerceOptsFor, } from '../utils.js'
-import { CLI_EPILOGUE } from '../constants.js'
+import { CLI_EPILOGUE, TS_FILE_EXTENSIONS } from '../constants.js'
 import type { RunCommandArguments } from '../types.js'
 import { config } from 'create-wdio/config/cli'
 import { ConfigParser } from '@wdio/config/node'
@@ -217,7 +217,6 @@ export async function handler(argv: RunCommandArguments) {
      * Load tsx before attempting to read the config file if it's TypeScript.
      * This prevents "Unknown file extension" errors when calling tsConfigPathFromConfigFile.
      */
-    const TS_FILE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts']
     if (TS_FILE_EXTENSIONS.some((ext) => confAccess.endsWith(ext))) {
         const { resolve } = await import('import-meta-resolve')
         const tsxPath = resolve('tsx', import.meta.url)

--- a/packages/wdio-cli/src/constants.ts
+++ b/packages/wdio-cli/src/constants.ts
@@ -21,6 +21,8 @@ export const IOS_CONFIG = {
     automationName: 'XCUITest',
     deviceName: 'iPhone Simulator'
 }
+
+export const TS_FILE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts']
 const SUPPORTED_SNAPSHOTSTATE_OPTIONS = ['all', 'new', 'none'] as const
 
 export const TESTRUNNER_DEFAULTS: Options.Definition<Options.Testrunner & { capabilities: unknown }> = {

--- a/packages/wdio-cli/src/launcher.ts
+++ b/packages/wdio-cli/src/launcher.ts
@@ -10,7 +10,7 @@ import type { Capabilities, Services } from '@wdio/types'
 
 import CLInterface from './interface.js'
 import { runLauncherHook, runOnCompleteHook, runServiceHook, nodeVersion, type HookError } from './utils.js'
-import { TESTRUNNER_DEFAULTS, WORKER_GROUPLOGS_MESSAGES } from './constants.js'
+import { TESTRUNNER_DEFAULTS, TS_FILE_EXTENSIONS, WORKER_GROUPLOGS_MESSAGES } from './constants.js'
 import type { RunCommandArguments } from './types.js'
 const log = logger('@wdio/cli:launcher')
 
@@ -34,8 +34,6 @@ export interface EndMessage {
     specs: string[],
     retries: number
 }
-
-const TS_FILE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts']
 
 class Launcher {
     #isInitialized: boolean = false

--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -174,6 +174,17 @@ export async function getCapabilities(arg: ReplCommandArguments) {
     } else if (/ios/.test(arg.option)) {
         return { capabilities: { browserName: 'Safari', ...IOS_CONFIG, ...optionalCapabilites } }
     } else if (/(js|ts)$/.test(arg.option)) {
+        /**
+         * Load tsx before attempting to read the config file if it's TypeScript.
+         * This prevents "Unknown file extension" errors when parsing the config.
+         */
+        const TS_FILE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts']
+        if (TS_FILE_EXTENSIONS.some((ext) => arg.option.endsWith(ext))) {
+            const { resolve } = await import('import-meta-resolve')
+            const tsxPath = resolve('tsx', import.meta.url)
+            await import(tsxPath)
+        }
+
         const config = new ConfigParser(arg.option)
         try {
             await config.initialize()

--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -9,6 +9,7 @@ import type { Capabilities, Services } from '@wdio/types'
 import {
     ANDROID_CONFIG,
     IOS_CONFIG,
+    TS_FILE_EXTENSIONS,
 } from './constants.js'
 import type {
     OnCompleteResult,
@@ -173,12 +174,11 @@ export async function getCapabilities(arg: ReplCommandArguments) {
         return { capabilities: { browserName: 'Chrome', ...ANDROID_CONFIG, ...optionalCapabilites } }
     } else if (/ios/.test(arg.option)) {
         return { capabilities: { browserName: 'Safari', ...IOS_CONFIG, ...optionalCapabilites } }
-    } else if (/\.(m|c)?[jt]sx?$/.test(arg.option)) {
+    } else if (/\.(m|c)?(js|tsx?)$/.test(arg.option)) {
         /**
          * Load tsx before attempting to read the config file if it's TypeScript.
          * This prevents "Unknown file extension" errors when parsing the config.
          */
-        const TS_FILE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts']
         if (TS_FILE_EXTENSIONS.some((ext) => arg.option.endsWith(ext))) {
             const { resolve } = await import('import-meta-resolve')
             const tsxPath = resolve('tsx', import.meta.url)

--- a/packages/wdio-cli/src/utils.ts
+++ b/packages/wdio-cli/src/utils.ts
@@ -173,7 +173,7 @@ export async function getCapabilities(arg: ReplCommandArguments) {
         return { capabilities: { browserName: 'Chrome', ...ANDROID_CONFIG, ...optionalCapabilites } }
     } else if (/ios/.test(arg.option)) {
         return { capabilities: { browserName: 'Safari', ...IOS_CONFIG, ...optionalCapabilites } }
-    } else if (/(js|ts)$/.test(arg.option)) {
+    } else if (/\.(m|c)?[jt]sx?$/.test(arg.option)) {
         /**
          * Load tsx before attempting to read the config file if it's TypeScript.
          * This prevents "Unknown file extension" errors when parsing the config.

--- a/packages/wdio-cli/tests/__snapshots__/utils.test.ts.snap
+++ b/packages/wdio-cli/tests/__snapshots__/utils.test.ts.snap
@@ -81,6 +81,14 @@ exports[`getCapabilities > should return driver with capabilities for multiremot
 }
 `;
 
+exports[`getCapabilities > should support TypeScript config files 1`] = `
+{
+  "capabilities": {
+    "browserName": "chrome",
+  },
+}
+`;
+
 exports[`getCapabilities > should through capability not found 1`] = `[Error: No capability found in given config file with the provided capability indexed/named property: 5. Please check the capability in your wdio config file.]`;
 
 exports[`getCapabilities > should throw capability not provided 1`] = `[Error: Please provide index/named property of capability to use from the capabilities array/object in wdio config file]`;

--- a/packages/wdio-cli/tests/__snapshots__/utils.test.ts.snap
+++ b/packages/wdio-cli/tests/__snapshots__/utils.test.ts.snap
@@ -81,14 +81,6 @@ exports[`getCapabilities > should return driver with capabilities for multiremot
 }
 `;
 
-exports[`getCapabilities > should support TypeScript config files 1`] = `
-{
-  "capabilities": {
-    "browserName": "chrome",
-  },
-}
-`;
-
 exports[`getCapabilities > should through capability not found 1`] = `[Error: No capability found in given config file with the provided capability indexed/named property: 5. Please check the capability in your wdio config file.]`;
 
 exports[`getCapabilities > should throw capability not provided 1`] = `[Error: Please provide index/named property of capability to use from the capabilities array/object in wdio config file]`;

--- a/packages/wdio-cli/tests/utils.test.ts
+++ b/packages/wdio-cli/tests/utils.test.ts
@@ -313,6 +313,15 @@ describe('getCapabilities', () => {
         expect(autoCompileMock).toBeCalledTimes(1)
     })
 
+    it('should support TypeScript config files', async () => {
+        const getCapabilitiesMock = vi.spyOn(ConfigParser.prototype, 'getCapabilities')
+        getCapabilitiesMock.mockReturnValue([
+            { browserName: 'chrome' }
+        ] as WebdriverIO.Capabilities)
+        expect(await getCapabilities({ option: '/path/to/config.ts', capabilities: 0 } as any))
+            .toMatchSnapshot()
+    })
+
     it('should return driver with capabilities for multiremote config', async () => {
         const getCapabilitiesMock = vi.spyOn(ConfigParser.prototype, 'getCapabilities')
         getCapabilitiesMock.mockReturnValue({

--- a/packages/wdio-cli/tests/utils.test.ts
+++ b/packages/wdio-cli/tests/utils.test.ts
@@ -313,13 +313,13 @@ describe('getCapabilities', () => {
         expect(autoCompileMock).toBeCalledTimes(1)
     })
 
-    it('should support TypeScript config files', async () => {
+    it.each(['.ts', '.tsx', '.mts', '.cts'])('should support %s TypeScript config files', async (ext) => {
         const getCapabilitiesMock = vi.spyOn(ConfigParser.prototype, 'getCapabilities')
         getCapabilitiesMock.mockReturnValue([
             { browserName: 'chrome' }
         ] as WebdriverIO.Capabilities)
-        expect(await getCapabilities({ option: '/path/to/config.ts', capabilities: 0 } as any))
-            .toMatchSnapshot()
+        expect(await getCapabilities({ option: `/path/to/config${ext}`, capabilities: 0 } as any))
+            .toEqual({ capabilities: { browserName: 'chrome' } })
     })
 
     it('should return driver with capabilities for multiremote config', async () => {

--- a/packages/wdio-cli/tests/utils.test.ts
+++ b/packages/wdio-cli/tests/utils.test.ts
@@ -51,6 +51,12 @@ vi.mock('@wdio/config/node', () => ({
     }
 }))
 
+const { resolveMock } = vi.hoisted(() => ({
+    resolveMock: vi.fn((specifier: string) => specifier)
+}))
+vi.mock('import-meta-resolve', () => ({ resolve: resolveMock }))
+vi.mock('tsx', () => ({}))
+
 beforeEach(() => {
     global.console.log = vi.fn()
 
@@ -61,6 +67,7 @@ beforeEach(() => {
             type: 'module'
         }
     })
+    resolveMock.mockClear()
 })
 
 describe('runServiceHook', () => {
@@ -320,6 +327,17 @@ describe('getCapabilities', () => {
         ] as WebdriverIO.Capabilities)
         expect(await getCapabilities({ option: `/path/to/config${ext}`, capabilities: 0 } as any))
             .toEqual({ capabilities: { browserName: 'chrome' } })
+        expect(resolveMock).toHaveBeenCalledWith('tsx', expect.any(String))
+    })
+
+    it('should not load tsx for non-TypeScript config files', async () => {
+        const getCapabilitiesMock = vi.spyOn(ConfigParser.prototype, 'getCapabilities')
+        getCapabilitiesMock.mockReturnValue([
+            { browserName: 'chrome' }
+        ] as WebdriverIO.Capabilities)
+        expect(await getCapabilities({ option: '/path/to/config.js', capabilities: 0 } as any))
+            .toEqual({ capabilities: { browserName: 'chrome' } })
+        expect(resolveMock).not.toHaveBeenCalled()
     })
 
     it('should return driver with capabilities for multiremote config', async () => {


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

This PR implements https://github.com/webdriverio/webdriverio/issues/13109

Root cause: `getCapabilities` in `packages/wdio-cli/src/utils.ts` matched `.js/.ts` config paths but only run/launcher actually loaded the tsx ESM loader hooks before parsing — repl never did, so .ts configs failed with `"Unknown file extension"`.

Fix (`packages/wdio-cli/src/utils.ts`): before instantiating `ConfigParser`, if `arg.option` ends in a TS extension (`.ts/.tsx/.mts/.cts`), dynamically resolve and `import tsx` — mirroring the exact pattern already used in `commands/run.ts`. No new dependencies needed (`tsx` and `import-meta-resolve` are already wdio-cli deps).

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
