### PR TITLE
docs: add RobotActions to the cloud services page

### DIFF
--- a/website/docs/CloudServices.md
+++ b/website/docs/CloudServices.md
@@ -184,7 +184,7 @@ In addition, you need to add cloud configuration, as follows:
 
 ## RobotActions
 
-[RobotActions](https://robotactions.com) provides real Android and iOS devices alongside browser nodes behind a single endpoint. It authenticates with an API token sent as a bearer header rather than a `user` and `key` pair:
+[RobotActions](https://robotactions.com) provides real Android and iOS devices alongside browser nodes behind a single endpoint. It authenticates with an API token rather than a `user` and `key` pair. Send the token as a bearer header:
 
 ```js
 export const config = {
@@ -197,17 +197,41 @@ export const config = {
   },
   capabilities: [{
     browserName: 'chrome'
-  }],
+  }]
+}
 ```
 
-The grid also accepts the token as a `/t/<token>/` path prefix, but WebdriverIO cannot use that form: it is fetch-based, and Node 18 and above reject credentials embedded in a URL. Use the header shown above.
-
-To run against a real device, pass the browser as an Appium capability:
+Alternatively, pass the token as a path prefix, which the grid strips before forwarding the request:
 
 ```js
+export const config = {
+  protocol: 'https',
+  hostname: 'grid.robotactions.com',
+  port: 443,
+  path: `/t/${process.env.RA_API_TOKEN}/`,
+  capabilities: [{
+    browserName: 'chrome'
+  }]
+}
+```
+
+The grid additionally accepts credentials embedded in the URL (`https://user:token@host`) for other WebDriver clients, but that form cannot be used from WebdriverIO: it is fetch-based, and Node 18 and above reject URL-embedded credentials.
+
+To run against a real device, pass the browser as an Appium capability alongside either connection style above:
+
+```js
+export const config = {
+  protocol: 'https',
+  hostname: 'grid.robotactions.com',
+  port: 443,
+  path: '/',
+  headers: {
+    Authorization: `Bearer ${process.env.RA_API_TOKEN}`
+  },
   capabilities: [{
     platformName: 'Android',
     'appium:browserName': 'chrome',
     'appium:automationName': 'UiAutomator2'
-  }],
+  }]
+}
 ```

--- a/website/docs/CloudServices.md
+++ b/website/docs/CloudServices.md
@@ -181,3 +181,33 @@ In addition, you need to add cloud configuration, as follows:
   port: 443,
   protocol: "https",
 ```
+
+## RobotActions
+
+[RobotActions](https://robotactions.com) provides real Android and iOS devices alongside browser nodes behind a single endpoint. It authenticates with an API token sent as a bearer header rather than a `user` and `key` pair:
+
+```js
+export const config = {
+  protocol: 'https',
+  hostname: 'grid.robotactions.com',
+  port: 443,
+  path: '/',
+  headers: {
+    Authorization: `Bearer ${process.env.RA_API_TOKEN}`
+  },
+  capabilities: [{
+    browserName: 'chrome'
+  }],
+```
+
+The grid also accepts the token as a `/t/<token>/` path prefix, but WebdriverIO cannot use that form: it is fetch-based, and Node 18 and above reject credentials embedded in a URL. Use the header shown above.
+
+To run against a real device, pass the browser as an Appium capability:
+
+```js
+  capabilities: [{
+    platformName: 'Android',
+    'appium:browserName': 'chrome',
+    'appium:automationName': 'UiAutomator2'
+  }],
+```


### PR DESCRIPTION
### Motivation

[RobotActions](https://robotactions.com) is a device cloud offering real Android and iOS devices alongside browser nodes behind a single WebDriver endpoint. Users connecting it to WebdriverIO currently have to work the configuration out for themselves, including one caveat that is specific to WebdriverIO (below).

### What this changes

A single `## RobotActions` section appended to `website/docs/CloudServices.md`. It is a **pure addition** — no existing prose is modified.

The section follows the shape already used on this page by Perfecto: configuration via `hostname`/`path`/`port`/`protocol` rather than a service package, so nothing is added to `services.json` or the `create-wdio` picker.

### The WebdriverIO-specific caveat

The grid accepts its API token two ways: an `Authorization: Bearer` header, or a `/t/<token>/` URL path prefix. The path form works for the Python and Java clients but **cannot** work with WebdriverIO, which is fetch-based — Node 18+ rejects credentials embedded in a URL. The docs therefore show the header form and say why, since this is the failure people hit first.

### Checks

- Documentation only; no code, no dependencies, no package listings touched.
- Configuration shown was verified against a live grid using WebdriverIO v9, on desktop browsers and on real Android and iOS devices.

Happy to adjust wording, placement, or trim the section if you'd prefer it shorter.