### PR TITLE
fix(webdriver): retry requests aborted by connectionRetryTimeout

### DIFF
--- a/__mocks__/fetch.ts
+++ b/__mocks__/fetch.ts
@@ -414,6 +414,19 @@ const requestMock: any = vi.fn().mockImplementation((uri, params) => {
         return Promise.reject(timeoutError)
     }
 
+    if (uri.pathname.endsWith('abortTimeout')) {
+        if (params?.signal?.aborted) {
+            return Promise.reject(params.signal.reason)
+        }
+
+        if (requestMock.retryCnt < 5) {
+            ++requestMock.retryCnt
+            return Promise.reject(
+                new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+            )
+        }
+    }
+
     if (uri.pathname.startsWith(`/session/${sessionId}/element/`) && uri.pathname.includes('/attribute/')) {
         value = `${uri.pathname.substring(uri.pathname.lastIndexOf('/') + 1)}-value`
     }

--- a/packages/webdriver/src/request/error.ts
+++ b/packages/webdriver/src/request/error.ts
@@ -67,14 +67,22 @@ export class WebDriverRequestError extends WebDriverError {
         this.url = url
         this.opts = opts
 
+        /**
+         * A request that exceeds `connectionRetryTimeout` is aborted by
+         * `AbortSignal.timeout`, which rejects with a `DOMException` whose `code`
+         * is the numeric `TIMEOUT_ERR` rather than a string.
+         */
+        const isAbortTimeout = err.name === 'TimeoutError'
         const errorCode = typeof err.cause === 'object' && err.cause && 'code' in err.cause && typeof err.cause.code === 'string'
             ? err.cause.code
             : 'code' in err && typeof err.code === 'string'
                 ? err.code
-                : undefined
+                : isAbortTimeout
+                    ? 'ETIMEDOUT'
+                    : undefined
         if (errorCode) {
             this.code = errorCode
-            this.message = errorCode === 'UND_ERR_CONNECT_TIMEOUT'
+            this.message = errorCode === 'UND_ERR_CONNECT_TIMEOUT' || isAbortTimeout
                 ? 'Request timed out! Consider increasing the "connectionRetryTimeout" option.'
                 : 'Request failed with error code ' + errorCode
         }

--- a/packages/webdriver/src/request/request.ts
+++ b/packages/webdriver/src/request/request.ts
@@ -67,6 +67,7 @@ export abstract class WebDriverRequest {
     requiresSessionId: boolean
     eventHandler: RequestEventHandler
     abortSignal?: AbortSignal
+    connectionRetryTimeout = DEFAULTS.connectionRetryTimeout.default!
     constructor (
         method: string,
         endpoint: string,
@@ -90,15 +91,19 @@ export abstract class WebDriverRequest {
         return this._request(url, requestOptions, options.transformResponse, options.connectionRetryCount, 0)
     }
 
+    private createAbortSignal () {
+        return AbortSignal.any([
+            AbortSignal.timeout(this.connectionRetryTimeout),
+            ...(this.abortSignal ? [this.abortSignal] : [])
+        ])
+    }
+
     async createOptions (options: RequestOptions, sessionId?: string, isBrowser: boolean = false): Promise<{ url: URL; requestOptions: RequestInit; }> {
-        const timeout = options.connectionRetryTimeout || DEFAULTS.connectionRetryTimeout.default as number
+        this.connectionRetryTimeout = options.connectionRetryTimeout || DEFAULTS.connectionRetryTimeout.default!
         const requestOptions: RequestInit = {
             method: this.method,
             redirect: 'follow',
-            signal: AbortSignal.any([
-                AbortSignal.timeout(timeout),
-                ...(this.abortSignal ? [this.abortSignal] : [])
-            ])
+            signal: this.createAbortSignal()
         }
 
         const requestHeaders: HeadersInit = new Headers({
@@ -198,7 +203,13 @@ export abstract class WebDriverRequest {
             this.eventHandler.onLogData?.(loggableBody)
         }
 
-        const { ...requestLibOptions } = fullRequestOptions
+        /**
+         * a retry needs a fresh timeout signal, the one composed for the
+         * previous attempt may already have aborted
+         */
+        const requestLibOptions = retryCount > 0
+            ? { ...fullRequestOptions, signal: this.createAbortSignal() }
+            : { ...fullRequestOptions }
         const startTime = performance.now()
         let response = await this._libRequest(url!, requestLibOptions)
             .catch((err: WebDriverRequestError) => err)

--- a/packages/webdriver/src/request/request.ts
+++ b/packages/webdriver/src/request/request.ts
@@ -91,10 +91,10 @@ export abstract class WebDriverRequest {
         return this._request(url, requestOptions, options.transformResponse, options.connectionRetryCount, 0)
     }
 
-    private createAbortSignal () {
+    private createAbortSignal (signal?: AbortSignal | null) {
         return AbortSignal.any([
             AbortSignal.timeout(this.connectionRetryTimeout),
-            ...(this.abortSignal ? [this.abortSignal] : [])
+            ...(signal ? [signal] : [])
         ])
     }
 
@@ -103,7 +103,7 @@ export abstract class WebDriverRequest {
         const requestOptions: RequestInit = {
             method: this.method,
             redirect: 'follow',
-            signal: this.createAbortSignal()
+            signal: this.abortSignal
         }
 
         const requestHeaders: HeadersInit = new Headers({
@@ -204,12 +204,13 @@ export abstract class WebDriverRequest {
         }
 
         /**
-         * a retry needs a fresh timeout signal, the one composed for the
-         * previous attempt may already have aborted
+         * every attempt gets its own timeout, a retry must not inherit the
+         * already aborted signal of the attempt before it
          */
-        const requestLibOptions = retryCount > 0
-            ? { ...fullRequestOptions, signal: this.createAbortSignal() }
-            : { ...fullRequestOptions }
+        const requestLibOptions = {
+            ...fullRequestOptions,
+            signal: this.createAbortSignal(fullRequestOptions.signal)
+        }
         const startTime = performance.now()
         let response = await this._libRequest(url!, requestLibOptions)
             .catch((err: WebDriverRequestError) => err)

--- a/packages/webdriver/tests/request.test.ts
+++ b/packages/webdriver/tests/request.test.ts
@@ -513,6 +513,38 @@ describe('webdriver request', () => {
                 expect(onRetry).toBeCalledTimes(retryCnt)
             })
 
+            it('should retry a request aborted by "connectionRetryTimeout"', async () => {
+                const onRetry = vi.fn()
+                const req = new WebFetchRequest('POST', '/abortTimeout', {}, undefined, true, { onRetry })
+                const result = await req.makeRequest({
+                    protocol: 'https',
+                    hostname: 'localhost',
+                    port: 4445,
+                    path: '/',
+                    connectionRetryCount: 7,
+                    connectionRetryTimeout: 10000,
+                    logLevel: 'warn'
+                }, 'foobar').then(
+                    (res) => res,
+                    (e) => e
+                )
+
+                expect(result).toEqual({ value: {} })
+                expect(onRetry).toBeCalledTimes(5)
+                expect(onRetry).toBeCalledWith({
+                    error: expect.objectContaining({ code: 'ETIMEDOUT' }),
+                    retryCount: expect.any(Number)
+                })
+
+                /**
+                 * every attempt needs its own signal, sharing one would make each
+                 * retry abort immediately
+                 */
+                const signals = vi.mocked(fetch).mock.calls.map(([, opts]) => opts!.signal)
+                expect(signals).toHaveLength(6)
+                expect(new Set(signals).size).toBe(6)
+            })
+
             it('should use error from "getRequestError" helper', async () => {
                 const onRetry = vi.fn()
                 const onRequest = vi.fn()

--- a/packages/webdriver/tests/request.test.ts
+++ b/packages/webdriver/tests/request.test.ts
@@ -545,6 +545,41 @@ describe('webdriver request', () => {
                 expect(new Set(signals).size).toBe(6)
             })
 
+            it('should keep honouring a signal supplied by "transformRequest" across retries', async () => {
+                const controller = new AbortController()
+                const transformRequest = vi.fn().mockImplementation((requestOptions) => ({
+                    ...requestOptions,
+                    signal: controller.signal
+                }))
+                const req = new WebFetchRequest('POST', '/abortTimeout', {}, undefined, true)
+                const result = await req.makeRequest({
+                    protocol: 'https',
+                    hostname: 'localhost',
+                    port: 4445,
+                    path: '/',
+                    connectionRetryCount: 7,
+                    connectionRetryTimeout: 10000,
+                    transformRequest,
+                    logLevel: 'warn'
+                }, 'foobar').then(
+                    (res) => res,
+                    (e) => e
+                )
+
+                expect(result).toEqual({ value: {} })
+
+                /**
+                 * each attempt composes a fresh timeout with the caller's signal,
+                 * so aborting it still cancels a retried request
+                 */
+                const signals = vi.mocked(fetch).mock.calls.map(([, opts]) => opts!.signal)
+                expect(signals).toHaveLength(6)
+                expect(signals.every((signal) => !signal!.aborted)).toBe(true)
+
+                controller.abort()
+                expect(signals.every((signal) => signal!.aborted)).toBe(true)
+            })
+
             it('should use error from "getRequestError" helper', async () => {
                 const onRetry = vi.fn()
                 const onRequest = vi.fn()


### PR DESCRIPTION
## Proposed changes

A request that exceeds `connectionRetryTimeout` is aborted by `AbortSignal.timeout`, which rejects with a `DOMException` whose `code` is the numeric `TIMEOUT_ERR`. `WebDriverRequestError` only picks up string codes, so the error reached `_request` with no `code` at all, missed `RETRYABLE_ERROR_CODES` and was thrown on the first attempt. As a result, a session that takes longer than the timeout to start fails the whole run rather than being retried.

This patch maps the abort onto `ETIMEDOUT` so it retries like every other connection timeout, and gives each attempt its own signal (`createOptions` composed one signal for the whole request, so a retry would otherwise inherit the already aborted signal of the attempt before it and fail instantly).

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate) -- n/a
- [ ] I have added proper type definitions for new commands (if appropriate) -- n/a

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
