### PR TITLE
fix(wdio-utils): compose element command overrides

### DIFF
--- a/packages/wdio-utils/src/monad.ts
+++ b/packages/wdio-utils/src/monad.ts
@@ -19,6 +19,34 @@ interface PropertiesObject {
     [key: string | symbol]: PropertyDescriptor
 }
 
+function composeElementOverrides(previousCommand: Function | undefined, nextCommand: Function): Function {
+    if (!previousCommand) {
+        return nextCommand
+    }
+
+    const previousElementCommand = previousCommand
+
+    return function composedElementOverride(this: WebdriverIO.Element, originalCommand: Function, ...args: unknown[]) {
+        const element = this
+
+        function previousCommandAsOriginal(this: WebdriverIO.Element, ...previousArgs: unknown[]) {
+            const context = this || element
+
+            function originalForPrevious(this: WebdriverIO.Element, ...originalArgs: unknown[]) {
+                return originalCommand.apply(this || context, originalArgs)
+            }
+
+            return previousElementCommand.call(context, originalForPrevious, ...previousArgs)
+        }
+
+        return nextCommand.call(element, previousCommandAsOriginal, ...args)
+    }
+}
+
+function setElementOverride(overrides: Record<string, Function>, name: string, command: Function): void {
+    overrides[name] = composeElementOverrides(overrides[name], command)
+}
+
 export default function WebDriver(options: object, modifier?: Function, propertiesObject: PropertiesObject = {}) {
     /**
      * In order to allow named scopes for elements we have to propagate that
@@ -188,13 +216,13 @@ export default function WebDriver(options: object, modifier?: Function, properti
                      * add command to every multiremote instance
                      */
                     Object.values(instances).forEach(instance => {
-                        instance.__propertiesObject__.__elementOverrides__.value[name] = customCommand
+                        setElementOverride(instance.__propertiesObject__.__elementOverrides__.value, name, customCommand)
                     })
                 } else {
                     /**
                      * regular mode
                      */
-                    this.__propertiesObject__.__elementOverrides__.value[name] = customCommand
+                    setElementOverride(this.__propertiesObject__.__elementOverrides__.value, name, customCommand)
                 }
             } else if (client[name]) {
                 const origCommand = client[name]

--- a/packages/wdio-utils/tests/monad.test.ts
+++ b/packages/wdio-utils/tests/monad.test.ts
@@ -17,6 +17,14 @@ beforeEach(() => {
 
 const sessionId = 'c5fa4320-07d5-48f5-b7c2-922d4405e17f'
 
+function createElement(elementOverrides: PropertyDescriptor, command: Function) {
+    return webdriverMonad({}, (element: any) => element, {
+        scope: { value: 'element' },
+        someFunc: { value: command },
+        __elementOverrides__: elementOverrides
+    })(sessionId)
+}
+
 describe('monad', () => {
     it('should be able to initialize client with prototype with commands', () => {
         const modifier = vi.fn()
@@ -106,6 +114,168 @@ describe('monad', () => {
         expect(client.__propertiesObject__.__elementOverrides__.value.someFunc(2, 3)).toBe(5)
     })
 
+    it('should compose sequential element command overrides and propagate arguments and return values', async () => {
+        const client = webdriverMonad({}, (browser: any) => browser, { ...prototype })(sessionId)
+        const calls: string[] = []
+
+        client.overwriteCommand('someFunc', async (originalCommand: Function, value: string) => {
+            calls.push(`first before: ${value}`)
+            const result = await originalCommand('value from first')
+            calls.push('first after')
+            return `first(${result})`
+        }, true)
+        client.overwriteCommand('someFunc', async (originalCommand: Function, value: string) => {
+            calls.push(`second before: ${value}`)
+            const result = await originalCommand('value from second')
+            calls.push('second after')
+            return `second(${result})`
+        }, true)
+
+        const element = createElement(client.__propertiesObject__.__elementOverrides__, async (value: string) => {
+            calls.push(`base: ${value}`)
+            return 'base result'
+        })
+
+        await expect(element.someFunc('initial value')).resolves.toBe('second(first(base result))')
+        expect(calls).toEqual([
+            'second before: initial value',
+            'first before: value from second',
+            'base: value from first',
+            'first after',
+            'second after'
+        ])
+    })
+
+    it.each([
+        {
+            name: 'plugin before guard',
+            register: (client: any, plugin: Function, guard: Function) => {
+                client.overwriteCommand('someFunc', plugin, true)
+                client.overwriteCommand('someFunc', guard, true)
+            },
+            expected: ['guard start', 'plugin', 'base', 'guard wait']
+        },
+        {
+            name: 'guard before plugin',
+            register: (client: any, plugin: Function, guard: Function) => {
+                client.overwriteCommand('someFunc', guard, true)
+                client.overwriteCommand('someFunc', plugin, true)
+            },
+            expected: ['plugin', 'guard start', 'base', 'guard wait']
+        }
+    ])('should preserve a navigation guard with $name', async ({ register, expected }) => {
+        const client = webdriverMonad({}, (browser: any) => browser, { ...prototype })(sessionId)
+        const calls: string[] = []
+        let resolveBase!: (value: string) => void
+        const baseResult = new Promise<string>((resolve) => {
+            resolveBase = resolve
+        })
+        const plugin = async (originalCommand: Function) => {
+            calls.push('plugin')
+            return originalCommand()
+        }
+        const guard = async (originalCommand: Function) => {
+            calls.push('guard start')
+            const result = await originalCommand()
+            calls.push('guard wait')
+            return result
+        }
+
+        register(client, plugin, guard)
+        const element = createElement(client.__propertiesObject__.__elementOverrides__, async () => {
+            calls.push('base')
+            return baseResult
+        })
+        let commandSettled = false
+        const commandResult = element.someFunc().then((result: string) => {
+            commandSettled = true
+            return result
+        })
+
+        await Promise.resolve()
+        expect(commandSettled).toBe(false)
+        expect(calls).toEqual(expected.slice(0, -1))
+
+        resolveBase('base result')
+        await expect(commandResult).resolves.toBe('base result')
+        expect(calls).toEqual(expected)
+    })
+
+    it('should propagate errors through sequential element command overrides', async () => {
+        const client = webdriverMonad({}, (browser: any) => browser, { ...prototype })(sessionId)
+        const calls: string[] = []
+        const error = new Error('boom')
+
+        client.overwriteCommand('someFunc', async (originalCommand: Function) => {
+            try {
+                return await originalCommand()
+            } catch (err) {
+                calls.push('first caught')
+                throw err
+            }
+        }, true)
+        client.overwriteCommand('someFunc', async (originalCommand: Function) => {
+            try {
+                return await originalCommand()
+            } catch (err) {
+                calls.push('second caught')
+                throw err
+            }
+        }, true)
+
+        const element = createElement(client.__propertiesObject__.__elementOverrides__, async () => {
+            calls.push('base')
+            throw error
+        })
+
+        await expect(element.someFunc()).rejects.toBe(error)
+        expect(calls).toEqual(['base', 'first caught', 'second caught'])
+    })
+
+    it('should preserve explicit context rebinding through sequential element command overrides', () => {
+        const client = webdriverMonad({}, (browser: any) => browser, { ...prototype })(sessionId)
+        const reboundElement = { name: 'rebound element' }
+        let firstContext: unknown
+        let secondContext: unknown
+        let baseContext: unknown
+
+        client.overwriteCommand('someFunc', function (this: unknown, originalCommand: Function, value: string) {
+            firstContext = this
+            return originalCommand(value)
+        }, true)
+        client.overwriteCommand('someFunc', function (this: unknown, originalCommand: Function, value: string) {
+            secondContext = this
+            return originalCommand.call(reboundElement, value)
+        }, true)
+
+        const element = createElement(client.__propertiesObject__.__elementOverrides__, function (this: unknown, value: string) {
+            baseContext = this
+            return value
+        })
+
+        expect(element.someFunc('command result')).toBe('command result')
+        expect(secondContext).toBe(element)
+        expect(firstContext).toBe(reboundElement)
+        expect(baseContext).toBe(reboundElement)
+    })
+
+    it('should compose three element command overrides in reverse registration order', () => {
+        const client = webdriverMonad({}, (browser: any) => browser, { ...prototype })(sessionId)
+        const calls: string[] = []
+
+        for (const label of ['first', 'second', 'third']) {
+            client.overwriteCommand('someFunc', (originalCommand: Function) => {
+                calls.push(label)
+                return originalCommand()
+            }, true)
+        }
+
+        const element = createElement(client.__propertiesObject__.__elementOverrides__, () => calls.push('base'))
+
+        element.someFunc()
+        expect(calls).toEqual(['third', 'second', 'first', 'base'])
+    })
+
     it('should add element commands to the __propertiesObject__ cache in multiremote', () => {
         const monad = webdriverMonad({}, (client: any) => client, prototype)
         const client = monad(sessionId)
@@ -118,25 +288,89 @@ describe('monad', () => {
         expect(instances.foo.__propertiesObject__.myCustomElementCommand.value).toBe(func)
     })
 
-    it('should add element commands for override to the __propertiesObject__.__elementOverrides__ cache in multiremote', () => {
+    it('should compose element command overrides in multiremote', () => {
         const monad = webdriverMonad({}, (client: any) => client, { ...prototype })
         const client = monad(sessionId)
+        const calls: string[] = []
         const instances = {
             foo: {
                 __propertiesObject__: {
                     __elementOverrides__: {
-                        value: {
-                            someFunc: (x: number, y: number) => x - y
-                        }
+                        value: {}
+                    }
+                }
+            },
+            bar: {
+                __propertiesObject__: {
+                    __elementOverrides__: {
+                        value: {}
                     }
                 }
             }
         }
 
-        const func = function (x: number, y: number) { return x + y }
+        client.overwriteCommand('someFunc', function (originalCommand: Function, value: string) {
+            calls.push(`first: ${value}`)
+            return originalCommand(`${value} -> first`)
+        }, true, undefined, instances)
+        client.overwriteCommand('someFunc', function (originalCommand: Function, value: string) {
+            calls.push(`second: ${value}`)
+            return originalCommand(`${value} -> second`)
+        }, true, undefined, instances)
+        const fooElement = createElement(instances.foo.__propertiesObject__.__elementOverrides__, (value: string) => {
+            calls.push(`foo base: ${value}`)
+            return `foo: ${value}`
+        })
+        const barElement = createElement(instances.bar.__propertiesObject__.__elementOverrides__, (value: string) => {
+            calls.push(`bar base: ${value}`)
+            return `bar: ${value}`
+        })
 
-        client.overwriteCommand('someFunc', func, true, undefined, instances)
-        expect(instances.foo.__propertiesObject__.__elementOverrides__.value.someFunc(4, 5)).toBe(9)
+        expect(fooElement.someFunc('start')).toBe('foo: start -> second -> first')
+        expect(barElement.someFunc('start')).toBe('bar: start -> second -> first')
+        expect(calls).toEqual([
+            'second: start',
+            'first: start -> second',
+            'foo base: start -> second -> first',
+            'second: start',
+            'first: start -> second',
+            'bar base: start -> second -> first'
+        ])
+    })
+
+    it('should invoke command wrappers once for each composed element override', () => {
+        const calls: string[] = []
+        const client = webdriverMonad({}, (browser: any) => browser, { ...prototype })(sessionId, (commandName: string, commandFn: Function) => {
+            return function (this: unknown, ...args: unknown[]) {
+                calls.push(`wrapper: ${commandName}`)
+                return commandFn.apply(this, args)
+            }
+        })
+
+        client.overwriteCommand('someFunc', (originalCommand: Function) => originalCommand(), true)
+        client.overwriteCommand('someFunc', (originalCommand: Function) => originalCommand(), true)
+
+        const element = createElement(client.__propertiesObject__.__elementOverrides__, () => calls.push('base'))
+
+        element.someFunc()
+        expect(calls).toEqual(['wrapper: someFunc', 'wrapper: someFunc', 'base'])
+    })
+
+    it('should keep composing sequential browser command overrides', () => {
+        const client = webdriverMonad({}, (browser: any) => browser, { ...prototype })(sessionId, (_commandName: string, commandFn: Function) => commandFn)
+        const calls: string[] = []
+
+        client.overwriteCommand('someFunc', (originalCommand: Function, value: string) => {
+            calls.push('first')
+            return originalCommand(`${value} -> first`)
+        })
+        client.overwriteCommand('someFunc', (originalCommand: Function, value: string) => {
+            calls.push('second')
+            return originalCommand(`${value} -> second`)
+        })
+
+        expect(client.someFunc('start')).toBe('result-start -> second -> first')
+        expect(calls).toEqual(['second', 'first'])
     })
 
     it('allows to use custom command wrapper', () => {

--- a/packages/webdriverio/tests/overwriteCommand.test.ts
+++ b/packages/webdriverio/tests/overwriteCommand.test.ts
@@ -166,6 +166,25 @@ describe('overwriteCommand', () => {
                 expect(await elem.getAttribute('foo', 'bar')).toBe('foo-value foo bar')
             })
 
+            test('should compose sequential element command overwrites', async () => {
+                const browser = await remote(remoteConfig)
+                const calls: string[] = []
+
+                browser.overwriteCommand('click', async function firstOverride(originalCommand, ...args) {
+                    calls.push('first')
+                    return originalCommand(...args)
+                }, isElementScope)
+                browser.overwriteCommand('click', async function secondOverride(originalCommand, ...args) {
+                    calls.push('second')
+                    return originalCommand(...args)
+                }, isElementScope)
+
+                const elem = await browser.$('#foo')
+                await elem.click()
+
+                expect(calls).toEqual(['second', 'first'])
+            })
+
             test('should properly throw exceptions on the element scope', async () => {
                 const browser = await remote(remoteConfig)
                 browser.overwriteCommand('click', function () {


### PR DESCRIPTION
Fixes https://github.com/webdriverio/webdriverio/issues/15494

## Proposed changes

Sequential element command overwrites now compose instead of replacing one another. The latest registered override remains the outermost wrapper, while its `originalCommand` calls the previously registered override before reaching the base element command.

This matches browser command overwrite behavior and preserves arguments, return values, errors, explicit `this` rebinding, command wrappers, and multiremote registration.

## Reproduction

Run this in a WebdriverIO test:

```js
it('composes element click overrides', async () => {
    await browser.url('data:text/html,<button id="target">Click</button>')

    const calls = []

    browser.overwriteCommand('click', async function firstOverride(originalClick, ...args) {
        calls.push('first')
        return originalClick(...args)
    }, true)

    browser.overwriteCommand('click', async function secondOverride(originalClick, ...args) {
        calls.push('second')
        return originalClick(...args)
    }, true)

    const button = await browser.$('#target')
    await button.click()

    expect(calls).toEqual(['second', 'first'])
})
```

Before this fix, `calls` contains only `['second']` because the second element override replaces the first one. After this fix, both overrides run in reverse registration order.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [x] Back-ported PR at https://github.com/webdriverio/webdriverio/pull/15495

## Further comments

I wanted "overwriteCommand" command to act the same way for browser and element

Browser overwrites currently chain up, and that is super useful. So i decided to chain overwrited element commands the same way.

### Reviewers: @webdriverio/project-committers
