### PR TITLE
Docs/actions api guidance

### DIFF
--- a/packages/wdio-protocols/src/protocols/webdriver.ts
+++ b/packages/wdio-protocols/src/protocols/webdriver.ts
@@ -1171,7 +1171,7 @@ export default {
         POST: {
             command: 'performActions',
             description:
-                'The Perform Actions command is used to execute complex user actions. See [spec](https://github.com/jlipps/simple-wd-spec#perform-actions) for more details.',
+                'The Perform Actions command is used to execute complex user actions. Most users should prefer the higher-level [`browser.action()`](https://webdriver.io/docs/api/browser/action) API. See [spec](https://github.com/jlipps/simple-wd-spec#perform-actions) for more details.',
             ref: 'https://w3c.github.io/webdriver/#dfn-perform-actions',
             parameters: [
                 {

--- a/packages/webdriverio/src/commands/browser/action.ts
+++ b/packages/webdriverio/src/commands/browser/action.ts
@@ -4,6 +4,10 @@ import { KeyAction, PointerAction, WheelAction } from '../../utils/actions/index
 /**
  * The action command is a low-level interface for providing virtualized device input actions to the web browser.
  *
+ * For simple key presses, use [`browser.keys()`](https://webdriver.io/docs/api/browser/keys) instead. To perform
+ * multiple action chains at once, such as holding `Control` while clicking, use
+ * [`browser.actions()`](https://webdriver.io/docs/api/browser/actions).
+ *
  * In addition to high level commands such like `scrollIntoView`, `doubleClick`, the Actions API provides granular
  * control over exactly what designated input devices can do. WebdriverIO provides an interface for 3 kinds of input
  * sources:

--- a/packages/webdriverio/src/commands/browser/actions.ts
+++ b/packages/webdriverio/src/commands/browser/actions.ts
@@ -1,8 +1,9 @@
 import type { KeyAction, PointerAction, WheelAction } from '../../utils/actions/index.js'
 
 /**
- * Allows to run multiple action interaction at once, e.g. to simulate a pinch zoom.
- * For more information on the `action` command, check out the [docs](/docs/api/browser/action).
+ * Allows to run multiple action interactions at once, e.g. to simulate a pinch zoom or hold a modifier key while
+ * clicking. Build each action chain with [`browser.action()`](/docs/api/browser/action), then pass the chains to this
+ * command.
  *
  * <example>
     :action.js

--- a/packages/webdriverio/src/commands/browser/keys.ts
+++ b/packages/webdriverio/src/commands/browser/keys.ts
@@ -22,8 +22,8 @@ import { checkUnicode } from '../../utils/index.js'
  * See the [Key API docs](/docs/api/modules#key) for a complete list.
  *
  * Modifier keys like `Control`, `Shift`, `Alt` and `Command` will stay pressed throughout the sequence and will be released
- * at the end. Modifying a click requires you to use the WebDriver Actions API through the
- * [performActions](https://webdriver.io/docs/api/webdriver#performactions) method.
+ * at the end. To combine keyboard input with pointer actions, use
+ * [`browser.action()`](https://webdriver.io/docs/api/browser/action) instead.
  *
  * :::info Cross-Platform Modifier
  *

--- a/packages/webdriverio/src/commands/browser/keys.ts
+++ b/packages/webdriverio/src/commands/browser/keys.ts
@@ -22,8 +22,9 @@ import { checkUnicode } from '../../utils/index.js'
  * See the [Key API docs](/docs/api/modules#key) for a complete list.
  *
  * Modifier keys like `Control`, `Shift`, `Alt` and `Command` will stay pressed throughout the sequence and will be released
- * at the end. To combine keyboard input with pointer actions, use
- * [`browser.action()`](https://webdriver.io/docs/api/browser/action) instead.
+ * at the end. To combine keyboard input with pointer actions, build separate input-source chains with
+ * [`browser.action()`](https://webdriver.io/docs/api/browser/action) and submit them together with
+ * [`browser.actions()`](https://webdriver.io/docs/api/browser/actions).
  *
  * :::info Cross-Platform Modifier
  *


### PR DESCRIPTION
## Proposed changes

Improves the Actions API documentation by linking users to the most appropriate high-level API:

- points `browser.keys()` users to `browser.action()` for combined keyboard and pointer interactions;
- explains when to use `browser.keys()` and `browser.actions()` from `browser.action()`;
- clarifies that `performActions` is a low-level protocol command and recommends `browser.action()` for most use cases.

Closes #15272.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

No test changes are needed; this PR only updates generated API documentation source comments.

### Reviewers: @webdriverio/project-committers