### PR TITLE
feat: Beta ElementArray under feature flag for `multiRemote.$$()` e.g. MultiRemoteElement[]

### DIFF
--- a/e2e/wdio/headless/multiRemoteTest.e2e.ts
+++ b/e2e/wdio/headless/multiRemoteTest.e2e.ts
@@ -1,6 +1,7 @@
 import { multiRemoteBrowser, expect } from '@wdio/globals'
 import type { ElementArray } from 'webdriverio'
 import { Key } from 'webdriverio'
+import type MultiRemote from '../../../packages/webdriverio/src/multiremote.js'
 
 let browserA: WebdriverIO.Browser
 let browserB: WebdriverIO.Browser
@@ -222,6 +223,7 @@ describe('multi remote test', () => {
         })
 
         it('should return an ElementArray at runtime', async () => {
+            (multiRemoteBrowser as unknown as MultiRemote).enableMultiRemoteElementArray = true
 
             await multiRemoteBrowser.getInstance('browserA').url('about:blank')
             await multiRemoteBrowser.getInstance('browserB').url('about:blank')

--- a/e2e/wdio/headless/multiRemoteTest.e2e.ts
+++ b/e2e/wdio/headless/multiRemoteTest.e2e.ts
@@ -107,7 +107,7 @@ describe('multi remote test', () => {
             const existingHeaders = await header.unstable_filter((e) => e.isExisting())
 
             // TODO review to assert order of instances, as it may not be guaranteed to be the same order each time
-            expect(existingHeaders.instances).toEqual(['browserA', 'browserC'])
+            expect(existingHeaders.instances).toEqual(expect.arrayContaining(['browserA', 'browserC']))
             const header1Texts = await existingHeaders.isExisting()
             expect(header1Texts).toEqual([true, true])
         })
@@ -205,6 +205,19 @@ describe('multi remote test', () => {
             // Throws instance[commandName] is not a function
             const texts = await existing.getText()
             expect(texts).toEqual([])  // ← fails today: returns ['', '', ''] (3 browsers executed)
+        })
+
+        it('should always have selector for MultiRemoteElement[]', async () => {
+
+            await multiRemoteBrowser.getInstance('browserA').url('about:blank')
+            await multiRemoteBrowser.getInstance('browserB').url('about:blank')
+            await multiRemoteBrowser.getInstance('browserC').url('https://guinea-pig.webdriver.io/')
+
+            const elements = await multiRemoteBrowser.$$('h1')
+
+            expect(elements).toHaveLength(2)
+            expect(elements[0].selector).toBe('h1')
+            expect(elements[1].selector).toBe('h1')
         })
     })
 })

--- a/e2e/wdio/headless/multiRemoteTest.e2e.ts
+++ b/e2e/wdio/headless/multiRemoteTest.e2e.ts
@@ -1,4 +1,5 @@
 import { multiRemoteBrowser, expect } from '@wdio/globals'
+import type { ElementArray } from 'webdriverio'
 import { Key } from 'webdriverio'
 
 let browserA: WebdriverIO.Browser
@@ -207,7 +208,7 @@ describe('multi remote test', () => {
             expect(texts).toEqual([])  // ← fails today: returns ['', '', ''] (3 browsers executed)
         })
 
-        it('should always have selector for MultiRemoteElement[]', async () => {
+        it('should always have selector for MultiRemoteElement[] when some browsers have no matching elements', async () => {
 
             await multiRemoteBrowser.getInstance('browserA').url('about:blank')
             await multiRemoteBrowser.getInstance('browserB').url('about:blank')
@@ -218,6 +219,24 @@ describe('multi remote test', () => {
             expect(elements).toHaveLength(2)
             expect(elements[0].selector).toBe('h1')
             expect(elements[1].selector).toBe('h1')
+        })
+
+        it('should return an ElementArray at runtime', async () => {
+
+            await multiRemoteBrowser.getInstance('browserA').url('about:blank')
+            await multiRemoteBrowser.getInstance('browserB').url('about:blank')
+            await multiRemoteBrowser.getInstance('browserC').url('about:blank')
+
+            const elements = await multiRemoteBrowser.$$('h1')
+
+            console.log('elements', elements)
+            expect(elements).toHaveLength(0)
+            expect(elements).toHaveProperty('selector')
+            expect((elements as unknown as ElementArray).selector).toBe('h1')
+            expect((elements as unknown as ElementArray).foundWith).toBe('$$')
+            expect((elements as unknown as ElementArray).parent).toBeDefined()
+            expect((elements as unknown as ElementArray).getElements).toBeDefined()
+            expect(Array.isArray(elements)).toBe(true)
         })
     })
 })

