### PR TITLE
fix(webdriverio): reset current context when browsing context is destroyed

### DIFF
--- a/packages/webdriverio/src/session/context.ts
+++ b/packages/webdriverio/src/session/context.ts
@@ -30,6 +30,7 @@ export class ContextManager extends SessionManager {
     #onCommandListener: (event: { command: string, body: unknown }) => void
     #onCommandResultMobileListener: (event: { command: string, result: unknown }) => void
     #navigationStartedListener: (nav: local.BrowsingContextNavigationInfo) => void
+    #destroyedListener: (destroyed: local.BrowsingContextInfo) => void
 
     constructor(browser: WebdriverIO.Browser) {
         super(browser, ContextManager.name)
@@ -46,6 +47,7 @@ export class ContextManager extends SessionManager {
         this.#onCommandListener = this.#onCommand.bind(this)
         this.#onCommandResultMobileListener = this.#onCommandResultMobile.bind(this)
         this.#navigationStartedListener = this.#navigationStarted.bind(this)
+        this.#destroyedListener = this.#contextDestroyed.bind(this)
 
         /**
          * Listens for the 'closeWindow' browser command to handle context changes.
@@ -77,9 +79,10 @@ export class ContextManager extends SessionManager {
              * through navigation within e.g. frames.
              */
             this.#browser.sessionSubscribe({
-                events: ['browsingContext.navigationStarted']
+                events: ['browsingContext.navigationStarted', 'browsingContext.contextDestroyed']
             })
             this.#browser.on('browsingContext.navigationStarted', this.#navigationStartedListener)
+            this.#browser.on('browsingContext.contextDestroyed', this.#destroyedListener)
         }
     }
 
@@ -91,6 +94,7 @@ export class ContextManager extends SessionManager {
             this.#browser.off('result', this.#onCommandResultMobileListener)
         } else {
             this.#browser.off('browsingContext.navigationStarted', this.#navigationStartedListener)
+            this.#browser.off('browsingContext.contextDestroyed', this.#destroyedListener)
         }
     }
 
@@ -121,6 +125,93 @@ export class ContextManager extends SessionManager {
             await this.#browser.switchToWindow(this.#currentContext)
             return
         }
+    }
+
+    async #contextDestroyed(destroyed: local.BrowsingContextInfo) {
+        /**
+         * no need to do anything if the destroyed context is not the current one
+         */
+        if (!this.#currentContext || destroyed.context !== this.#currentContext) {
+            return
+        }
+
+        /**
+         * the current context was destroyed, e.g. when the user closes a tab or
+         * popup window, so reset the current context and switch to a remaining
+         * window to avoid running subsequent commands against a context that no
+         * longer exists.
+         */
+        this.#currentWindowHandle = undefined
+        this.#currentContext = undefined
+
+        let handle: string | undefined
+        try {
+            /**
+             * if the destroyed context is a child frame, resolve the top-level
+             * context it belongs to rather than switching to a potentially
+             * unrelated top-level window
+             */
+            if (destroyed.parent) {
+                handle = await this.#getTopLevelContext(destroyed.parent)
+            }
+
+            if (!handle) {
+                const windowHandles = await this.#browser.getWindowHandles()
+                handle = windowHandles.find((windowHandle) => windowHandle !== destroyed.context) ?? windowHandles[0]
+            }
+
+            if (!handle) {
+                return
+            }
+
+            /**
+             * a newer context transition may have happened while the recovery
+             * was resolving, in which case the cached context is already set
+             * and must not be overwritten
+             */
+            if (this.#currentContext) {
+                return
+            }
+
+            await this.#browser.switchToWindow(handle)
+
+            /**
+             * a newer context transition may also happen while the recovery
+             * switch is pending, so only cache the handle if no other
+             * transition took over in the meantime
+             */
+            if (this.#currentContext && this.#currentContext !== handle) {
+                return
+            }
+            this.setCurrentContext(handle)
+        } catch (err) {
+            /**
+             * the recovery switch failed (e.g. the target handle is already
+             * gone), so clear the cached context to force a re-initialization
+             * on the next `getCurrentContext()` call, unless a newer transition
+             * already took over
+             */
+            if (!this.#currentContext || this.#currentContext === handle) {
+                this.#currentContext = undefined
+                this.#currentWindowHandle = undefined
+            }
+            log.warn(`Failed to switch context after "${destroyed.context}" was destroyed: ${(err as Error).message}`)
+        }
+    }
+
+    /**
+     * Resolve the top-level context of a given context id, e.g. the top-level
+     * browsing context a child frame belongs to.
+     * @param contextId the context id to resolve the top-level context for
+     * @returns the top-level context id, or undefined if it can't be found
+     */
+    async #getTopLevelContext(contextId: string) {
+        const { contexts } = await this.#browser.browsingContextGetTree({})
+        let context = this.findContext(contextId, contexts, 'byContextId')
+        while (context?.parent) {
+            context = this.findContext(context.parent, contexts, 'byContextId')
+        }
+        return context?.context
     }
 
     #onCommandResultBidiAndClassic(event: { command: string, result: unknown, body: unknown }) {

