### PR TITLE
fix(wdio-allure-reporter): label skipped tests

### DIFF
--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -807,17 +807,7 @@ export default class AllureReporter extends WDIOReporter {
         const fullName = toFullName(this._pkgByCid.get(cid)!, fullTitle || test.title)
         this._pushRuntimeMessage({ type: 'allure:test:info', data: { fullName: fullName } })
 
-        const suitePath = [...this._suiteStack(cid)]
-        const pkg = isFeatureFilePath(this._pkgByCid.get(cid)) ? toPackageLabelCucumber(this._pkgByCid.get(cid) || '') : toPackageLabel(this._pkgByCid.get(cid) || '')
-        const labels = [
-            ...getSuiteLabels(suitePath),
-            ...(pkg ? [{ name: LabelName.PACKAGE, value: pkg }] : []),
-            { name: LabelName.LANGUAGE, value: 'javascript' },
-            { name: LabelName.FRAMEWORK, value: 'wdio' },
-            { name: LabelName.THREAD, value: cid },
-            ...getEnvironmentLabels(),
-        ]
-        this._pushRuntimeMessage({ type: 'metadata', data: { labels } })
+        this._emitTestLabels(cid)
     }
 
     onTestPass(test: TestStats | HookStats): void {
@@ -893,8 +883,10 @@ export default class AllureReporter extends WDIOReporter {
         const start = AllureReporter.getTimeOrNow(test.start)
         this._startTest({ name: test.title, start })
         if (test.fullTitle) { this._emitHistoryIdsFrom(test.fullTitle) }
-        const fullName = toFullName(this._pkgByCid.get(this._currentCid())!, test.fullTitle || test.title)
+        const cid = this._currentCid()
+        const fullName = toFullName(this._pkgByCid.get(cid)!, test.fullTitle || test.title)
         this._pushRuntimeMessage({ type: 'allure:test:info', data: { fullName } })
+        this._emitTestLabels(cid)
         this._attachLogs()
         this._skipTest()
     }
@@ -1080,6 +1072,21 @@ export default class AllureReporter extends WDIOReporter {
         const suitePath = [...this._suiteStack(cid)]
         const labels = [
             ...getSuiteLabels(suitePath),
+            { name: LabelName.LANGUAGE, value: 'javascript' },
+            { name: LabelName.FRAMEWORK, value: 'wdio' },
+            { name: LabelName.THREAD, value: cid },
+            ...getEnvironmentLabels(),
+        ]
+        this._pushRuntimeMessage({ type: 'metadata', data: { labels } })
+    }
+
+    private _emitTestLabels(cid: string): void {
+        const file = this._pkgByCid.get(cid)
+        const suitePath = [...this._suiteStack(cid)]
+        const pkg = isFeatureFilePath(file) ? toPackageLabelCucumber(file || '') : toPackageLabel(file || '')
+        const labels = [
+            ...getSuiteLabels(suitePath),
+            ...(pkg ? [{ name: LabelName.PACKAGE, value: pkg }] : []),
             { name: LabelName.LANGUAGE, value: 'javascript' },
             { name: LabelName.FRAMEWORK, value: 'wdio' },
             { name: LabelName.THREAD, value: cid },

--- a/packages/wdio-allure-reporter/tests/suite.test.ts
+++ b/packages/wdio-allure-reporter/tests/suite.test.ts
@@ -479,6 +479,10 @@ describe('Pending tests', () => {
         expect(results[0].historyId).toEqual(
             '0afaf0cb3770d6ce7ae0665f2eeecf81',
         )
+
+        const labels = mapBy<Label>(results[0].labels, 'name')
+        expect(labels.parentSuite[0].value).toEqual('A passing Suite')
+        expect(labels[LabelName.PACKAGE][0].value).toContain('spec.js')
     })
 
     it('should detect not started pending test case after completed test', async () => {


### PR DESCRIPTION
## Proposed changes

Fixes #15498.

Skipped tests that start directly from `onTestSkip()` now emit the same suite/package/runtime labels as tests that go through `onTestStart()`, so Allure can group them under the spec file in the Packages view. The shared label helper keeps both paths using the same metadata.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

The new regression checks that a not-started skipped test result includes `parentSuite` and `package` labels.

### Reviewers: @webdriverio/project-committers
