### PR TITLE
chore: fix test since instances order is not guarantee

### DIFF
--- a/e2e/wdio/headless/multiRemoteTest.e2e.ts
+++ b/e2e/wdio/headless/multiRemoteTest.e2e.ts
@@ -122,7 +122,7 @@ describe('multi remote test', () => {
             const existingHeaders = await h1.unstable_filter((e) => e.isExisting())
 
             // TODO review to assert order of instances, as it may not be guaranteed to be the same order each time
-            expect(existingHeaders.instances).toEqual(['browserA', 'browserC'])
+            expect(existingHeaders.instances).toEqual(expect.arrayContaining(['browserA', 'browserC']))
             const header1Texts = await existingHeaders.getText()
             expect(header1Texts).toEqual(['WebdriverJS Testpage', 'WebdriverJS Testpage'])
         })
@@ -135,7 +135,7 @@ describe('multi remote test', () => {
 
             const existingHeaders = await header.unstable_select(['browserA', 'browserC']).unstable_filter((e) => e.isExisting())
 
-            expect(existingHeaders.instances).toEqual(['browserA', 'browserC'])
+            expect(existingHeaders.instances).toEqual(expect.arrayContaining(['browserA', 'browserC']))
             const headerExistence = await existingHeaders.isExisting()
             expect(headerExistence).toEqual([true, true])
         })

--- a/packages/webdriverio/src/multiremote.ts
+++ b/packages/webdriverio/src/multiremote.ts
@@ -97,6 +97,7 @@ export default class MultiRemote {
      * ```
      */
     static elementWrapper (
+        // TODO: One day let's change for a Map<string, WebdriverIO.Browser> to preserve the order of the instances
         instances: Record<string, WebdriverIO.Browser>,
         result: unknown,
         propertiesObject: Record<string, PropertyDescriptor>,


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

Using an array containing for UTs since Records of instance is not guaranteed to keep the order.

```
[MultiremoteBrowser on chrome, chrome and firefox #0-0] 1) Multi-remote instance should be able to filter on multi-remote element
[MultiremoteBrowser on chrome, chrome and firefox #0-0] expect(received).toEqual(expected) // deep equality

- Expected  - 1
+ Received  + 1

  Array [
-   "browserA",
    "browserC",
+   "browserA",
  ]
[MultiremoteBrowser on chrome, chrome and firefox #0-0] Error: expect(received).toEqual(expected) // deep equality
[MultiremoteBrowser on chrome, chrome and firefox #0-0]
[MultiremoteBrowser on chrome, chrome and firefox #0-0] - Expected  - 1
[MultiremoteBrowser on chrome, chrome and firefox #0-0] + Received  + 1
[MultiremoteBrowser on chrome, chrome and firefox #0-0]
[MultiremoteBrowser on chrome, chrome and firefox #0-0]   Array [
[MultiremoteBrowser on chrome, chrome and firefox #0-0] -   "browserA",
[MultiremoteBrowser on chrome, chrome and firefox #0-0]     "browserC",
[MultiremoteBrowser on chrome, chrome and firefox #0-0] +   "browserA",
[MultiremoteBrowser on chrome, chrome and firefox #0-0]   ]
[MultiremoteBrowser on chrome, chrome and firefox #0-0]     at Context.<anonymous> (D:\a\webdriverio\webdriverio\e2e\wdio\headless\multiRemoteTest.e2e.ts:110:47)
[MultiremoteBrowser on chrome, chrome and firefox #0-0]     at async Context.executeAsync (D:\a\webdriverio\webdriverio\packages\wdio-utils\build\index.js:1133:20)
[MultiremoteBrowser on chrome, chrome and firefox #0-0]     at async Context.testFrameworkFnWrapper (D:\a\webdriverio\webdriverio\packages\wdio-utils\build\index.js:1214:14)
```

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