--- a/packages/webdriverio/tests/session/context.test.ts
+++ b/packages/webdriverio/tests/session/context.test.ts
@@ -2,12 +2,13 @@ import path from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { getContextManager } from '../../src/session/context.js'
+import { logMock } from '@wdio/logger'
 
 vi.mock('@wdio/logger', () => import(path.join(process.cwd(), '__mocks__', '@wdio/logger')))
 
 type ListenerMap = Record<string, Array<(arg: any) => any>>
 
-function createBrowserStub() {
+function createBrowserStub(overrides: Partial<WebdriverIO.Browser> = {}) {
     const listeners: ListenerMap = {}
     const browser = {
         sessionId: Math.random().toString(36).slice(2),
@@ -21,7 +22,10 @@ function createBrowserStub() {
         off: vi.fn(),
         switchToWindow: vi.fn(),
         sessionSubscribe: vi.fn(),
-        browsingContextGetTree: vi.fn()
+        browsingContextGetTree: vi.fn(),
+        getWindowHandles: vi.fn(),
+        getWindowHandle: vi.fn(),
+        ...overrides
     } as unknown as WebdriverIO.Browser & { on: any, off: any, switchToWindow: any }
 
     return {
@@ -38,6 +42,7 @@ describe('ContextManager', () => {
         const stub = createBrowserStub()
         browser = stub.browser
         getListeners = stub.getListeners
+        vi.mocked(logMock.warn).mockClear()
         // instantiate to register listeners
         getContextManager(browser)
     })
@@ -99,5 +104,231 @@ describe('ContextManager', () => {
         const error = new Error('no such window')
         handler({ command: 'switchToWindow', result: { error } })
         expect(getContextManager(browser).getCurrentWindowHandle()).toBeUndefined()
+    })
+
+    it('registers a listener for browsingContext.contextDestroyed in bidi sessions', () => {
+        const wid = process.env.WDIO_UNIT_TESTS
+        delete process.env.WDIO_UNIT_TESTS
+        const stub = createBrowserStub({ isBidi: true } as any)
+        getContextManager(stub.browser)
+        process.env.WDIO_UNIT_TESTS = wid
+        expect(stub.browser.sessionSubscribe).toHaveBeenCalledWith({
+            events: ['browsingContext.navigationStarted', 'browsingContext.contextDestroyed']
+        })
+        expect(stub.getListeners()['browsingContext.contextDestroyed']?.length).toBeGreaterThan(0)
+    })
+
+    it('resets the current context and switches to a remaining window when the current context is destroyed', async () => {
+        const wid = process.env.WDIO_UNIT_TESTS
+        delete process.env.WDIO_UNIT_TESTS
+        const stub = createBrowserStub({ isBidi: true } as any)
+        const browser = stub.browser
+        ;(browser as any).getWindowHandles.mockResolvedValue(['handle-B'])
+        const manager = getContextManager(browser)
+        process.env.WDIO_UNIT_TESTS = wid
+        manager.setCurrentContext('context-1')
+
+        const destroyedHandlers = stub.getListeners()['browsingContext.contextDestroyed']
+        await destroyedHandlers![0]({ context: 'context-1' })
+
+        expect(browser.switchToWindow).toHaveBeenCalledWith('handle-B')
+        expect(await manager.getCurrentContext()).toBe('handle-B')
+        expect(manager.getCurrentWindowHandle()).toBeUndefined()
+    })
+
+    it('ignores contextDestroyed events for contexts that are not the current one', async () => {
+        const wid = process.env.WDIO_UNIT_TESTS
+        delete process.env.WDIO_UNIT_TESTS
+        const stub = createBrowserStub({ isBidi: true } as any)
+        const browser = stub.browser
+        const manager = getContextManager(browser)
+        process.env.WDIO_UNIT_TESTS = wid
+        manager.setCurrentContext('context-1')
+
+        const destroyedHandlers = stub.getListeners()['browsingContext.contextDestroyed']
+        await destroyedHandlers![0]({ context: 'context-2' })
+
+        expect(browser.switchToWindow).not.toHaveBeenCalled()
+        expect(await manager.getCurrentContext()).toBe('context-1')
+    })
+
+    it('does not switch windows when no remaining window handles exist after the current context is destroyed', async () => {
+        const wid = process.env.WDIO_UNIT_TESTS
+        delete process.env.WDIO_UNIT_TESTS
+        const stub = createBrowserStub({ isBidi: true } as any)
+        const browser = stub.browser
+        ;(browser as any).getWindowHandles.mockResolvedValue([])
+        const manager = getContextManager(browser)
+        process.env.WDIO_UNIT_TESTS = wid
+        manager.setCurrentContext('context-1')
+
+        const destroyedHandlers = stub.getListeners()['browsingContext.contextDestroyed']
+        await destroyedHandlers![0]({ context: 'context-1' })
+
+        expect(browser.switchToWindow).not.toHaveBeenCalled()
+    })
+
+    it('switches to the parent context when a destroyed current context is a child frame (regression test)', async () => {
+        const wid = process.env.WDIO_UNIT_TESTS
+        delete process.env.WDIO_UNIT_TESTS
+        const stub = createBrowserStub({ isBidi: true } as any)
+        const browser = stub.browser
+        ;(browser as any).browsingContextGetTree.mockResolvedValue({
+            contexts: [{
+                context: 'context-1', parent: null, children: null,
+                url: '', clientWindow: 'window-1', originalOpener: null, userContext: 'default'
+            }]
+        })
+        const manager = getContextManager(browser)
+        process.env.WDIO_UNIT_TESTS = wid
+        manager.setCurrentContext('frame-1')
+
+        const destroyedHandlers = stub.getListeners()['browsingContext.contextDestroyed']
+        await destroyedHandlers![0]({ context: 'frame-1', parent: 'context-1' })
+
+        expect(browser.getWindowHandles).not.toHaveBeenCalled()
+        expect(browser.switchToWindow).toHaveBeenCalledWith('context-1')
+        expect(await manager.getCurrentContext()).toBe('context-1')
+        expect(manager.getCurrentWindowHandle()).toBeUndefined()
+    })
+
+    it('switches to the top-level context when a nested child frame is destroyed (regression test)', async () => {
+        const wid = process.env.WDIO_UNIT_TESTS
+        delete process.env.WDIO_UNIT_TESTS
+        const stub = createBrowserStub({ isBidi: true } as any)
+        const browser = stub.browser
+        ;(browser as any).browsingContextGetTree.mockResolvedValue({
+            contexts: [{
+                context: 'context-1', parent: null, url: '', clientWindow: 'window-1',
+                originalOpener: null, userContext: 'default',
+                children: [{
+                    context: 'frame-parent', parent: 'context-1', url: '', clientWindow: 'window-1',
+                    originalOpener: null, userContext: 'default', children: null
+                }]
+            }]
+        })
+        const manager = getContextManager(browser)
+        process.env.WDIO_UNIT_TESTS = wid
+        manager.setCurrentContext('frame-1')
+
+        const destroyedHandlers = stub.getListeners()['browsingContext.contextDestroyed']
+        await destroyedHandlers![0]({ context: 'frame-1', parent: 'frame-parent' })
+
+        expect(browser.getWindowHandles).not.toHaveBeenCalled()
+        expect(browser.switchToWindow).toHaveBeenCalledWith('context-1')
+        expect(await manager.getCurrentContext()).toBe('context-1')
+        expect(manager.getCurrentWindowHandle()).toBeUndefined()
+    })
+
+    it('does not overwrite a newer context transition that happened during recovery', async () => {
+        const wid = process.env.WDIO_UNIT_TESTS
+        delete process.env.WDIO_UNIT_TESTS
+        const stub = createBrowserStub({ isBidi: true } as any)
+        const browser = stub.browser
+        const manager = getContextManager(browser)
+        process.env.WDIO_UNIT_TESTS = wid
+        manager.setCurrentContext('context-1')
+
+        // simulate a newer switchToWindow command transitioning the context
+        // while the destroyed context recovery is resolving window handles
+        const commandHandlers = stub.getListeners().command || []
+        ;(browser as any).getWindowHandles.mockImplementation(async () => {
+            for (const handler of commandHandlers) {
+                handler({ command: 'switchToWindow', body: { handle: 'newer-handle' } })
+            }
+            return ['handle-B']
+        })
+
+        const destroyedHandlers = stub.getListeners()['browsingContext.contextDestroyed']
+        await destroyedHandlers![0]({ context: 'context-1' })
+
+        // recovery must not clobber the newer transition
+        expect(browser.switchToWindow).not.toHaveBeenCalled()
+        expect(await manager.getCurrentContext()).toBe('newer-handle')
+    })
+
+    it('does not overwrite a newer context transition that happens during the recovery switch', async () => {
+        const wid = process.env.WDIO_UNIT_TESTS
+        delete process.env.WDIO_UNIT_TESTS
+        const stub = createBrowserStub({ isBidi: true } as any)
+        const browser = stub.browser
+        const manager = getContextManager(browser)
+        process.env.WDIO_UNIT_TESTS = wid
+        manager.setCurrentContext('context-1')
+
+        const commandHandlers = stub.getListeners().command || []
+        ;(browser as any).getWindowHandles.mockResolvedValue(['handle-B'])
+        // a newer transition happens while the recovery switch is pending
+        ;(browser as any).switchToWindow.mockImplementation(async () => {
+            for (const handler of commandHandlers) {
+                handler({ command: 'switchToWindow', body: { handle: 'newer-handle' } })
+            }
+        })
+
+        const destroyedHandlers = stub.getListeners()['browsingContext.contextDestroyed']
+        await destroyedHandlers![0]({ context: 'context-1' })
+
+        expect(browser.switchToWindow).toHaveBeenCalledWith('handle-B')
+        expect(await manager.getCurrentContext()).toBe('newer-handle')
+    })
+
+    it('does not clear a newer context transition when the recovery switch fails', async () => {
+        const wid = process.env.WDIO_UNIT_TESTS
+        delete process.env.WDIO_UNIT_TESTS
+        const stub = createBrowserStub({ isBidi: true } as any)
+        const browser = stub.browser
+        const manager = getContextManager(browser)
+        process.env.WDIO_UNIT_TESTS = wid
+        manager.setCurrentContext('context-1')
+
+        const commandHandlers = stub.getListeners().command || []
+        ;(browser as any).getWindowHandles.mockResolvedValue(['handle-B'])
+        // a newer transition happens while the recovery switch is pending and
+        // the recovery switch then fails
+        ;(browser as any).switchToWindow.mockImplementation(async () => {
+            for (const handler of commandHandlers) {
+                handler({ command: 'switchToWindow', body: { handle: 'newer-handle' } })
+            }
+            throw new Error('no such window')
+        })
+
+        const destroyedHandlers = stub.getListeners()['browsingContext.contextDestroyed']
+        await destroyedHandlers![0]({ context: 'context-1' })
+
+        expect(vi.mocked(logMock.warn)).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to switch context after "context-1" was destroyed')
+        )
+        // the newer transition must not be erased by the failed recovery
+        expect(await manager.getCurrentContext()).toBe('newer-handle')
+    })
+
+    it('logs a warning and does not throw if the recovery switch fails after the current context is destroyed', async () => {
+        const wid = process.env.WDIO_UNIT_TESTS
+        delete process.env.WDIO_UNIT_TESTS
+        const stub = createBrowserStub({ isBidi: true } as any)
+        const browser = stub.browser
+        ;(browser as any).getWindowHandles.mockResolvedValue(['handle-B'])
+        ;(browser as any).getWindowHandle.mockResolvedValue('reinitialized-handle')
+        // simulate the production switchToWindow command, which fires a 'command'
+        // event that caches the target handle before the switch resolves
+        ;(browser as any).switchToWindow.mockImplementation(async (handle: string) => {
+            browser.emit('command', { command: 'switchToWindow', body: { handle } })
+            throw new Error('no such window')
+        })
+        const manager = getContextManager(browser)
+        manager.setCurrentContext('context-1')
+
+        const destroyedHandlers = stub.getListeners()['browsingContext.contextDestroyed']
+        await expect(destroyedHandlers![0]({ context: 'context-1' })).resolves.toBeUndefined()
+
+        expect(browser.switchToWindow).toHaveBeenCalledWith('handle-B')
+        expect(vi.mocked(logMock.warn)).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to switch context after "context-1" was destroyed')
+        )
+        // the failed switch must not leave the cached context pointing at the
+        // failed handle, so the next getCurrentContext() call re-initializes
+        expect(await manager.getCurrentContext()).toBe('reinitialized-handle')
+        expect(manager.getCurrentWindowHandle()).toBeUndefined()
+        process.env.WDIO_UNIT_TESTS = wid
     })
 })


