### PR TITLE
fix(webdriverio): handle BiDi no such node errors as stale

### DIFF
--- a/packages/webdriverio/src/utils/index.ts
+++ b/packages/webdriverio/src/utils/index.ts
@@ -244,7 +244,8 @@ export function isStaleElementError(err: Error) {
         // Chrome through JS execution
         err.message.includes('stale element not found in the current frame') ||
         // BIDI
-        err.message.includes('belongs to different document')
+        err.message.includes('belongs to different document') ||
+        err.message.includes('no such node - The node with the reference')
     )
 }
 

--- a/packages/webdriverio/tests/middleware.test.ts
+++ b/packages/webdriverio/tests/middleware.test.ts
@@ -71,6 +71,20 @@ describe('middleware', () => {
         vi.mocked(fetch).retryCnt = 0
     })
 
+    it('should refetch an element after a BiDi no such node error', async () => {
+        const isAfterNavigationDisplayed = vi.fn()
+            .mockRejectedValueOnce(new Error(
+                'WebDriver Bidi command "script.callFunction" failed with error: no such node - The node with the reference stale-element-123 is not known'
+            ))
+            .mockResolvedValueOnce(false)
+        browser.addCommand('isAfterNavigationDisplayed', isAfterNavigationDisplayed, true)
+        const elem = await browser.$('#foo')
+
+        // @ts-expect-error undefined custom command
+        await expect(elem.isAfterNavigationDisplayed()).resolves.toBe(false)
+        expect(isAfterNavigationDisplayed).toHaveBeenCalledTimes(2)
+    })
+
     it('should successfully getAttribute of an element that falls stale after being re-found in Safari', async () => {
         browser = await remote({
             baseUrl: 'http://foobar.com',


### PR DESCRIPTION
## Proposed changes

Fixes #15534.

When a Firefox WebDriver BiDi node reference is invalidated by navigation, `script.callFunction` reports `no such node` instead of one of the stale-element messages WebdriverIO currently recognizes. Treat that precise error shape as stale so the existing element middleware refetches the selector and retries the command. A focused regression test exercises the middleware retry path and verifies that the retried display check can return `false`.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Validated with the focused WebdriverIO middleware, stale-error utility, and `isDisplayed` unit suites, plus ESLint on both changed files.

### Reviewers: @webdriverio/project-committers