### PR TITLE
fix: add .cts to supported file extensions

### DIFF
--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -100,7 +100,7 @@ export const SUPPORTED_HOOKS: (keyof Services.Hooks)[] = [
 ]
 
 export const SUPPORTED_FILE_EXTENSIONS = [
-    '.js', '.jsx', '.mjs', '.mts', '.es6', '.ts', '.tsx', '.feature', '.coffee', '.cjs'
+    '.js', '.jsx', '.mjs', '.mts', '.es6', '.ts', '.tsx', '.feature', '.coffee', '.cjs', '.cts'
 ]
 
 export const NO_NAMED_CONFIG_EXPORT = (

--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -100,9 +100,7 @@ export const SUPPORTED_HOOKS: (keyof Services.Hooks)[] = [
 ]
 
 export const SUPPORTED_FILE_EXTENSIONS = [
-        FileNamed(path.resolve(FIXTURES_PATH, 'test.cjs')).withContents('test file contents'),
-        FileNamed(path.resolve(FIXTURES_PATH, 'test.cts')).withContents('test file contents'),
-        FileNamed(path.resolve(FIXTURES_PATH, 'test.es6')).withContents('test file contents'),
+    '.js', '.jsx', '.mjs', '.mts', '.es6', '.ts', '.tsx', '.feature', '.coffee', '.cjs', '.cts'
 ]
 
 export const NO_NAMED_CONFIG_EXPORT = (

--- a/packages/wdio-config/src/constants.ts
+++ b/packages/wdio-config/src/constants.ts
@@ -100,7 +100,9 @@ export const SUPPORTED_HOOKS: (keyof Services.Hooks)[] = [
 ]
 
 export const SUPPORTED_FILE_EXTENSIONS = [
-    '.js', '.jsx', '.mjs', '.mts', '.es6', '.ts', '.tsx', '.feature', '.coffee', '.cjs', '.cts'
+        FileNamed(path.resolve(FIXTURES_PATH, 'test.cjs')).withContents('test file contents'),
+        FileNamed(path.resolve(FIXTURES_PATH, 'test.cts')).withContents('test file contents'),
+        FileNamed(path.resolve(FIXTURES_PATH, 'test.es6')).withContents('test file contents'),
 ]
 
 export const NO_NAMED_CONFIG_EXPORT = (


### PR DESCRIPTION
## Proposed changes

Add `.cts` to supported file extensions. Extensions `.ts` and `.mjs` are already supported.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

### Reviewers: @webdriverio/project-committers