### PR DESCRIPTION
## What's changed

When the current browsing context is destroyed (e.g. the user closes a tab or a popup window), `ContextManager` keeps its stale `#currentContext`. Subsequent commands are then executed against a context that no longer exists, which surfaces as:

```
WARN webdriverio: Failed to find the context "…" in the current browsing context tree.
… WebDriverError: no such window: target window already closed
```

This PR makes `ContextManager` listen for the `browsingContext.contextDestroyed` event. When the destroyed context is the **current** one, it clears the cached context and window handle and switches to a remaining window handle (falling back to the first handle if none other is reported). Contexts that are not the current one are ignored.

## Implementation

- Subscribe to `browsingContext.contextDestroyed` alongside `browsingContext.navigationStarted` (`packages/webdriverio/src/session/context.ts`)
- Add `#contextDestroyed` handler that resets `#currentContext` / `#currentWindowHandle` and switches to a live window
- Register/unregister the listener in the constructor and `removeListeners()`
- Add unit tests in `packages/webdriverio/tests/session/context.test.ts` covering: listener registration, current-context destroyed → reset + switch, non-current context destroyed → ignored, and no remaining handles → no switch

## Notes

This complements the same-context navigation handling already done via `browsingContext.navigationStarted` (see #15467). It specifically covers the multi-context case where the previous context disappears entirely.

## Repro

1. Open `main.html` (opens a popup window via `window.open`)
2. Run the spec below — the popup context becomes the current context, then it is closed

```html
<!-- main.html -->
<!doctype html>
<html>
<body>
    <button id="open">Open popup</button>
    <button id="close">Close popup</button>
    <script>
        let win
        document.getElementById('open').onclick = () => { win = window.open('popup.html', 'popup', 'width=400,height=400') }
        document.getElementById('close').onclick = () => { win.close() }
    </script>
</body>
</html>
```

```html
<!-- popup.html -->
<!doctype html>
<html>
<body><p>popup</p></body>
</html>
```

```js
const { browser } = require('@wdio/globals')

describe('context destroyed', () => {
    it('recovers after the current context is destroyed', async () => {
        await browser.url('http://localhost:8081/main.html')
        await $('#open').click()
        await browser.switchWindow('popup.html')
        await browser.pause(300)
        await $('#close').click()
        await browser.pause(300)
        await browser.switchWindow('main.html') // works after the fix; fails with "no such window: target window already closed" before
    })
})
```

## Checklist

- [x] Existing unit tests still pass
- [x] New unit tests cover the regression
- [x] `eslint` passes on the changed files

Closes #15476
