### PR TITLE
fix(allure-reporter): don't collapse Windows paths to drive letter in toPackageLabel

### DIFF
--- a/packages/wdio-allure-reporter/src/utils.ts
+++ b/packages/wdio-allure-reporter/src/utils.ts
@@ -282,7 +282,7 @@ export function isEmptyObject(value: unknown): boolean {
 export const toPackageLabel = (p?: string) => {
     if (!p) {return ''}
     const fsPath = fromUrlish(p)
-    const noPos = fsPath.split(':')[0]
+    const noPos = dropPosSuffix(fsPath)
     const rel = relNoSlash(noPos)
     return rel.replace(/\//g, '.')
 }

--- a/packages/wdio-allure-reporter/tests/utils.test.ts
+++ b/packages/wdio-allure-reporter/tests/utils.test.ts
@@ -3,6 +3,7 @@ import type { CommandArgs } from '@wdio/type'
 import process from 'node:process'
 import { Status } from 'allure-js-commons'
 import CompoundError from '../src/compoundError.js'
+import path from 'node:path'
 import {
     convertSuiteTagsToLabels,
     findLast,
@@ -14,6 +15,7 @@ import {
     isEachTypeHooks,
     isEmpty,
     isScreenshotCommand,
+    toPackageLabel,
 } from '../src/utils.js'
 import { linkPlaceholder } from '../src/constants.js'
 
@@ -239,6 +241,30 @@ describe('utils', () => {
                     []
                 )
             })
+        })
+    })
+
+    describe('toPackageLabel', () => {
+        it('should not collapse a Windows absolute path into just the drive letter (#15496)', () => {
+            const file = path.join(process.cwd(), 'test', 'specs', 'mySuite.e2e.js')
+
+            const pkg = toPackageLabel(file)
+
+            expect(pkg).not.toEqual('C')
+            expect(pkg).toEqual('test.specs.mySuite.e2e.js')
+        })
+
+        it('should still strip a trailing :line:column position suffix', () => {
+            const file = `${path.join(process.cwd(), 'test', 'specs', 'mySuite.e2e.js')}:10:5`
+
+            const pkg = toPackageLabel(file)
+
+            expect(pkg).toEqual('test.specs.mySuite.e2e.js')
+        })
+
+        it('should return an empty string for an empty path', () => {
+            expect(toPackageLabel()).toEqual('')
+            expect(toPackageLabel('')).toEqual('')
         })
     })
 })


### PR DESCRIPTION
## Proposed changes
Fixes `toPackageLabel()` collapsing every test into a bogus `"C"` package on Windows. It stripped a trailing `:line:col` suffix by splitting on the first colon, which also ate the Windows drive-letter colon (`C:/Users/...`). Now uses the existing `dropPosSuffix()` helper instead.
Closes #15496 
Closes #15498 

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
