### PR TITLE
fix(webdriverio): require all classic cookie filter attributes

### DIFF
--- a/packages/webdriverio/src/commands/browser/getCookies.ts
+++ b/packages/webdriverio/src/commands/browser/getCookies.ts
@@ -125,10 +125,11 @@ async function getCookiesClassic(
 
     const filter = getCookieFilter(names)
     const allCookies = await this.getAllCookies()
+    const filterValue = typeof filter === 'object' ? getCookieValue(filter.value) : undefined
     return allCookies.filter(cookie => (
         !filter || (typeof filter === 'object' && (
             (filter.name === undefined || filter.name === cookie.name) &&
-            (filter.value === undefined || filter.value?.value === cookie.value) &&
+            (filter.value === undefined || filterValue === cookie.value) &&
             (filter.path === undefined || filter.path === cookie.path) &&
             (filter.domain === undefined || filter.domain === cookie.domain) &&
             (filter.sameSite === undefined || filter.sameSite === cookie.sameSite) &&
@@ -137,6 +138,16 @@ async function getCookiesClassic(
             (filter.secure === undefined || filter.secure === cookie.secure)
         ))
     ))
+}
+
+function getCookieValue(value?: remote.NetworkBytesValue | null): string | undefined {
+    if (!value) {
+        return
+    }
+
+    return value.type === 'base64'
+        ? Buffer.from(value.value, 'base64').toString('utf-8')
+        : value.value
 }
 
 function getCookieFilter (names?: string | string[] | remote.StorageCookieFilter) {

--- a/packages/webdriverio/src/commands/browser/getCookies.ts
+++ b/packages/webdriverio/src/commands/browser/getCookies.ts
@@ -126,15 +126,16 @@ async function getCookiesClassic(
     const filter = getCookieFilter(names)
     const allCookies = await this.getAllCookies()
     return allCookies.filter(cookie => (
-        !filter ||
-        cookie.name && filter.name === cookie.name ||
-        cookie.value && filter.value?.value === cookie.value ||
-        cookie.path && filter.path === cookie.path ||
-        cookie.domain && filter.domain === cookie.domain ||
-        cookie.sameSite && filter.sameSite === cookie.sameSite ||
-        cookie.expiry && filter.expiry === cookie.expiry ||
-        typeof cookie.httpOnly === 'boolean' && filter.httpOnly === cookie.httpOnly ||
-        typeof cookie.secure === 'boolean' && filter.secure === cookie.secure
+        !filter || (typeof filter === 'object' && (
+            (filter.name === undefined || filter.name === cookie.name) &&
+            (filter.value === undefined || filter.value.value === cookie.value) &&
+            (filter.path === undefined || filter.path === cookie.path) &&
+            (filter.domain === undefined || filter.domain === cookie.domain) &&
+            (filter.sameSite === undefined || filter.sameSite === cookie.sameSite) &&
+            (filter.expiry === undefined || filter.expiry === cookie.expiry) &&
+            (filter.httpOnly === undefined || filter.httpOnly === cookie.httpOnly) &&
+            (filter.secure === undefined || filter.secure === cookie.secure)
+        ))
     ))
 }
 

--- a/packages/webdriverio/src/commands/browser/getCookies.ts
+++ b/packages/webdriverio/src/commands/browser/getCookies.ts
@@ -128,7 +128,7 @@ async function getCookiesClassic(
     return allCookies.filter(cookie => (
         !filter || (typeof filter === 'object' && (
             (filter.name === undefined || filter.name === cookie.name) &&
-            (filter.value === undefined || filter.value.value === cookie.value) &&
+            (filter.value === undefined || filter.value?.value === cookie.value) &&
             (filter.path === undefined || filter.path === cookie.path) &&
             (filter.domain === undefined || filter.domain === cookie.domain) &&
             (filter.sameSite === undefined || filter.sameSite === cookie.sameSite) &&

--- a/packages/webdriverio/tests/commands/browser/getCookies.test.ts
+++ b/packages/webdriverio/tests/commands/browser/getCookies.test.ts
@@ -69,6 +69,23 @@ describe('getCookies', () => {
             ])
         })
 
+        it('should require all attributes in an object filter to match', async () => {
+            vi.mocked(fetch).setMockResponse([[
+                { name: 'session', value: 'matching', domain: 'webdriver.io' },
+                { name: 'session', value: 'wrong-domain', domain: 'example.com' },
+                { name: 'another', value: 'wrong-name', domain: 'webdriver.io' },
+            ]])
+
+            const cookies = await browser.getCookies({
+                name: 'session',
+                domain: 'webdriver.io'
+            })
+
+            expect(cookies).toEqual([
+                { name: 'session', value: 'matching', domain: 'webdriver.io' }
+            ])
+        })
+
         it('should throw error if invalid arguments are passed', async () => {
             // @ts-ignore test invalid input
             const cookies = await browser.getCookies([2])

--- a/packages/webdriverio/tests/commands/browser/getCookies.test.ts
+++ b/packages/webdriverio/tests/commands/browser/getCookies.test.ts
@@ -86,6 +86,22 @@ describe('getCookies', () => {
             ])
         })
 
+        it('should decode base64 values in an object filter', async () => {
+            vi.mocked(fetch).setMockResponse([[
+                { name: 'session', value: 'matching', domain: 'webdriver.io' },
+            ]])
+
+            const cookies = await browser.getCookies({
+                name: 'session',
+                value: { type: 'base64', value: btoa('matching') },
+                domain: 'webdriver.io'
+            })
+
+            expect(cookies).toEqual([
+                { name: 'session', value: 'matching', domain: 'webdriver.io' }
+            ])
+        })
+
         it('should throw error if invalid arguments are passed', async () => {
             // @ts-ignore test invalid input
             const cookies = await browser.getCookies([2])

--- a/packages/webdriverio/tests/commands/browser/getCookies.test.ts
+++ b/packages/webdriverio/tests/commands/browser/getCookies.test.ts
@@ -92,6 +92,12 @@ describe('getCookies', () => {
             expect(cookies).toEqual([])
         })
 
+        it('should not throw for an invalid cookie value filter', async () => {
+            // @ts-expect-error test invalid input
+            const cookies = await browser.getCookies({ value: null })
+            expect(cookies).toEqual([])
+        })
+
         afterEach(() => {
             vi.mocked(fetch).mockClear()
         })


### PR DESCRIPTION
## Proposed changes

Fixes the WebDriver Classic fallback of `browser.getCookies()` so every provided object filter attribute must match.

Adds a regression unit test for combined `name` and `domain` filtering.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Polish (an improvement for an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments
The WebDriver Classic fallback combined object filter attributes with `||`. As a result, `browser.getCookies({ name: 'session', domain: 'webdriver.io' })` returned cookies that matched either the name or the domain, rather than both.

This was inconsistent with BiDi `storage.getCookies`. Its cookie matching algorithm checks every provided filter entry and rejects a cookie when any entry differs: https://w3c.github.io/webdriver-bidi/#match-cookie
### Reviewers: @webdriverio/project-committers