--- a/e2e/wdio/headless/multiRemoteTest.e2e.ts
+++ b/e2e/wdio/headless/multiRemoteTest.e2e.ts
@@ -1,7 +1,6 @@
 import { multiRemoteBrowser, expect } from '@wdio/globals'
 import type { ElementArray } from 'webdriverio'
 import { Key } from 'webdriverio'
-import type MultiRemote from '../../../packages/webdriverio/src/multiremote.js'
 
 let browserA: WebdriverIO.Browser
 let browserB: WebdriverIO.Browser
@@ -222,23 +221,30 @@ describe('multi remote test', () => {
             expect(elements[1].selector).toBe('h1')
         })
 
-        it('should return an ElementArray at runtime', async () => {
-            (multiRemoteBrowser as unknown as MultiRemote).enableMultiRemoteElementArray = true
+        describe('when enabling process.env.WDIO_ENABLE_MULTI_REMOTE_ELEMENT_ARRAY', () => {
+            before(() => {
+                process.env.WDIO_ENABLE_MULTI_REMOTE_ELEMENT_ARRAY = 'true'
+            })
 
-            await multiRemoteBrowser.getInstance('browserA').url('about:blank')
-            await multiRemoteBrowser.getInstance('browserB').url('about:blank')
-            await multiRemoteBrowser.getInstance('browserC').url('about:blank')
+            after(() => {
+                process.env.WDIO_ENABLE_MULTI_REMOTE_ELEMENT_ARRAY = 'false'
+            })
 
-            const elements = await multiRemoteBrowser.$$('h1')
+            it('should return an ElementArray at runtime', async () => {
+                await multiRemoteBrowser.getInstance('browserA').url('about:blank')
+                await multiRemoteBrowser.getInstance('browserB').url('about:blank')
+                await multiRemoteBrowser.getInstance('browserC').url('about:blank')
 
-            console.log('elements', elements)
-            expect(elements).toHaveLength(0)
-            expect(elements).toHaveProperty('selector')
-            expect((elements as unknown as ElementArray).selector).toBe('h1')
-            expect((elements as unknown as ElementArray).foundWith).toBe('$$')
-            expect((elements as unknown as ElementArray).parent).toBeDefined()
-            expect((elements as unknown as ElementArray).getElements).toBeDefined()
-            expect(Array.isArray(elements)).toBe(true)
+                const elements = await multiRemoteBrowser.$$('h1')
+
+                expect(elements).toHaveLength(0)
+                expect(elements).toHaveProperty('selector')
+                expect((elements as unknown as ElementArray).selector).toBe('h1')
+                expect((elements as unknown as ElementArray).foundWith).toBe('$$')
+                expect((elements as unknown as ElementArray).parent).toBeDefined()
+                expect((elements as unknown as ElementArray).getElements).toBeDefined()
+                expect(Array.isArray(elements)).toBe(true)
+            })
         })
     })
 })

--- a/packages/webdriverio/src/commands/browser/$$.ts
+++ b/packages/webdriverio/src/commands/browser/$$.ts
@@ -66,12 +66,12 @@ export async function $$ (
                 ? await globalThis.wdio.executeWithScope(command, this.elementId, selector) as unknown as ElementReference[]
                 : await globalThis.wdio.execute(command, selector) as unknown as ElementReference[]
             const elements = await getElements.call(this, selector as Selector, res)
-            return enhanceElementsArray(elements, this, selector as Selector) as WebdriverIO.ElementArray
+            return enhanceElementsArray(elements, this, selector as Selector)
         }
 
         const res = await findDeepElements.call(this, selector)
         const elements = await getElements.call(this, selector as Selector, res)
-        return enhanceElementsArray(elements, getParent.call(this, res), selector as Selector) as WebdriverIO.ElementArray
+        return enhanceElementsArray(elements, getParent.call(this, res), selector as Selector)
     }
 
     let res: (ElementReference | Error)[] = Array.isArray(selector)
@@ -92,7 +92,7 @@ export async function $$ (
     }
 
     const elements = await getElements.call(this, selector as Selector, res)
