### PR TITLE
fix: respect WEBDRIVER_CACHE_DIR during driver setup

### DIFF
--- a/packages/wdio-utils/src/node/utils.ts
+++ b/packages/wdio-utils/src/node/utils.ts
@@ -280,7 +280,7 @@ export function getDriverOptions (caps: WebdriverIO.Capabilities) {
 
 export function getCacheDir (options: Pick<Options.WebDriver, 'cacheDir'>, caps: WebdriverIO.Capabilities) {
     const driverOptions = getDriverOptions(caps)
-    return driverOptions.cacheDir || options.cacheDir || os.tmpdir()
+    return driverOptions.cacheDir || options.cacheDir || process.env.WEBDRIVER_CACHE_DIR || os.tmpdir()
 }
 
 export function getMajorVersionFromString(fullVersion:string) {

--- a/packages/wdio-utils/tests/node/utils.test.ts
+++ b/packages/wdio-utils/tests/node/utils.test.ts
@@ -3,13 +3,13 @@ import path from 'node:path'
 import url from 'node:url'
 import cp from 'node:child_process'
 import fs from 'node:fs'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { canDownload, resolveBuildId, detectBrowserPlatform } from '@puppeteer/browsers'
 import { locateChrome, locateApp } from 'locate-app'
 
 import {
     parseParams, getBuildIdByChromePath, getBuildIdByFirefoxPath, setupPuppeteerBrowser,
-    canAccess
+    canAccess, getCacheDir
 } from '../../src/node/utils.js'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
@@ -83,6 +83,26 @@ describe('driver utils', () => {
             stderr: '',
             status: 0,
             signal: null
+        })
+    })
+
+    describe('getCacheDir', () => {
+        afterEach(() => vi.unstubAllEnvs())
+
+        it('uses WEBDRIVER_CACHE_DIR when no cache directory is configured', () => {
+            vi.stubEnv('WEBDRIVER_CACHE_DIR', '/environment/cache')
+
+            expect(getCacheDir({}, {})).toBe('/environment/cache')
+        })
+
+        it('prefers configured cache directories over WEBDRIVER_CACHE_DIR', () => {
+            vi.stubEnv('WEBDRIVER_CACHE_DIR', '/environment/cache')
+
+            expect(getCacheDir({ cacheDir: '/options/cache' }, {})).toBe('/options/cache')
+            expect(getCacheDir(
+                { cacheDir: '/options/cache' },
+                { 'wdio:chromedriverOptions': { cacheDir: '/driver/cache' } }
+            )).toBe('/driver/cache')
         })
     })
 

--- a/packages/webdriver/src/constants.ts
+++ b/packages/webdriver/src/constants.ts
@@ -1,6 +1,5 @@
 import type { Options } from '@wdio/types'
 
-import { environment } from './environment.js'
 import { DEFAULT_RESPONSE_TIMEOUT } from './bidi/core.js'
 import type { RemoteConfig } from './types.js'
 
@@ -154,8 +153,7 @@ export const DEFAULTS: Options.Definition<Required<RemoteConfig>> = {
      * when attempting to start a session.
      */
     cacheDir: {
-        type: 'string',
-        default: environment.value.variables.WEBDRIVER_CACHE_DIR
+        type: 'string'
     },
     /**
      * Mask sensitive data in logs by replacing matching string or all captured groups for the provided regular expressions as string


### PR DESCRIPTION
## Proposed changes

Fixes #14542.

This moves the `WEBDRIVER_CACHE_DIR` fallback out of WebDriver's shared defaults and into the Node-only driver setup path. Testrunner setup now resolves cache directories in this order:

1. driver-specific capability option
2. WebDriver `cacheDir` option
3. `WEBDRIVER_CACHE_DIR`
4. the system temporary directory

Regression tests cover the environment fallback and preserve both explicit configuration precedence levels.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (not applicable for this internal resolution change)
- [x] I have added proper type definitions for new commands (not applicable; no command or public type is added)

## Backport Request

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Validated with:

- `pnpm vitest --config vitest.config.ts --run packages/wdio-utils/tests packages/webdriver/tests/constants.test.ts` (274 tests)
- `pnpm vitest --config vitest.config.ts --run packages/webdriver/tests` (182 tests)
- `pnpm eslint packages/webdriver/src/constants.ts packages/wdio-utils/src/node/utils.ts packages/wdio-utils/tests/node/utils.test.ts`
- `pnpm run compile:all:main`

### Reviewers: @webdriverio/project-committers
