### PR TITLE
fix(webdriverio): avoid expensive findElements call in isExisting on mobile

### DIFF
--- a/packages/webdriverio/src/commands/element/isExisting.ts
+++ b/packages/webdriverio/src/commands/element/isExisting.ts
@@ -61,6 +61,22 @@ export async function isExisting (this: WebdriverIO.Element) {
         )
     }
 
+    /**
+     * on mobile, `findElements` can be very expensive (e.g. large scrollable
+     * lists on iOS take 30+ seconds), so use a single `findElement` lookup to
+     * check existence. On web we keep `findElements` to avoid the implicitWait
+     * penalty on non-existent elements.
+     */
+    if (this.isMobile) {
+        const command = this.isReactElement
+            ? this.parent.react$.bind(this.parent)
+            : this.isShadowElement
+                ? this.shadow$.bind(this.parent)
+                : this.parent.$.bind(this.parent)
+        const element = await command(this.selector as string)
+        return Boolean(element.elementId)
+    }
+
     const command = this.isReactElement
         ? this.parent.react$$.bind(this.parent)
         : this.isShadowElement

--- a/packages/webdriverio/tests/commands/element/isExisting.test.ts
+++ b/packages/webdriverio/tests/commands/element/isExisting.test.ts
@@ -42,6 +42,20 @@ describe('isExisting test', () => {
 
     })
 
+    it('should use findElement (single) on mobile', async () => {
+        const mobileBrowser = await remote({
+            baseUrl: 'http://foobar.com',
+            capabilities: {
+                platformName: 'iOS'
+            }
+        })
+        const elem = await mobileBrowser.$('#foo')
+        await elem.isExisting()
+        // @ts-expect-error mock implementation
+        expect(vi.mocked(fetch).mock.calls[2][0]!.pathname)
+            .toBe('/session/foobar-123/element')
+    })
+
     afterEach(() => {
         vi.mocked(fetch).mockClear()
     })

--- a/packages/webdriverio/tests/commands/element/isExisting.test.ts
+++ b/packages/webdriverio/tests/commands/element/isExisting.test.ts
@@ -50,10 +50,15 @@ describe('isExisting test', () => {
             }
         })
         const elem = await mobileBrowser.$('#foo')
+
+        // clear the mock so we only assert isExisting's own request,
+        // not the findElement from $('#foo') above
+        vi.mocked(fetch).mockClear()
+
         await elem.isExisting()
-        // @ts-expect-error mock implementation
-        expect(vi.mocked(fetch).mock.calls[2][0]!.pathname)
-            .toBe('/session/foobar-123/element')
+        expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1)
+        const url = vi.mocked(fetch).mock.calls[0][0] as URL | string
+        expect(url.toString().endsWith('/element')).toBe(true)
     })
 
     afterEach(() => {

--- a/packages/webdriverio/tests/commands/element/isExisting.test.ts
+++ b/packages/webdriverio/tests/commands/element/isExisting.test.ts
@@ -57,8 +57,10 @@ describe('isExisting test', () => {
 
         await elem.isExisting()
         expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1)
-        const url = vi.mocked(fetch).mock.calls[0][0] as URL | string
-        expect(url.toString().endsWith('/element')).toBe(true)
+        expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+            expect.toSatisfy((url: URL | string) => url.toString().endsWith('/element')),
+            expect.any(Object)
+        )
     })
 
     afterEach(() => {


### PR DESCRIPTION
## Proposed changes

`isExisting` (and therefore `waitForExist`, which reuses it) always used `$$` / `findElements`. On mobile this can be very expensive — as reported in #7580, large scrollable lists on iOS can take 30+ seconds, because `findElements` materializes the whole list.

On mobile this PR switches `isExisting` to a single `$` / `findElement` lookup and checks for a resolved `elementId`, following the `isMobile`-conditional direction discussed in #7580.

Web keeps using `findElements` on purpose. As @BorisOsipov pointed out in the issue, switching web to `findElement` would make every lookup of a non-existent element pay the full `implicitWait` timeout. Scoping the change to `isMobile` targets exactly the case where `findElements` is the expensive path and `implicitWait` is rarely used, without changing web behavior.

I also reviewed `waitForExist`'s post-wait refetch: its non-indexed branch already uses `$` (single), and the `this.index !== undefined` branch keeps `$$` because resolving a positional selector (`$$(...)[n]`) inherently needs the full list. That `findElements` call is intentional and left as-is.

Fixes #7580

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported