### PR TITLE
docs: fix API doc generator output for machine extraction

### DIFF
--- a/packages/webdriverio/src/commands/browser/action.ts
+++ b/packages/webdriverio/src/commands/browser/action.ts
@@ -148,6 +148,7 @@ import { KeyAction, PointerAction, WheelAction } from '../../utils/actions/index
  *
  * @alias browser.action
  * @type utility
+ * @skipAwait returns a chainable action builder, the `perform()` call at the end of the chain is what gets awaited
  *
  */
 export function action (

--- a/scripts/templates/template.eta
+++ b/scripts/templates/template.eta
@@ -1,3 +1,98 @@
+<%
+/**
+ * Section headings sit exactly one level below the heading that names the
+ * command: the Docusaurus page title when a command gets its own page, and
+ * the `## <command>` heading when many commands share one protocol page.
+ * Skipping straight to `#####` left these pages with an empty table of
+ * contents, because Docusaurus only collects h2 and h3.
+ */
+const sectionHeading = it.hasHeader ? '###' : '##'
+
+/**
+ * Every command on `browser`, `element`, `dialog` and `clock` is awaited.
+ * `mock` methods are not, and a command can opt out with `@skipAwait` when
+ * it returns something chainable rather than a promise.
+ */
+const awaitPrefix = it.isSkipAwait ? '' : 'await '
+
+const PLATFORM_LABELS = { ios: 'iOS', android: 'Android', windows: 'Windows' }
+const platformLabel = (platform) => PLATFORM_LABELS[platform] || platform
+
+/**
+ * Eta finds the end of this block by scanning past quoted strings, counting
+ * backticks as it goes. An odd number of them anywhere in here, in code or
+ * in a comment, makes it run straight past the closing tag and swallow the
+ * rest of the template, so the character is written as an escape.
+ */
+const BACKTICK = '\u0060'
+const BACKTICK_PATTERN = new RegExp(BACKTICK, 'g')
+
+/**
+ * A GFM table cell is pipe delimited and cannot span lines, so pipes in
+ * prose have to be escaped and any hard break becomes a `<br />`.
+ */
+const cell = (value) => String(value === undefined || value === null ? '' : value)
+    .replace(/\|/g, '\\|')
+    .replace(/\r?\n/g, '<br />')
+    .trim()
+
+/**
+ * Rows are joined here rather than emitted from a template loop, because a
+ * single blank line between two rows splits the table in half.
+ */
+const parameterTable = (paramTags) => {
+    const rows = paramTags.map((paramTag) => {
+        /**
+         * `@rowInfo` groups the rows that follow it. Markdown has no
+         * colspan, so the label goes in the first column and any text after
+         * the `::` separator goes in the last one.
+         */
+        if (paramTag.tag === 'rowInfo') {
+            const [label, details] = paramTag.string.includes('::')
+                ? paramTag.string.split('::').map((part) => part.trim())
+                : [paramTag.string, '']
+            const detailsCell = cell(details)
+            return `| **${cell(label)}** | |${detailsCell ? ` ${detailsCell} ` : ''}|`
+        }
+
+        const isOptional = (!paramTag.required && typeof paramTag.optional === 'undefined') || paramTag.optional
+        const name = `\`${paramTag.name}${paramTag.default ? `=${paramTag.default}` : ''}\``
+        /**
+         * types arrive backtick wrapped from the JSDoc commands and bare from
+         * the protocol definitions, so they are normalised to one code span
+         */
+        const type = BACKTICK + paramTag.type
+            .replace(BACKTICK_PATTERN, '')
+            .replace('(', '')
+            .replace(')', '')
+            .split('|')
+            .map((part) => part.trim())
+            .filter(Boolean)
+            .join(', ') + BACKTICK
+
+        return `| ${cell(name)}${isOptional ? '<br />*optional*' : ''} | ${cell(type)} | ${cell(paramTag.description)} |`
+    })
+
+    /**
+     * the trailing newline keeps a blank line between the last row and
+     * whatever section follows, without which the table runs into it
+     */
+    return ['| Name | Type | Details |', '| --- | --- | --- |', ...rows].join('\n') + '\n'
+}
+
+/**
+ * The support icons carry the platform and driver versions in their alt
+ * text alone, which is lost by anything that strips images.
+ */
+const supportList = (support) => Object.keys(support)
+    .map((platform) => {
+        const drivers = Object.keys(support[platform])
+            .map((driver) => `${driver} (${support[platform][driver]})`)
+            .join(', ')
+        return `- **${platformLabel(platform)}:** ${drivers}`
+    })
+    .join('\n')
+%>
 <% if (it.hasDocusaurusHeader) { %>
 ---
 id: <%= it.command %>
@@ -31,11 +126,11 @@ This protocol command is embedded in the following convenient method<%= it.alter
 
 <% if (!it.isSkipUsage) { %>
 
-##### Usage
+<%= sectionHeading %> Usage
 
 ```js
 <% if (it.isElementScope) { %>
-$(selector).<%= it.command %>(<%= it.paramString %>)
+<%= awaitPrefix %>$(selector).<%= it.command %>(<%= it.paramString %>)
 <% } else if (it.isMockScope) { %>
 mock.<%= it.command %>(<%= it.paramString %>)
 <% } else if (it.isDialogScope) { %>
@@ -44,49 +139,23 @@ await dialog.<%= it.command %>(<%= it.paramString %>)
 const clock = await browser.emulate('clock', { ... })
 await clock.<%= it.command %>(<%= it.paramString %>)
 <% } else { %>
-<%= it.isMobile ? 'driver' : 'browser' %>.<%= it.command %>(<%= it.paramString %>)
+<%= awaitPrefix %><%= it.isMobile ? 'driver' : 'browser' %>.<%= it.command %>(<%= it.paramString %>)
 <% } %>
 ```
 
 <% } %>
 
 <% if (it.paramTags.length) { %>
-##### Parameters
+<%= sectionHeading %> Parameters
 
-<table>
-  <thead>
-    <tr>
-      <th>Name</th><th>Type</th><th>Details</th>
-    </tr>
-  </thead>
-  <tbody>
-<% it.paramTags.forEach((paramTag) => { %>
-<% if (paramTag.tag === "rowInfo") { %>
-    <tr>
-      <% if (paramTag.string.includes('::')) { %>
-        <% const parts = paramTag.string.split('::').map(part => part.trim()); %>
-        <td colspan="3"><strong><%= parts[0] %></strong><br /><%= parts[1] %></td>
-        <% } else { %>
-        <td colspan="3"><strong><%= paramTag.string %></strong></td>
-        <% } %>
-    </tr>
-<% } else { %>
-    <tr>
-      <td><code><var><%= paramTag.name + (paramTag.default ? `=${paramTag.default}` : '') %></var></code><% if ((!paramTag.required && typeof paramTag.optional === 'undefined') || paramTag.optional) { %><br /><span className="label labelWarning">optional</span><% } %></td>
-      <td><%= paramTag.type.split('|').join(', ').replace('(', '').replace(')', '') %></td>
-      <td><%= paramTag.description %></td>
-    </tr>
-<% } %>
-<% }) %>
-  </tbody>
-</table>
+<%= parameterTable(it.paramTags) %>
 <% } %>
 
 <%
 const allExamples = [...it.examples, ...it.exampleReferences];
 if (allExamples.length) {
 %>
-##### Example<%= allExamples.length > 1 ? 's' : '' %>
+<%= sectionHeading %> Example<%= allExamples.length > 1 ? 's' : '' %>
 
 <% it.exampleReferences.forEach(function(ref) {
 const filename = it.path.basename(ref.split('#')[0]);
@@ -112,7 +181,7 @@ const ext = it.path.extname(filename).slice(1);
 <% } %>
 
 <% if (it.returns) { %>
-##### Returns
+<%= sectionHeading %> Returns
 
 - **&lt;<%= it.returns.type %>&gt;**
     <% if (it.returns.description) { %>
@@ -121,18 +190,21 @@ const ext = it.path.extname(filename).slice(1);
 <% } %>
 
 <% if (it.throwsTags.length) { %>
-##### Throws
+<%= sectionHeading %> Throws
 
 <% it.throwsTags.forEach(function(throwsTag) { %>- **<%= throwsTag.type %>**: <%= throwsTag.description %><% }) %>
 <% } %>
 
 <% if (it.support) { %>
-##### Support
+<%= sectionHeading %> Support
 
 <% if (Array.isArray(it.support) && it.support.length) { %>
 <% it.support.forEach(function(platform) { %>
 ![Support for <%= platform %>](/img/icons/<%= platform %>.svg)
 <% }) %>
+
+**Supported platforms:** <%= it.support.map(platformLabel).join(', ') %>
+
 
 :::note
 
@@ -145,5 +217,7 @@ Refer to the official [Appium driver documentation](https://appium.io/docs/en/la
     return driver + " (" + it.support[platform][driver] + ")";
 }).join(", ") %>](/img/icons/<%= platform %>.svg)
 <% }) %>
+
+<%= supportList(it.support) %>
 <% } %>
 <% } %>

--- a/scripts/utils/formatter.ts
+++ b/scripts/utils/formatter.ts
@@ -58,6 +58,7 @@ export default function (docfile: {
     let tagCustomType = ''
     let tagMobileElement = false
     let tagSkipUsage = false
+    let tagSkipAwait = false
     let tagSupport: string[] | undefined
     let returns
 
@@ -151,6 +152,10 @@ export default function (docfile: {
         }
         case 'skipUsage': {
             tagSkipUsage = true
+            break
+        }
+        case 'skipAwait': {
+            tagSkipAwait = true
             break
         }
         case 'support': {
@@ -313,6 +318,7 @@ export default function (docfile: {
         originalId: `api/${scope}/${name}`,
         isElementScope: scope === 'element' || tagMobileElement,
         isSkipUsage: tagSkipUsage,
+        isSkipAwait: tagSkipAwait,
         isNetworkScope : scope === 'network',
         isMockScope : scope === 'mock',
         isDialogScope : scope === 'dialog',


### PR DESCRIPTION
## Motivation

A growing share of our audience never reaches webdriver.io directly — they ask an assistant, and the assistant answers from whatever it can extract from our pages. `scripts/templates/template.eta` drives **every** generated API command page, and today it degrades its own output in four ways. Because it is one template, each fix propagates across the whole API reference.

This is part of a wider LLM-readiness review; it is the self-contained generator piece and depends on nothing else.

## Changes

**C1 — heading outline.** Section headings jumped from the page title straight to `#####`. Docusaurus only collects h2 and h3 for the table of contents, so every generated command page shipped an **empty TOC and no anchors** for exactly the sections someone needs to answer *"what parameters does `click` take?"*. Heading-depth chunkers also collapsed all six sections into one leaf.

Headings now sit one level below whatever names the command:

| Mode | Command heading | Sections |
| --- | --- | --- |
| `hasDocusaurusHeader` (one page per command) | Docusaurus page title | `##` |
| `hasHeader` (protocol pages, many commands per page) | `## <command>` | `###` |

**C2 — parameters as a markdown table.** They were a raw `<table>` carrying a JSX-only `className="label labelWarning"` — the least extractable form for the most structured content on the site. Now a GFM table.

- pipes in prose are escaped and hard breaks become `<br />`, since a cell cannot span lines
- `@rowInfo` group rows have no colspan equivalent in markdown, so the label goes in the first column and anything after the `::` separator goes in the last
- types are normalised to a single code span; they arrived backtick-wrapped from the JSDoc commands and bare from the protocol definitions

**C3 — `await` in usage snippets.** The snippet omitted `await` on the element and browser branches while the dialog and clock branches had it. WebdriverIO has been async-only since v8, and these snippets are the most-copied text on the site, so the omission actively teaches broken code.

`mock` methods stay unawaited, matching their own documented examples. Commands returning something chainable rather than a promise can opt out with a new `@skipAwait` tag, mirroring the existing `@skipUsage`. Only `browser.action` needs it today — it returns an action builder, and it is the `perform()` call at the end of the chain that gets awaited.

**C4 — support as text.** Platform and driver-version support was conveyed *only* as image alt text, so anything that strips images lost it entirely. The icons now carry a text line beside them.

## Before / after

`element/click`:

````diff
-##### Usage
+## Usage

 ```js
-$(selector).click({ button, x, y, skipRelease, duration })
+await $(selector).click({ button, x, y, skipRelease, duration })
 ```

-##### Parameters
-
-<table>
-  <thead><tr><th>Name</th><th>Type</th><th>Details</th></tr></thead>
-  <tbody>
-    <tr>
-      <td><code><var>options</var></code><br /><span className="label labelWarning">optional</span></td>
-      <td>`ClickOptions`</td>
-      <td>Click options (optional)</td>
-    </tr>
+## Parameters
+
+| Name | Type | Details |
+| --- | --- | --- |
+| `options`<br />*optional* | `ClickOptions` | Click options (optional) |
````

`mobile/getStrings` support section:

```diff
 ![Support for ios](/img/icons/ios.svg)
 ![Support for android](/img/icons/android.svg)
+
+**Supported platforms:** iOS, Android
```

## Testing

`node_modules` was not available in my environment, so I could not run `pnpm docs:generate` or the site build end to end. Instead I rendered the template directly through the real `formatter.ts` against `element/click`, `element/scrollIntoView`, `browser/url`, `browser/action`, `mock/respond`, `mobile/swipe`, `clock/setSystemTime` and `mobile/getStrings`, plus a hand-built protocol-mode fixture covering the object form of `@support`.

Checked in the output: populated `##`/`###` outlines in both modes, no `#####` left, valid GFM tables including the `@rowInfo` and escaped-pipe cases, `await` present on element/browser/clock and absent on `mock` and `browser.action`, and support present as text.

**Please run `pnpm docs:generate` and the site build before merging** — that is the one gap in my verification.

## Notes for reviewers

- Rows and support lines are assembled in the template's JS rather than emitted from a loop, because a single blank line between two rows splits a GFM table in half.
- The template's leading JS block writes the backtick character as a unicode escape rather than a literal. Eta finds the end of a block by scanning past quoted strings and counts backticks as it goes, so an odd number of them anywhere in that block — code *or* comment — makes it run past the closing tag and swallow the rest of the template. This is commented in place; it bit me while writing this.
- `@skipAwait` is new machinery for exactly one command. The alternative was shipping `await browser.action(...)` on that page, which contradicts the point of C3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