-    return enhanceElementsArray(elements, getParent.call(this, res), selector as Selector) as WebdriverIO.ElementArray
+    return enhanceElementsArray(elements, getParent.call(this, res), selector as Selector)
 }
 
 function getParent (this: WebdriverIO.Browser | WebdriverIO.Element, res: ElementReference[]) {

--- a/packages/webdriverio/src/commands/element/shadow$$.ts
+++ b/packages/webdriverio/src/commands/element/shadow$$.ts
@@ -49,7 +49,7 @@ export async function shadow$$ (
         const { using, value } = findStrategy(selector as string, this.isW3C, this.isMobile)
         const res = await browser.findElementsFromShadowRoot(shadowRoot[SHADOW_ELEMENT_KEY], using, value)
         const elements = await getElements.call(this, selector as Selector, res, { isShadowElement: true })
-        return enhanceElementsArray(elements, this, selector as Selector) as WebdriverIO.ElementArray
+        return enhanceElementsArray(elements, this, selector as Selector)
     } catch (err) {
         log.warn(
             `Failed to fetch element within shadow DOM using WebDriver command: ${(err as Error).message}!\n` +

--- a/packages/webdriverio/src/multiremote.ts
+++ b/packages/webdriverio/src/multiremote.ts
@@ -101,7 +101,8 @@ export default class MultiRemote {
         instances: Record<string, WebdriverIO.Browser>,
         result: unknown,
         propertiesObject: Record<string, PropertyDescriptor>,
-        scope: MultiRemote
+        scope: MultiRemote,
+        selector?: string,
     ): WebdriverIO.MultiRemoteElement {
         const prototype = { ...propertiesObject, ...clone(getPrototype('element')), scope: { value: 'element' } }
 
@@ -116,9 +117,9 @@ export default class MultiRemote {
 
             client.instances = Object.keys(instances)
             client.isMultiremote = true
-            client.selector = Array.isArray(result) && result[0]
+            client.selector = selector ?? (Array.isArray(result) && result[0]
                 ? result[0].selector
-                : null
+                : null)
             // @ts-expect-error ToDo(Christian): remove eventually
             delete client.sessionId
 
@@ -231,10 +232,13 @@ export default class MultiRemote {
             if (commandName === '$') {
                 return MultiRemote.elementWrapper(activeInstances, result, this.__propertiesObject__, self)
             } else if (commandName === '$$') {
-                const zippedResult = zip(...result)
-                return zippedResult.map((singleResult) => MultiRemote.elementWrapper(activeInstances, singleResult, this.__propertiesObject__, self))
-            }
+                const selector = typeof args[0] === 'string' ? args[0] : undefined
 
+                const zippedResult = zip(...result)
+                const wrappedResult = zippedResult.map((singleResult) => MultiRemote.elementWrapper(activeInstances, singleResult, this.__propertiesObject__, self, selector))
+                // TODO wrapped MultiRemoteElement[] into a MultiRemoteElementArray and set selector/foundWith/isMultiremote
+                return wrappedResult
+            }
             return result
         })
     }

--- a/packages/webdriverio/src/multiremote.ts
+++ b/packages/webdriverio/src/multiremote.ts
@@ -30,7 +30,7 @@ export default class MultiRemote {
     /**
      * modifier for multibrowser instance
      */
-    modifier (wrapperClient: { options: Options.WebdriverIO, commandList: (keyof (ProtocolCommands & BrowserCommandsType) & 'getInstance' & 'unstable_select')[], enableMultiRemoteElementArray: boolean }) {
+    modifier (wrapperClient: { options: Options.WebdriverIO, commandList: (keyof (ProtocolCommands & BrowserCommandsType) & 'getInstance' & 'unstable_select')[] }) {
         const propertiesObject: Record<string, PropertyDescriptor> = {}
         propertiesObject.commandList = { value: wrapperClient.commandList }
         propertiesObject.options = { value: wrapperClient.options }

--- a/packages/webdriverio/src/multiremote.ts
+++ b/packages/webdriverio/src/multiremote.ts
@@ -18,7 +18,6 @@ export default class MultiRemote {
     baseInstance?: MultiRemoteDriver
     sessionId?: string
     usedUnstableSelectAPIOnElementScope = false
-    enableMultiRemoteElementArray = false
 
     /**
      * add instance to multibrowser instance
@@ -31,7 +30,7 @@ export default class MultiRemote {
     /**
      * modifier for multibrowser instance
      */
-    modifier (wrapperClient: { options: Options.WebdriverIO, commandList: (keyof (ProtocolCommands & BrowserCommandsType) & 'getInstance' & 'unstable_select')[] }) {
+    modifier (wrapperClient: { options: Options.WebdriverIO, commandList: (keyof (ProtocolCommands & BrowserCommandsType) & 'getInstance' & 'unstable_select')[], enableMultiRemoteElementArray: boolean }) {
         const propertiesObject: Record<string, PropertyDescriptor> = {}
         propertiesObject.commandList = { value: wrapperClient.commandList }
         propertiesObject.options = { value: wrapperClient.options }
@@ -238,7 +237,7 @@ export default class MultiRemote {
                 const wrappedResult = zippedResult.map((singleResult) => MultiRemote.elementWrapper(activeInstances, singleResult, this.__propertiesObject__, self, typeof selector === 'string' ? selector : undefined))
 
                 // TODO remove this flag in v10
-                if (!self.enableMultiRemoteElementArray) {
+                if (process.env.WDIO_ENABLE_MULTI_REMOTE_ELEMENT_ARRAY !== 'true') {
                     return wrappedResult
                 }
 

--- a/packages/webdriverio/src/multiremote.ts
+++ b/packages/webdriverio/src/multiremote.ts
@@ -18,6 +18,7 @@ export default class MultiRemote {
     baseInstance?: MultiRemoteDriver
     sessionId?: string
     usedUnstableSelectAPIOnElementScope = false
+    enableMultiRemoteElementArray = false
 
     /**
      * add instance to multibrowser instance
@@ -235,6 +236,12 @@ export default class MultiRemote {
                 const selector = args[0] as Selector
                 const zippedResult = zip(...result)
                 const wrappedResult = zippedResult.map((singleResult) => MultiRemote.elementWrapper(activeInstances, singleResult, this.__propertiesObject__, self, typeof selector === 'string' ? selector : undefined))
+
+                // TODO remove this flag in v10
+                if (!self.enableMultiRemoteElementArray) {
+                    return wrappedResult
+                }
+
                 // TODO in v10, let's do a proper MultiRemoteElementArray type instead of casting
                 const elementArray = enhanceElementsArray(
                     wrappedResult as unknown as WebdriverIO.Element[],

--- a/packages/webdriverio/src/multiremote.ts
+++ b/packages/webdriverio/src/multiremote.ts
@@ -5,8 +5,8 @@ import type { Options } from '@wdio/types'
 import type { ProtocolCommands } from '@wdio/protocols'
 
 import { multiremoteHandler } from './middlewares.js'
-import { getPrototype } from './utils/index.js'
-import type { BrowserCommandsType, WebdriverIOEventMap } from './types.js'
+import { enhanceElementsArray, getPrototype } from './utils/index.js'
+import type { BrowserCommandsType, Selector, WebdriverIOEventMap } from './types.js'
 
 type EventEmitter = (args: unknown) => void
 
@@ -232,12 +232,20 @@ export default class MultiRemote {
             if (commandName === '$') {
                 return MultiRemote.elementWrapper(activeInstances, result, this.__propertiesObject__, self)
             } else if (commandName === '$$') {
-                const selector = typeof args[0] === 'string' ? args[0] : undefined
-
+                const selector = args[0] as Selector
                 const zippedResult = zip(...result)
-                const wrappedResult = zippedResult.map((singleResult) => MultiRemote.elementWrapper(activeInstances, singleResult, this.__propertiesObject__, self, selector))
-                // TODO wrapped MultiRemoteElement[] into a MultiRemoteElementArray and set selector/foundWith/isMultiremote
-                return wrappedResult
+                const wrappedResult = zippedResult.map((singleResult) => MultiRemote.elementWrapper(activeInstances, singleResult, this.__propertiesObject__, self, typeof selector === 'string' ? selector : undefined))
+                // TODO in v10, let's do a proper MultiRemoteElementArray type instead of casting
+                const elementArray = enhanceElementsArray(
+                    wrappedResult as unknown as WebdriverIO.Element[],
+                    this as unknown as WebdriverIO.Browser,
+                    selector,
+                    commandName
+                )
+
+                // TODO expose this property in v10 with a new MultiRemoteElementArray type
+                Object.assign(elementArray, { isMultiremote: true })
+                return elementArray
             }
             return result
         })

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -147,6 +147,7 @@ type ElementCommandNames = SingleElementCommandNames | MultiElementCommandNames
 type MultiRemoteElementCommands = {
     [K in keyof Pick<BrowserCommandsType, SingleElementCommandNames>]: (...args: Parameters<BrowserCommandsType[K]>) => ThenArg<WebdriverIO.MultiRemoteElement>
 } & {
+    // TODO change MultiRemoteElement[] for a MultiRemoteElementArray type in v10
     [K in keyof Pick<BrowserCommandsType, MultiElementCommandNames>]: (...args: Parameters<BrowserCommandsType[K]>) => ThenArg<WebdriverIO.MultiRemoteElement[]>
 }
 


### PR DESCRIPTION
## Proposed changes

When querying multiple elements with `$$()` under a multi-remote browser, we can end up with an empty array and be unable to refetch elements because the `selectors`, `foundWith`, and `parent` properties are missing.
This impairs the assertion in `expect-webdriverio` since the `waitUntil` might be useless.

As a quick and non-breaking solution, `enhanceElementsArray` was leveraged behind a flag so that we can unblock support for multi-remote in `expect-webdriverio`.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
