### PR TITLE
fix(@wdio/utils): keep an undefined element that passes filter

### DIFF
--- a/packages/wdio-utils/src/pIteration.ts
+++ b/packages/wdio-utils/src/pIteration.ts
@@ -1,3 +1,8 @@
+/* Marks an element the callback rejected. A plain `undefined` cannot do it:
+ * an element that is itself `undefined` and passes the test has to survive.
+ */
+const REJECTED = Symbol('rejected')
+
 /**
  * Implements ES5 [`Array#forEach()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) method.<br><br>
  * Executes the provided callback once for each element.<br>
@@ -302,14 +307,25 @@ export const filter = <T>(array: T[], callback: Function, thisArg?: T) => {
             }
         }
 
-        return Promise.all(
-            promiseArray.map(async (p, i) => {
-                if (await p) {
-                    return await array[i]
-                }
-                return undefined
-            })).then((result) => result.filter((val) => typeof val !== 'undefined')
-        ).then(resolve, reject)
+        /* `undefined` cannot mark a rejected element: an element that is
+         * itself `undefined` and passes the test has to survive, the way
+         * `Array#filter` and `filterSeries` keep it. Holes are dropped here
+         * rather than by the value, since a hole never ran the callback.
+         */
+        const results: Promise<T | typeof REJECTED>[] = []
+        for (let i = 0; i < array.length; i++) {
+            if (!(i in array)) {
+                continue
+            }
+            const passed = promiseArray[i]
+            results.push(
+                (async () => ((await passed) ? await array[i] : REJECTED))()
+            )
+        }
+
+        return Promise.all(results)
+            .then((result) => result.filter((val) => val !== REJECTED) as T[])
+            .then(resolve, reject)
     })
 }
 

--- a/packages/wdio-utils/tests/pIteration.test.ts
+++ b/packages/wdio-utils/tests/pIteration.test.ts
@@ -462,6 +462,24 @@ test('filter should skip holes in arrays', async () => {
     expect(numbers).toEqual([0, 1, 2, 5])
 })
 
+test('filter keeps an undefined element that passes the test', async () => {
+    // `undefined` cannot double as the marker for a rejected element:
+    // `Array#filter` and `filterSeries` both keep it.
+    const input = [undefined, 1, undefined, 2]
+    const predicate = async () => true
+
+    await expect(filter(input, predicate)).resolves.toEqual(input.filter(() => true))
+    await expect(filter(input, predicate)).resolves.toEqual(
+        await filterSeries(input, predicate)
+    )
+})
+
+test('filter drops an undefined element that fails the test', async () => {
+    await expect(
+        filter([undefined, 1, undefined, 2], async (value: unknown) => typeof value === 'number')
+    ).resolves.toEqual([1, 2])
+})
+
 test('filter, check callbacks are run in parallel', async () => {
     const parallelCheck: number[] = []
     const numbers = await filter([2, 1, '3'], async (num: number, index: number, array: number[]) => {


### PR DESCRIPTION
## Proposed changes

`filter` in `@wdio/utils` marks a rejected element with `undefined`, then strips every `undefined` from the result:

```ts
promiseArray.map(async (p, i) => {
    if (await p) {
        return await array[i]
    }
    return undefined
})).then((result) => result.filter((val) => typeof val !== 'undefined'))
```

So an element that is itself `undefined` and passes the test is stripped along with the rejected ones:

```js
await filter([undefined, 1, undefined, 2], async () => true)
// [1, 2]
```

Both references disagree with that. The docblock says the function implements `Array#filter`, and the native method keeps them. `filterSeries`, a few lines below in the same file, keeps them too, because it decides from the callback rather than from the value:

```js
[undefined, 1, undefined, 2].filter(() => true)                    // [undefined, 1, undefined, 2]
await filterSeries([undefined, 1, undefined, 2], async () => true) // [undefined, 1, undefined, 2]
await filter([undefined, 1, undefined, 2], async () => true)       // [1, 2]
```

A step returning `undefined` is ordinary, so an array of them run through the concurrent `filter` silently comes back short.

### How it is fixed

A module-level symbol marks the rejected elements, so no user value can be mistaken for one.

Holes need care, because today they are dropped by the same `typeof val !== 'undefined'` pass. The result is now assembled in an explicit loop that skips holes up front, which is where the decision belongs anyway: a hole never ran the callback. `filter should skip holes in arrays` still passes untouched, callback count included.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

The last two are left unticked because neither applies: no public API changed and no command was added. The behaviour now matches what the existing docblock already promises.

## Backport Request

Leaving both boxes unticked, because neither is true yet and I would rather you decide.

`packages/wdio-utils/src/pIteration.ts` on `v8` carries the same `filter` byte for byte, so the bug is there as well. I have not raised a `v8` PR: the branch last moved on 2026-07-01 and I do not know whether you still want fixes of this size on it. Say the word and I will open it against `v8` with the same diff.

## Further comments

Two cases were added next to the existing `filter` ones: an `undefined` that passes the test survives, cross-checked against both `Array#filter` and `filterSeries` for the same input, and an `undefined` that fails the test is still dropped.

The first fails on `main` and passes here. The second passes on both sides, so a harness that stopped reaching the function would not read as a fix.

`vitest run packages/wdio-utils/tests/pIteration.test.ts`: 76 passed. `eslint` is clean on both files.

One caveat worth stating: I installed with `--ignore-scripts`, so the workspace type packages are unbuilt and `tsc -p packages/wdio-utils` reports 82 pre-existing errors about missing `@wdio/types` declarations. None of them are in `pIteration.ts`.

While reading the file I noticed something adjacent that I left alone: `find` and `findIndex` resolve with whichever callback settles first rather than the lowest matching index, which reads differently from `Array#find`. The docblocks do say callbacks run concurrently and point at `findSeries`, so I could not tell whether that is intended. Happy to open an issue if it is not.

### Reviewers: @webdriverio/project-committers
