### PR TITLE
fix(docs): unbreak non-English docs builds after flowchart component removal

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,0 +1,51 @@
+# Builds the documentation website on pull requests.
+#
+# The docs site is otherwise only ever built by `deploy.yml`, which is manually
+# dispatched — so a broken Docusaurus config, plugin or MDX page could only be
+# discovered at deploy time.
+#
+# This deliberately builds a non-English locale as well as `en`. Translated pages are
+# downloaded from the `webdriverio/i18n` repo at generate time and lag behind the
+# English source, so an `en`-only build cannot catch a translation referencing an MDX
+# component that no longer exists.
+name: Docs Build
+
+on:
+  workflow_call:
+
+jobs:
+  docs_build:
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: ⬇️ Checkout Code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: 🧑‍🔧 Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      - name: 📖 Generate Docs
+        run: pnpm run docs:setup && pnpm run docs:generate
+        env:
+          # required by scripts/docs-generation/downloadDocsTranslations.ts to fetch
+          # translations from the public webdriverio/i18n repo; the default read-only
+          # token is sufficient, including for pull requests from forks
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+
+      # Both locales must be passed to a single invocation: Docusaurus disables baseUrl
+      # localization when exactly one --locale is given, so two separate builds would
+      # each emit at the site root and the second would overwrite the first.
+      - name: 🏗️ Build Site (en + ar)
+        run: pnpm exec docusaurus build --locale en --locale ar
+        working-directory: ./website
+
+      - name: ✅ Verify Machine-Readable Output
+        run: |
+          set -euo pipefail
+          for f in robots.txt llms.txt llms-full.txt sitemap.xml; do
+            test -s "website/build/$f" || { echo "::error::website/build/$f missing or empty"; exit 1; }
+            echo "ok: website/build/$f ($(wc -c < "website/build/$f") bytes)"
+          done
+          grep -q '<lastmod>' website/build/sitemap.xml || { echo "::error::sitemap.xml has no <lastmod> entries"; exit 1; }
+          echo "ok: sitemap.xml contains $(grep -c '<lastmod>' website/build/sitemap.xml) <lastmod> entries"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,11 @@ jobs:
     name: Static Code Analysis
     uses: ./.github/workflows/test-static.yml
 
+  docs_build:
+    name: Docs Build
+    needs: [static_code_analysis]
+    uses: ./.github/workflows/test-docs.yml
+
   typing_tests:
     name: Typing Tests
     needs: [build_core, static_code_analysis]

--- a/scripts/docs-generation/downloadDocsTranslations.ts
+++ b/scripts/docs-generation/downloadDocsTranslations.ts
@@ -25,6 +25,39 @@ export function downloadDocsTranslations() {
     return downloadAndExtractRepo(REPO_OWNER, REPO_NAME)
 }
 
