### PR TITLE
fix: encode file URLs for absolute plugin paths

### DIFF
--- a/packages/wdio-utils/src/initializePlugin.ts
+++ b/packages/wdio-utils/src/initializePlugin.ts
@@ -1,4 +1,6 @@
 import type { Services } from '@wdio/types'
+import { platform } from 'node:os'
+import { pathToFileURL } from 'node:url'
 
 import { safeImport, isAbsolute, REG_EXP_WINDOWS_ABS_PATH, SLASH } from './utils.js'
 
@@ -57,12 +59,17 @@ function ensureFileURL(path:string) {
 
     // Windows drive path
     if (REG_EXP_WINDOWS_ABS_PATH.test(path)) {
-        return `${FILE_PROTOCOL}/${path.replace(/\\/g, '/')}`
+        if (platform() === 'win32') {
+            return pathToFileURL(path).href
+        }
+
+        const pathname = path.replace(/\\/g, '/').split('/').map(encodeURIComponent).join('/')
+        return `${FILE_PROTOCOL}/${pathname}`
     }
 
     // Unix absolute path
     if (path.startsWith(SLASH)) {
-        return `${FILE_PROTOCOL}${path}`
+        return pathToFileURL(path).href
     }
 
     return path

--- a/packages/wdio-utils/tests/__fixtures__/plugins/percent%service.js
+++ b/packages/wdio-utils/tests/__fixtures__/plugins/percent%service.js
@@ -1,0 +1,3 @@
+export default class PercentService {
+    foo = 'percent'
+}

--- a/packages/wdio-utils/tests/initializePlugin.test.ts
+++ b/packages/wdio-utils/tests/initializePlugin.test.ts
@@ -50,6 +50,14 @@ describe('initializePlugin', () => {
         expect(service.foo).toBe('foo')
     })
 
+    it('should allow reserved characters in an absolute plugin path', async () => {
+        const servicePath = path.resolve(fixtureDir, 'percent%service.js')
+        vi.mocked(resolve).mockImplementation((specifier: string) => specifier)
+        const { default: Service } = await initializePlugin(servicePath, 'service')
+        const service = new Service({} as any, {}, {}) as TestService
+        expect(service.foo).toBe('percent')
+    })
+
     it('should allow to load a scoped service plugin', async ()=>{
         const name = 'foo'
         const type = 'service'


### PR DESCRIPTION
## Proposed changes

- build native absolute plugin URLs with Node's pathToFileURL() so reserved characters are encoded correctly
- preserve Windows drive-path support when WebdriverIO resolves those paths on non-Windows hosts
- add a regression fixture whose filename contains a literal percent sign

Fixes #15543.

## Verification

- corepack pnpm@10.34.5 -r --filter=@wdio/compiler run build -p @wdio/logger -p @wdio/types -p @wdio/globals -p @wdio/protocols -p @wdio/repl`n- corepack pnpm@10.34.5 exec vitest --config vitest.config.ts --run packages/wdio-utils/tests (14 files, 281 tests, no type errors)
- corepack pnpm@10.34.5 exec eslint packages/wdio-utils/src packages/wdio-utils/tests`n- git diff --check`n
AI assistance was used to help implement and validate this change; the behavior was reproduced against a real percent-sign fixture and the resulting patch was reviewed and tested locally.