### PR TITLE
Add title path

### DIFF
--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -572,7 +572,7 @@ export default class AllureReporter extends WDIOReporter {
             const fullName = toFullName(this._pkgByCid.get(cid)!, fullTitleForHash)
             this._pushRuntimeMessage({
                 type: 'allure:test:info',
-                data: { fullName, fullTitle: fullTitleForHash, titlePath: this._titlePath(cid) }
+                data: { fullName, fullTitle: fullTitleForHash, titlePath: this._titlePath(cid, this._suiteStack(cid)) }
             })
 
             applyTestPlanLabel(this._testPlan, (m) => this._pushRuntimeMessage(m), {

--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -108,6 +108,15 @@ function hasCucumberKeywordInTitle(title?: string): boolean {
     return /^(Given|When|Then|And|But)\b/.test(title)
 }
 
+function splitTitlePathPart(part?: string): string[] {
+    if (!part) { return [] }
+    return part
+        .replace(/\\/g, '/')
+        .split('/')
+        .map((p) => p.trim())
+        .filter(Boolean)
+}
+
 export default class AllureReporter extends WDIOReporter {
     private _allureRuntime: ReporterRuntime
     private _capabilities: Capabilities.ResolvedTestrunnerCapabilities
@@ -129,6 +138,7 @@ export default class AllureReporter extends WDIOReporter {
     private _suiteStack = (cid: string) =>
         this._suiteStackByCid.get(cid) ?? this._suiteStackByCid.set(cid, []).get(cid)!
     private _pkgByCid: Map<string, string> = new Map()
+    private _titlePathFileByCid: Map<string, string> = new Map()
 
     private _cukeScenarioActiveByCid = new Map<string, boolean>()
 
@@ -444,14 +454,16 @@ export default class AllureReporter extends WDIOReporter {
 
             if (file) {
                 this._pkgByCid.set(cid, absPosix(file))
+                this._titlePathFileByCid.set(cid, file)
             }
 
             const fileStr = (file || '').replace(/\\/g, '/')
             if (/\.feature$/i.test(fileStr)) {
                 const ft = Array.isArray(testPath) ? testPath.map(String).join(' ') : ''
                 const fullName = `${relNoSlash(file)}#${ft}`
+                const titlePath = this._titlePath(cid, Array.isArray(testPath) ? testPath.slice(0, -1) : undefined)
 
-                this._pushRuntimeMessage({ type: 'allure:test:info', data: { fullName, fullTitle: ft } })
+                this._pushRuntimeMessage({ type: 'allure:test:info', data: { fullName, fullTitle: ft, titlePath } })
                 applyTestPlanLabel(this._testPlan, (m) => this._pushRuntimeMessage(m), {
                     file,
                     testPath,
@@ -506,6 +518,7 @@ export default class AllureReporter extends WDIOReporter {
         const specs = (runner as unknown as { specs?: string[] }).specs || []
         if (specs.length) {
             this._pkgByCid.set(runner.cid, absPosix(specs[0]))
+            this._titlePathFileByCid.set(runner.cid, specs[0])
         }
     }
 
@@ -536,6 +549,7 @@ export default class AllureReporter extends WDIOReporter {
             const featureFile = (suite as unknown as MaybeFile).file
             if (isFeatureFilePath(featureFile)) {
                 this._pkgByCid.set(cid, absPosix(featureFile!))
+                this._titlePathFileByCid.set(cid, featureFile!)
             }
             break
         }
@@ -556,7 +570,10 @@ export default class AllureReporter extends WDIOReporter {
             this._emitHistoryIdsFrom(fullTitleForHash)
 
             const fullName = toFullName(this._pkgByCid.get(cid)!, fullTitleForHash)
-            this._pushRuntimeMessage({ type: 'allure:test:info', data: { fullName, fullTitle: fullTitleForHash } })
+            this._pushRuntimeMessage({
+                type: 'allure:test:info',
+                data: { fullName, fullTitle: fullTitleForHash, titlePath: this._titlePath(cid) }
+            })
 
             applyTestPlanLabel(this._testPlan, (m) => this._pushRuntimeMessage(m), {
                 fullTitle: fullTitleForHash,
@@ -601,6 +618,10 @@ export default class AllureReporter extends WDIOReporter {
         }
         default: {
             this._suiteStack(cid).push(suite.title)
+            const suiteFile = (suite as unknown as MaybeFile).file
+            if (suiteFile) {
+                this._titlePathFileByCid.set(cid, suiteFile)
+            }
             this._startSuite({ name: suite.title })
         }
         }
@@ -726,7 +747,10 @@ export default class AllureReporter extends WDIOReporter {
         this._emitHistoryIdsFrom(fullTitleForHash)
 
         const fullName = toFullName(this._pkgByCid.get(cid)!, fullTitleForHash)
-        this._pushRuntimeMessage({ type: 'allure:test:info', data: { fullName, fullTitle: fullTitleForHash } })
+        this._pushRuntimeMessage({
+            type: 'allure:test:info',
+            data: { fullName, fullTitle: fullTitleForHash, titlePath: this._titlePath(cid) }
+        })
 
         this._emitBaseLabels(cid)
 
@@ -771,6 +795,10 @@ export default class AllureReporter extends WDIOReporter {
 
         const fullTitle = (test as TestStats).fullTitle
         const file = (test as MaybeFile).file
+        const cid = this._currentCid()
+        if (file) {
+            this._titlePathFileByCid.set(cid, file)
+        }
         applyTestPlanLabel(this._testPlan, (m) => this._pushRuntimeMessage(m), { file, fullTitle })
 
         if (this._inCucumberStepMode(test)) {
@@ -795,7 +823,6 @@ export default class AllureReporter extends WDIOReporter {
             })
         }
 
-        const cid = this._currentCid()
         this._ensureSuitesStarted(cid)
         const start = AllureReporter.getTimeOrNow((test as TestStats).start)
         const uuid = (test as MaybeUid).uid
@@ -805,7 +832,10 @@ export default class AllureReporter extends WDIOReporter {
         if (testCaseTitle) { this._emitHistoryIdsFrom(testCaseTitle) }
 
         const fullName = toFullName(this._pkgByCid.get(cid)!, fullTitle || test.title)
-        this._pushRuntimeMessage({ type: 'allure:test:info', data: { fullName: fullName } })
+        this._pushRuntimeMessage({
+            type: 'allure:test:info',
+            data: { fullName: fullName, titlePath: this._titlePath(cid) }
+        })
 
         const suitePath = [...this._suiteStack(cid)]
         const pkg = isFeatureFilePath(this._pkgByCid.get(cid)) ? toPackageLabelCucumber(this._pkgByCid.get(cid) || '') : toPackageLabel(this._pkgByCid.get(cid) || '')
@@ -893,8 +923,9 @@ export default class AllureReporter extends WDIOReporter {
         const start = AllureReporter.getTimeOrNow(test.start)
         this._startTest({ name: test.title, start })
         if (test.fullTitle) { this._emitHistoryIdsFrom(test.fullTitle) }
-        const fullName = toFullName(this._pkgByCid.get(this._currentCid())!, test.fullTitle || test.title)
-        this._pushRuntimeMessage({ type: 'allure:test:info', data: { fullName } })
+        const cid = this._currentCid()
+        const fullName = toFullName(this._pkgByCid.get(cid)!, test.fullTitle || test.title)
+        this._pushRuntimeMessage({ type: 'allure:test:info', data: { fullName, titlePath: this._titlePath(cid) } })
         this._attachLogs()
         this._skipTest()
     }
@@ -1145,6 +1176,23 @@ export default class AllureReporter extends WDIOReporter {
         const parts = [...this._suiteStack(cid)]
         if (leaf) { parts.push(leaf) }
         return parts.map((s) => String(s).trim()).filter(Boolean).join(' ')
+    }
+
+    private _titlePath(cid: string, cucumberPath?: string[]): string[] {
+        const file = this._titlePathFileByCid.get(cid) ?? this._pkgByCid.get(cid)
+        const relativeFilePath = relNoSlash(file)
+        const fileParts = splitTitlePathPart(relativeFilePath)
+        const suitePath = this._suiteStack(cid).map(String).map((s) => s.trim()).filter(Boolean)
+        const normalizedCucumberPath = cucumberPath?.map(String).map((s) => s.trim()).filter(Boolean)
+
+        if (isFeatureFilePath(file)) {
+            return [
+                ...fileParts.slice(0, -1),
+                ...(normalizedCucumberPath && normalizedCucumberPath.length > 0 ? normalizedCucumberPath : suitePath.slice(0, 1)),
+            ].filter(Boolean)
+        }
+
+        return [...fileParts, ...suitePath]
     }
 
     private _deriveHookType(hook: HookStats): 'before' | 'after' {

--- a/packages/wdio-allure-reporter/src/state.ts
+++ b/packages/wdio-allure-reporter/src/state.ts
@@ -206,13 +206,16 @@ export class AllureReportState {
     }
 
     private _addTestInfo(message: WDIOTestInfoMessage): void {
-        const { fullName } = message.data
+        const { fullName, titlePath } = message.data
         const testUuid = last(this._executablesStack)
         if (!testUuid) {
             return
         }
         this.allureRuntime.updateTest(testUuid, (r) => {
             r.fullName = fullName
+            if (Array.isArray(titlePath) && titlePath.length > 0) {
+                r.titlePath = titlePath
+            }
         })
     }
 

--- a/packages/wdio-allure-reporter/src/types.ts
+++ b/packages/wdio-allure-reporter/src/types.ts
@@ -209,6 +209,7 @@ export type WDIOTestInfoMessage = {
         fullTitle?: string
         historyId?: string
         testCaseId?: string
+        titlePath?: string[]
     }
 }
 

--- a/packages/wdio-allure-reporter/tests/cucumber.suite.test.ts
+++ b/packages/wdio-allure-reporter/tests/cucumber.suite.test.ts
@@ -85,6 +85,10 @@ describe('reporter option "useCucumberStepReporter" set to true', () => {
                 expect(parentSuiteLabel?.value).toEqual('MyFeature')
             })
 
+            it('should add title path', () => {
+                expect(allureResult.titlePath).toEqual(['foo', 'MyFeature'])
+            })
+
             it('should detect passed test case', () => {
                 expect(allureResult.name).toEqual('MyScenario')
                 expect(allureResult.status).toEqual(Status.PASSED)
@@ -943,6 +947,11 @@ describe('Cucumber retries (issue #15177)', () => {
         it('should assign the same historyId to both attempts so Allure groups them as retries', () => {
             expect(results[0].historyId).toBeDefined()
             expect(results[0].historyId).toBe(results[1].historyId)
+        })
+
+        it('should assign the same titlePath to both attempts', () => {
+            expect(results[0].titlePath).toEqual(['foo', 'MyFeature'])
+            expect(results[0].titlePath).toEqual(results[1].titlePath)
         })
 
         it('attempt 1 should be tagged as "retried" with FAILED status', () => {

--- a/packages/wdio-allure-reporter/tests/state.test.ts
+++ b/packages/wdio-allure-reporter/tests/state.test.ts
@@ -3,7 +3,7 @@ import { temporaryDirectory } from 'tempy'
 import { ReporterRuntime } from 'allure-js-commons/sdk/reporter'
 import { FileSystemWriter } from 'allure-js-commons/sdk/reporter'
 import { AllureReportState } from '../src/state.js'
-import { clean } from './helpers/wdio-allure-helper.js'
+import { clean, getResults } from './helpers/wdio-allure-helper.js'
 
 describe('state', () => {
     const outputDir = temporaryDirectory()
@@ -63,6 +63,24 @@ describe('state', () => {
             state.pushRuntimeMessage({ type: 'allure:test:start', data: { name: 'test case', start: Date.now() } })
 
             expect(state.hasPendingTest).toBe(true)
+        })
+
+        it('writes title path from test info', async () => {
+            state.pushRuntimeMessage({ type: 'allure:test:start', data: { name: 'test case', start: Date.now() } })
+            state.pushRuntimeMessage({
+                type: 'allure:test:info',
+                data: {
+                    fullName: 'foo/bar.test.js#test suite test case',
+                    titlePath: ['foo', 'bar.test.js', 'test suite']
+                }
+            })
+            state.pushRuntimeMessage({ type: 'allure:test:end', data: { status: 'passed' as any } })
+
+            await state.processRuntimeMessage()
+
+            const { results } = getResults(outputDir)
+            expect(results).toHaveLength(1)
+            expect(results[0].titlePath).toEqual(['foo', 'bar.test.js', 'test suite'])
         })
     })
 

--- a/packages/wdio-allure-reporter/tests/suite.test.ts
+++ b/packages/wdio-allure-reporter/tests/suite.test.ts
@@ -121,6 +121,10 @@ describe('Passing tests', () => {
         expect(allureResult.name).toEqual('should can do something')
     })
 
+    it('should add title path', () => {
+        expect(allureResult.titlePath).toEqual(['foo', 'bar.test.js', 'A passing Suite'])
+    })
+
     it('should detect passed test case', () => {
         expect(allureResult.name).toEqual('should can do something')
         expect(allureResult.status).toEqual(Status.PASSED)
@@ -457,6 +461,7 @@ describe('Pending tests', () => {
         expect(results[0].historyId).toEqual(
             '0afaf0cb3770d6ce7ae0665f2eeecf81',
         )
+        expect(results[0].titlePath).toEqual(['foo', 'bar.test.js', 'A passing Suite'])
     })
 
     it('should detect not started pending test case', async () => {
@@ -479,6 +484,7 @@ describe('Pending tests', () => {
         expect(results[0].historyId).toEqual(
             '0afaf0cb3770d6ce7ae0665f2eeecf81',
         )
+        expect(results[0].titlePath).toEqual(['foo', 'bar.test.js', 'A passing Suite'])
     })
 
     it('should detect not started pending test case after completed test', async () => {


### PR DESCRIPTION
## Proposed changes

Add native Allure 3 `titlePath` support to `@wdio/allure-reporter` results.

The reporter now writes a `titlePath` array for WDIO tests so Allure can build file/suite-based navigation from the result JSON, while keeping existing `fullName`, `historyId`, `testCaseId`, and test-plan behavior unchanged.

## Testing

- Added regression coverage for state-level persistence, spec tests, skipped tests, Cucumber feature paths, and Cucumber retries.
- Ran targeted `wdio-allure-reporter` Vitest coverage.
- Built `@wdio/allure-reporter` successfully.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