+const FLOWCHARTS_DIR = path.resolve(__dirname, '..', '..', 'website', 'docs', 'flowcharts')
+const CREATE_FLOWCHARTS_TAG = /^[^\S\n]*<CreateFlowcharts\s+id=['"]([^'"]+)['"]\s*\/>[^\S\n]*$/gm
+
+/**
+ * Reads the English flowchart docs and maps each page's `id` to its diagram body
+ * (everything from the first heading or ```mermaid fence onwards, i.e. skipping the
+ * frontmatter and intro paragraph).
+ *
+ * The English markdown is the single source of truth: the diagrams themselves were
+ * never translated — they used to be rendered from a shared React component — so
+ * splicing the English body into a translated page loses nothing.
+ */
+async function getFlowchartDiagrams() {
+    const diagrams = new Map<string, string>()
+    const files = await fs.readdir(FLOWCHARTS_DIR).catch((err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOENT') {
+            return [] as string[]
+        }
+        throw err
+    })
+
+    for (const file of files.filter((f) => f.endsWith('.md'))) {
+        const source = await fs.readFile(path.join(FLOWCHARTS_DIR, file), 'utf-8')
+        const id = source.match(/^---\n(?:.*\n)*?id:\s*(\S+)\s*$/m)?.[1]
+        const bodyStart = source.search(/^(##\s|```mermaid\s*$)/m)
+        if (id && bodyStart !== -1) {
+            diagrams.set(id, source.slice(bodyStart).trimEnd())
+        }
+    }
+
+    return diagrams
+}
+
 /**
  * Patches known stale links in translated i18n files that become broken when English
  * source docs are restructured but translations haven't been updated yet.
@@ -41,8 +74,42 @@ async function applyTranslationFixes(i18nPath: string) {
     // only iterate locale directories; ignore stray files (e.g. .gitkeep, config)
     const locales = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name)
 
+    const flowchartDiagrams = await getFlowchartDiagrams()
+
     for (const locale of locales) {
         const contentPath = path.join(i18nPath, locale, 'docusaurus-plugin-content-docs', 'current')
+
+        // Fix: translated flowchart pages still reference the <CreateFlowcharts /> component,
+        // which was replaced by inline ```mermaid fences in the English docs. Without this
+        // the MDX compiler fails every non-English locale with "Expected component
+        // `CreateFlowcharts` to be defined". Remove once webdriverio/i18n is updated.
+        const flowchartsPath = path.join(contentPath, 'flowcharts')
+        const flowchartFiles = await fs.readdir(flowchartsPath).catch((err: NodeJS.ErrnoException) => {
+            if (err.code === 'ENOENT') {
+                return [] as string[]
+            }
+            throw err
+        })
+        for (const file of flowchartFiles.filter((f) => f.endsWith('.md'))) {
+            const filePath = path.join(flowchartsPath, file)
+            const content = await fs.readFile(filePath, 'utf-8')
+            let unresolvedId: string | undefined
+            const fixed = content.replace(CREATE_FLOWCHARTS_TAG, (match, id: string) => {
+                const diagram = flowchartDiagrams.get(id)
+                if (!diagram) {
+                    unresolvedId = id
+                    return match
+                }
+                return diagram
+            })
+            if (unresolvedId) {
+                throw new Error(`No English flowchart diagram found for id '${unresolvedId}' referenced by ${locale}/flowcharts/${file}. Add the diagram to website/docs/flowcharts, or remove the <CreateFlowcharts /> reference from the translation.`)
+            }
+            if (fixed !== content) {
+                await fs.writeFile(filePath, `${fixed.trimEnd()}\n`)
+                console.log(`Applied flowchart mermaid fix to ${locale}/flowcharts/${file}`)
+            }
+        }
 
         // Fix: Devtools.md links missing wdio/ prefix after devtools section was restructured
         // Old: devtools/interactive-test-rerunning  New: devtools/wdio/interactive-test-rerunning


### PR DESCRIPTION
### Proposed changes

Fixes the **Docs Deploy** failure introduced by #15492: [run 32444583896](https://github.com/webdriverio/webdriverio/actions/runs/32444583896/job/96661680704).

```
[ERROR] Error: Unable to build website for locale ar.
  Docusaurus static site generation failed for 4 paths:
  - "/ar/docs/flowcharts/createlocalworkerprocess"
  - "/ar/docs/flowcharts/highleveloverview"
  - "/ar/docs/flowcharts/testexecution"
  - "/ar/docs/flowcharts/wdiocommands"
    Error: Expected component `CreateFlowcharts` to be defined
```

#### Root cause

#15492 replaced `<CreateFlowcharts />` with inline ` ```mermaid ` fences in the English
flowchart docs and deleted the component plus its entry in `website/src/theme/MDXComponents.js`.

Translated docs are not in this repo. `scripts/docs-generation/downloadDocsTranslations.ts`
downloads [`webdriverio/i18n`](https://github.com/webdriverio/i18n) as a zipball at generate
time, and those pages are snapshots of older English source. **All 15 non-English locales
still ship the four flowchart pages containing the literal JSX tag** (60 files), so every one
of them now fails MDX compilation. `ar` is simply first alphabetically — the build aborts there.

The English build passes, which is why nothing showed up on #15492.

#### Impact

The last successful docs deploy was **2026-08-12**, before #15492 merged on 08-18. Production
still serves that build, so `/llms.txt` and `/robots.txt` currently 404 and no docs change
merged since 08-12 is live. The site is stale, not broken.

#### Fix 1 — `downloadDocsTranslations.ts`

Extends `applyTranslationFixes()`, whose documented purpose is exactly this ("*Add entries here
whenever a doc restructure breaks translated pages*", alongside two existing precedents). It
splices the mermaid body from the corresponding English page in place of the JSX tag, keyed on
frontmatter `id`.

- The English markdown stays the **single source of truth** — no duplicated graph text.
- The diagrams were never translated (they were rendered from a shared React component), so
  nothing is lost.
- Translated frontmatter and intro prose are preserved verbatim.
- An unmapped `id` **throws** rather than silently leaving the tag in place.

#### Fix 2 — `test-docs.yml`, a docs build on PR CI

The site was previously only ever built by `deploy.yml`, which is `workflow_dispatch` only.
Config, plugin and MDX regressions therefore could not surface on a PR — which is precisely how
#15492 went green and still broke the deploy.

Two details worth reviewing:

- It builds **`ar` as well as `en`**, deliberately. An `en`-only build cannot catch this class
  of failure.
- Both locales go to a **single** `docusaurus build` invocation. Docusaurus disables baseUrl
  localization when exactly one `--locale` is passed (`isAutomaticBaseUrlLocalizationDisabled`),
  so two separate build steps would each emit at the site root and the second would silently
  overwrite the first.

It also asserts `robots.txt`, `llms.txt`, `llms-full.txt` and sitemap `<lastmod>` are present,
so #15492's acceptance criteria are now enforced somewhere.

#### Verification

The changed function was run verbatim against **real** translated files fetched from
`webdriverio/i18n` (`ar`, `zh`, `de` — 12 genuinely stale files). 74/74 checks passed: JSX tag
removed, mermaid fence injected, fences balanced, translated frontmatter and intro
byte-preserved, all 4 English diagrams resolved by id (including `wdiocommands` carrying all
three), second run a no-op, and a descriptive throw on an unknown id.

**Not verified locally:** the full 16-locale build, and `tsc`/`eslint`. This PR's own new
`Docs Build` job is the real test of both halves — it should self-test here.

#### Follow-up (not in this PR)

The proper fix is to update those 60 files in `webdriverio/i18n` to use mermaid fences directly,
so translators own the section headings and node labels. Once that lands, the patch added here
can be deleted.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)

### Reviewers

@webdriverio/project-committers
