### PR TITLE
fix(sumologic-reporter): retry after failed sync

### DIFF
--- a/packages/wdio-sumologic-reporter/src/index.ts
+++ b/packages/wdio-sumologic-reporter/src/index.ts
@@ -176,13 +176,14 @@ export default class SumoLogicReporter extends WDIOReporter {
              */
             this._unsynced.splice(0, MAX_LINES)
 
+            return log.debug(`synchronised collector data, server status: ${resp.status}`)
+        } catch (err) {
+            return log.error('failed send data to Sumo Logic:\n', (err as Error).stack)
+        } finally {
             /**
              * reset sync flag so we can sync again
              */
             this._isSynchronising = false
-            return log.debug(`synchronised collector data, server status: ${resp.status}`)
-        } catch (err) {
-            return log.error('failed send data to Sumo Logic:\n', (err as Error).stack)
         }
     }
 }

--- a/packages/wdio-sumologic-reporter/tests/reporter.test.ts
+++ b/packages/wdio-sumologic-reporter/tests/reporter.test.ts
@@ -111,6 +111,22 @@ describe('wdio-sumologic-reporter', () => {
             .toContain('failed send data to Sumo Logic')
     })
 
+    it('should retry syncing after a failed request', async () => {
+        reporter = new SumoLogicReporter({ sourceAddress: 'http://localhost:1234' })
+        vi.mocked(fetch)
+            .mockRejectedValueOnce(new Error('temporary network failure'))
+            .mockResolvedValueOnce({ status: 200 } as Response)
+        reporter.onRunnerStart('onRunnerStart' as any)
+
+        await reporter.sync()
+        expect(reporter['_isSynchronising']).toBe(false)
+        expect(reporter['_unsynced']).toHaveLength(1)
+
+        await reporter.sync()
+        expect(fetch).toHaveBeenCalledTimes(2)
+        expect(reporter['_unsynced']).toHaveLength(0)
+    })
+
     it('should be synchronised when no unsynced messages', async () => {
         reporter = new SumoLogicReporter({ sourceAddress: 'http://localhost:1234' })
         reporter.onRunnerStart('onRunnerStart' as any)


### PR DESCRIPTION
## Proposed changes

Fix the Sumo Logic reporter so that a failed network request does not leave it permanently marked as synchronising.

The synchronisation flag is now reset in `finally`, allowing the reporter to retry queued events on the next sync interval. A regression test covers a failed request followed by a successful retry.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Tests:

```sh
corepack pnpm vitest --config vitest.config.ts --run packages/wdio-sumologic-reporter/tests/reporter.test.ts