### PR TITLE
fix(sumologic-reporter): retry after failed sync

### DIFF
--- a/packages/wdio-sumologic-reporter/src/index.ts
+++ b/packages/wdio-sumologic-reporter/src/index.ts
@@ -9,6 +9,7 @@ import type { Options } from './types.js'
 const log = logger('@wdio/sumologic-reporter')
 
 const MAX_LINES = 100
+const MAX_RETRY_DELAY = 1000
 
 /**
  * Format date to match dateformat pattern 'yyyy-mm-dd HH:mm:ss,l o'
@@ -42,6 +43,8 @@ export default class SumoLogicReporter extends WDIOReporter {
     private _unsynced: string[] = []
     private _isSynchronising = false
     private _hasRunnerEnd = false
+    private _retryDelay = 0
+    private _nextRetryAt = 0
 
     constructor(options: Options) {
         super(options)
@@ -152,8 +155,14 @@ export default class SumoLogicReporter extends WDIOReporter {
          *  - we've already send out a request and are waiting for the successful response
          *  - we have nothing to synchronise
          *  - there is an invalid source address
+         *  - the retry backoff has not elapsed
          */
-        if (this._isSynchronising || this._unsynced.length === 0 || typeof this._options.sourceAddress !== 'string') {
+        if (
+            this._isSynchronising ||
+            this._unsynced.length === 0 ||
+            typeof this._options.sourceAddress !== 'string' ||
+            Date.now() < this._nextRetryAt
+        ) {
             return
         }
 
@@ -171,6 +180,9 @@ export default class SumoLogicReporter extends WDIOReporter {
                 body: JSON.stringify(logLines)
             })
 
+            this._retryDelay = 0
+            this._nextRetryAt = 0
+
             /**
              * remove transfered logs from log bucket
              */
@@ -178,6 +190,11 @@ export default class SumoLogicReporter extends WDIOReporter {
 
             return log.debug(`synchronised collector data, server status: ${resp.status}`)
         } catch (err) {
+            this._retryDelay = Math.min(
+                Math.max(this._options.syncInterval ?? 100, this._retryDelay * 2),
+                MAX_RETRY_DELAY
+            )
+            this._nextRetryAt = Date.now() + this._retryDelay
             return log.error('failed send data to Sumo Logic:\n', (err as Error).stack)
         } finally {
             this._isSynchronising = false

--- a/packages/wdio-sumologic-reporter/src/index.ts
+++ b/packages/wdio-sumologic-reporter/src/index.ts
@@ -176,13 +176,11 @@ export default class SumoLogicReporter extends WDIOReporter {
              */
             this._unsynced.splice(0, MAX_LINES)
 
-            /**
-             * reset sync flag so we can sync again
-             */
-            this._isSynchronising = false
             return log.debug(`synchronised collector data, server status: ${resp.status}`)
         } catch (err) {
             return log.error('failed send data to Sumo Logic:\n', (err as Error).stack)
+        } finally {
+            this._isSynchronising = false
         }
     }
 }

--- a/packages/wdio-sumologic-reporter/tests/reporter.test.ts
+++ b/packages/wdio-sumologic-reporter/tests/reporter.test.ts
@@ -111,19 +111,40 @@ describe('wdio-sumologic-reporter', () => {
             .toContain('failed send data to Sumo Logic')
     })
 
-    it('should retry queued events after a failed sync', async () => {
-        vi.mocked(fetch)
-            .mockRejectedValueOnce(new Error('network error'))
-            .mockResolvedValueOnce({ status: 200 } as Response)
+    it('should back off failed syncs with a bounded delay and reset after success', async () => {
+        vi.setSystemTime(0)
+        vi.mocked(fetch).mockRejectedValue(new Error('network error'))
 
         reporter = new SumoLogicReporter({ sourceAddress: 'http://localhost:1234' })
         reporter.onRunnerStart('onRunnerStart' as any)
 
-        await reporter.sync()
-        expect(reporter.isSynchronised).toBe(false)
+        const retryTimes = [0, 100, 300, 700, 1500, 2500]
+        for (const [index, retryTime] of retryTimes.entries()) {
+            vi.setSystemTime(retryTime)
+            await reporter.sync()
+            expect(vi.mocked(fetch)).toHaveBeenCalledTimes(index + 1)
 
+            const nextRetryTime = retryTimes[index + 1]
+            if (nextRetryTime) {
+                vi.setSystemTime(nextRetryTime - 1)
+                await reporter.sync()
+                expect(vi.mocked(fetch)).toHaveBeenCalledTimes(index + 1)
+            }
+        }
+
+        vi.mocked(fetch).mockResolvedValue({ status: 200 } as Response)
+        vi.setSystemTime(3499)
         await reporter.sync()
-        expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2)
+        expect(vi.mocked(fetch)).toHaveBeenCalledTimes(6)
+
+        vi.setSystemTime(3500)
+        await reporter.sync()
+        expect(vi.mocked(fetch)).toHaveBeenCalledTimes(7)
+        expect(reporter.isSynchronised).toBe(true)
+
+        reporter.onRunnerStart('onRunnerStart' as any)
+        await reporter.sync()
+        expect(vi.mocked(fetch)).toHaveBeenCalledTimes(8)
         expect(reporter.isSynchronised).toBe(true)
     })
 

--- a/packages/wdio-sumologic-reporter/tests/reporter.test.ts
+++ b/packages/wdio-sumologic-reporter/tests/reporter.test.ts
@@ -111,6 +111,22 @@ describe('wdio-sumologic-reporter', () => {
             .toContain('failed send data to Sumo Logic')
     })
 
+    it('should retry queued events after a failed sync', async () => {
+        vi.mocked(fetch)
+            .mockRejectedValueOnce(new Error('network error'))
+            .mockResolvedValueOnce({ status: 200 } as Response)
+
+        reporter = new SumoLogicReporter({ sourceAddress: 'http://localhost:1234' })
+        reporter.onRunnerStart('onRunnerStart' as any)
+
+        await reporter.sync()
+        expect(reporter.isSynchronised).toBe(false)
+
+        await reporter.sync()
+        expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2)
+        expect(reporter.isSynchronised).toBe(true)
+    })
+
     it('should be synchronised when no unsynced messages', async () => {
         reporter = new SumoLogicReporter({ sourceAddress: 'http://localhost:1234' })
         reporter.onRunnerStart('onRunnerStart' as any)


### PR DESCRIPTION
## Proposed changes

Fixes #15546.

Release the Sumo Logic reporter's in-flight guard when a collector request settles, including network failures. Failed batches remain queued, allowing the reporter's existing sync interval to retry them instead of waiting until the runner's reporter timeout. A focused regression test covers a rejected request followed by a successful retry.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Validated with the complete Sumo Logic reporter unit suite and ESLint on both changed files.

### Reviewers: @webdriverio/project-committers