### PR TITLE
ci: fix alpine e2e issue by freezing pnpm to 10

### DIFF
--- a/e2e/wdio/xvfb/docker/alpine-base.dockerfile
+++ b/e2e/wdio/xvfb/docker/alpine-base.dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache \
         libstdc++
 
 # Install pnpm globally as root
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10
 
 # Install Chrome for testing
 RUN apk add --no-cache chromium@latest

--- a/e2e/wdio/xvfb/docker/alpine-with-xvfb.dockerfile
+++ b/e2e/wdio/xvfb/docker/alpine-with-xvfb.dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache \
         libstdc++
 
 # Install pnpm globally as root
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10
 
 # Install Chromium for testing
 RUN apk add --no-cache chromium@latest

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webdriverio-monorepo",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.12.4",
+  "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e",
   "scripts": {
     "create": "tsx ./scripts/generateSubPackage.ts",
     "backport": "tsx ./scripts/backport.ts",
@@ -130,7 +130,7 @@
     "vitest": "^3.2.6"
   },
   "engines": {
-    "pnpm": ">=8.15.3"
+    "pnpm": ">=8.15.3 <11"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Proposed changes

Alpine e2e tests are failing with the error below because the Alpine container uses pnpm 11, which the project is not compatible with.
Moreover, with pnpm 11, the package's `pnpm.overrides` is now discarded and should be moved to pnpm-workspace instead.
Engine was reinforced to be more verbose on incompatible pnpm 11

See https://github.com/webdriverio/webdriverio/actions/runs/31080402558/job/92615349084
```
Run # Copy built packages and test files to container
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.
[ERROR] Cannot verify the identity of the @pnpm/exe.linux-x64 native binary: it is missing from pnpm-lock.yaml.
For help, run: pnpm help install
Error: Process completed with exit code 1.
```

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
