### PR TITLE
fix(@wdio/allure-reporter): don't cut the package label at a Windows drive letter

### DIFF
--- a/packages/wdio-allure-reporter/src/utils.ts
+++ b/packages/wdio-allure-reporter/src/utils.ts
@@ -282,7 +282,10 @@ export function isEmptyObject(value: unknown): boolean {
 export const toPackageLabel = (p?: string) => {
     if (!p) {return ''}
     const fsPath = fromUrlish(p)
-    const noPos = fsPath.split(':')[0]
+    // Only a trailing `:line[:col]` is a position suffix. Splitting on the first
+    // colon instead would cut a Windows path at its drive letter, collapsing every
+    // spec into a single `C` package.
+    const noPos = dropPosSuffix(fsPath)
     const rel = relNoSlash(noPos)
     return rel.replace(/\//g, '.')
 }

--- a/packages/wdio-allure-reporter/tests/utils.test.ts
+++ b/packages/wdio-allure-reporter/tests/utils.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import type { CommandArgs } from '@wdio/type'
 import process from 'node:process'
+import path from 'node:path'
 import { Status } from 'allure-js-commons'
 import CompoundError from '../src/compoundError.js'
 import {
@@ -14,6 +15,7 @@ import {
     isEachTypeHooks,
     isEmpty,
     isScreenshotCommand,
+    toPackageLabel,
 } from '../src/utils.js'
 import { linkPlaceholder } from '../src/constants.js'
 
@@ -240,5 +242,34 @@ describe('utils', () => {
                 )
             })
         })
+    })
+})
+
+describe('toPackageLabel', () => {
+    it('returns an empty label for an empty path', () => {
+        expect(toPackageLabel()).toEqual('')
+        expect(toPackageLabel('')).toEqual('')
+    })
+
+    it('maps the spec directories to a dotted package', () => {
+        const spec = path.join(process.cwd(), 'test', 'specs', 'my.e2e.js')
+
+        expect(toPackageLabel(spec)).toEqual('test.specs.my.e2e.js')
+    })
+
+    it('drops a trailing line/column position suffix', () => {
+        const spec = path.join(process.cwd(), 'test', 'specs', 'my.e2e.js')
+
+        expect(toPackageLabel(`${spec}:12`)).toEqual('test.specs.my.e2e.js')
+        expect(toPackageLabel(`${spec}:12:5`)).toEqual('test.specs.my.e2e.js')
+    })
+
+    it('keeps a Windows drive letter out of the position suffix', () => {
+        // Splitting on the first colon used to cut this path down to `C`, so every
+        // spec on Windows landed in the same package.
+        const label = toPackageLabel('C:/Users/me/project/test/specs/my.e2e.js')
+
+        expect(label).not.toEqual('C')
+        expect(label).toMatch(/test\.specs\.my\.e2e\.js$/)
     })
 })


### PR DESCRIPTION
### Proposed changes

Fixes #15496.

`toPackageLabel()` in `@wdio/allure-reporter` strips a trailing `:line[:col]` position suffix off the spec path before turning it into a dotted Allure package label. It did so with `fsPath.split(':')[0]`, which is only safe on POSIX paths — those never contain a colon.

A Windows spec path starts with one:

```
C:/Users/me/project/test/specs/mySuite.e2e.js
        ^ first colon is the drive letter, not a position suffix
```

so `noPos` became `"C"` and every spec in the run collapsed into a single bogus top-level package named `C` in Allure's **Packages** view, instead of the package tree derived from the spec directories.

The module already has the correct helper for this, used by `fromUrlish()` and `toPackageLabelCucumber()`:

```ts
const dropPosSuffix = (p: string) => p.replace(/:(\d+)(?::\d+)?$/, '')
```

It anchors the suffix to the end of the string, so the drive letter is left alone. `toPackageLabel()` simply wasn't using it. One-line change:

```diff
-    const noPos = fsPath.split(':')[0]
+    const noPos = dropPosSuffix(fsPath)
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective

Added `toPackageLabel` unit tests covering the empty path, the normal directory → dotted-package mapping, `:12` / `:12:5` position suffixes (so the behaviour the old `split(':')` provided stays covered), and the Windows drive-letter regression.

The Windows case fails on `main` and passes with the fix:

```
 × toPackageLabel > keeps a Windows drive letter out of the position suffix
   → expected 'C' to not deeply equal 'C'
```

```
$ npx vitest run packages/wdio-allure-reporter/tests/utils.test.ts
 ✓ packages/wdio-allure-reporter/tests/utils.test.ts (28 tests) 15ms
 Test Files  1 passed (1)
      Tests  28 passed (28)
Type Errors  no errors

$ npx eslint packages/wdio-allure-reporter/src/utils.ts packages/wdio-allure-reporter/tests/utils.test.ts
(clean)
```

The test builds the expected paths with `path.join(process.cwd(), ...)` so it stays correct on any platform; the Windows case asserts on the suffix rather than the full label, since `path.relative` resolves the foreign absolute path differently on POSIX.
