### PR TITLE
docs(webdriverio): document the $$ async iterator methods

### DIFF
--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -79,25 +79,91 @@ export interface ChainablePromiseElement extends
     AsyncElementProto,
     Omit<WebdriverIO.Element, keyof ChainablePromiseBaseElement | keyof AsyncElementProto> {}
 
+/**
+ * Asynchronous equivalents of the ES5 `Array` iteration methods, available on
+ * the element list returned by `$$`.
+ *
+ * Every method comes in two flavors: the base method runs its callbacks
+ * **concurrently**, while the `*Series` variant runs **one callback at a time**,
+ * in order. Prefer a `*Series` variant when the callback interacts with the
+ * browser and the order of those interactions matters.
+ */
 interface AsyncIterators<T> {
     /**
-     * Unwrap the nth element of the element list.
+     * Executes the callback once for each element, running the callbacks concurrently.
      */
     forEach: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => unknown, thisArg?: T) => Promise<void>
+    /**
+     * Same as `forEach`, but runs only one callback at a time.
+     */
     forEachSeries: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => unknown, thisArg?: T) => Promise<void>
+    /**
+     * Creates a new array with the result of the callback for each element, running
+     * the callbacks concurrently. The result always has the same length as the
+     * element list.
+     */
     map: <U>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => U | Promise<U>, thisArg?: T) => Promise<U[]>
+    /**
+     * Same as `map`, but runs only one callback at a time.
+     */
     mapSeries: <T, U>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => U | Promise<U>, thisArg?: T) => Promise<U[]>;
+    /**
+     * Returns the first element that satisfies the callback, running the callbacks
+     * concurrently. "First" means the first match to resolve, which is not
+     * necessarily the earliest element in the list, and every callback still runs
+     * even once a match is found. Use `findSeries` if either matters.
+     */
     find: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<T>;
+    /**
+     * Same as `find`, but runs only one callback at a time, so the first match in
+     * list order is returned.
+     */
     findSeries: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<T>;
+    /**
+     * Returns the index of the first element that satisfies the callback, running
+     * the callbacks concurrently.
+     */
     findIndex: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<number>;
+    /**
+     * Same as `findIndex`, but runs only one callback at a time.
+     */
     findIndexSeries: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<number>;
+    /**
+     * Resolves to `true` if at least one element satisfies the callback, running
+     * the callbacks concurrently.
+     */
     some: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<boolean>;
+    /**
+     * Same as `some`, but runs only one callback at a time.
+     */
     someSeries: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<boolean>;
+    /**
+     * Resolves to `true` if every element satisfies the callback, running the
+     * callbacks concurrently.
+     */
     every: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<boolean>;
+    /**
+     * Same as `every`, but runs only one callback at a time.
+     */
     everySeries: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<boolean>;
+    /**
+     * Creates a new array with the elements that satisfy the callback, running the
+     * callbacks concurrently.
+     */
     filter: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<WebdriverIO.Element[]>;
+    /**
+     * Same as `filter`, but runs only one callback at a time.
+     */
     filterSeries: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<WebdriverIO.Element[]>;
+    /**
+     * Reduces the element list to a single value, awaiting the accumulator between
+     * elements. Always runs one callback at a time, since each call depends on the
+     * previous result.
+     */
     reduce: <T, U>(callback: (accumulator: U, currentValue: WebdriverIO.Element, currentIndex: number, array: T[]) => U | Promise<U>, initialValue?: U) => Promise<U>;
+    /**
+     * Returns an async iterator over `[index, element]` pairs.
+     */
     entries(): AsyncIterableIterator<[number, WebdriverIO.Element]>;
 }
 

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -109,9 +109,10 @@ interface AsyncIterators<T> {
     mapSeries: <T, U>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => U | Promise<U>, thisArg?: T) => Promise<U[]>;
     /**
      * Returns the first element that satisfies the callback, running the callbacks
-     * concurrently. "First" means the first match to resolve, which is not
-     * necessarily the earliest element in the list, and every callback still runs
-     * even once a match is found. Use `findSeries` if either matters.
+     * concurrently, or `undefined` if none does. "First" means the first match to
+     * resolve, which is not necessarily the earliest element in the list, and every
+     * callback still runs even once a match is found. Use `findSeries` if either
+     * matters.
      */
     find: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<T>;
     /**
@@ -121,7 +122,10 @@ interface AsyncIterators<T> {
     findSeries: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<T>;
     /**
      * Returns the index of the first element that satisfies the callback, running
-     * the callbacks concurrently.
+     * the callbacks concurrently, or `-1` if none does. "First" means the first
+     * match to resolve, which is not necessarily the earliest element in the list,
+     * and every callback still runs even once a match is found. Use
+     * `findIndexSeries` if either matters.
      */
     findIndex: <T>(callback: (currentValue: WebdriverIO.Element, index: number, array: T[]) => boolean | Promise<boolean>, thisArg?: T) => Promise<number>;
     /**


### PR DESCRIPTION
Addresses part of #13919.

### What

`AsyncIterators<T>` in `packages/webdriverio/src/types.ts` carried exactly one JSDoc comment:

```ts
interface AsyncIterators<T> {
    /**
     * Unwrap the nth element of the element list.
     */
    forEach: ...
    forEachSeries: ...
    map: ...
    mapSeries: ...
```

That comment describes indexing rather than iteration, and looks like copy-paste drift from the `index?` property just above it. The other 16 methods had no documentation at all. In an editor that means `forEach` shows a wrong tooltip and `mapSeries` shows nothing, which is what @htho ran into in #13919: they had to read `pIteration.ts` to work out how `map` and `mapSeries` differ.

### Why here

Accurate descriptions already exist in `packages/wdio-utils/src/pIteration.ts`, they were just never surfaced on the public type. This PR propagates them, so the information reaches users through IntelliSense and the generated type definitions rather than requiring a trip into the implementation.

Each method now says what it does, and each base/`Series` pair says whether callbacks run **concurrently** or **one at a time**.

`find` and `findIndex` also note two things that are easy to get wrong, both verified against `find()` in `pIteration.ts`: with concurrent execution the result is the first match to *resolve* rather than the earliest element in the list, and every callback still runs after a match is found. The existing implementation comment makes the same point.

### Scope

Comments only. Stripping all comments from the file before and after this change gives byte-identical output, 473 lines of code unchanged, so there is no runtime or type behaviour change.

@christian-bromann you asked in #13919 where this documentation should live. This covers the type definitions half of the request. The issue also suggests a dedicated docs section on async iterators. I am happy to write that too, but wanted to keep it separate so this small correction is not blocked on agreeing where a new docs page belongs, and so you can tell me whether it fits better under the `$$` API page or as its own guide.
