### PR TITLE
fix(wdio-allure-reporter): write results incrementally instead of only at runner end

### DIFF
--- a/packages/wdio-allure-reporter/src/reporter.ts
+++ b/packages/wdio-allure-reporter/src/reporter.ts
@@ -126,6 +126,8 @@ export default class AllureReporter extends WDIOReporter {
     private _consoleOutput = ''
     private _originalStdoutWrite: typeof process.stdout.write
     private _isFlushing = false
+    private _flushChain: Promise<void> = Promise.resolve()
+    private _pendingFlushes = 0
     private _cid?: string
 
     private _testPlan: TestPlanV1 | undefined
@@ -305,9 +307,44 @@ export default class AllureReporter extends WDIOReporter {
         this._pushRuntimeMessage({ type: 'allure:suite:end', data: {} })
     }
 
+    /**
+     * Write out everything buffered so far without finalising the run, so results of
+     * completed tests reach the results directory while the run is still going. Flushes are
+     * chained so they cannot overlap.
+     */
+    private _flushIncrementally(): void {
+        const state = this._ensureState(this._currentCid())
+
+        this._beginFlush()
+        this._flushChain = this._flushChain
+            .then(() => state.processRuntimeMessage(false))
+            // the state's cursor stays on the message that threw, so the runner end pass
+            // retries it and rethrows if it still fails
+            .catch(() => {})
+            .then(() => this._endFlush())
+    }
+
+    private _beginFlush(): void {
+        this._pendingFlushes++
+        this._isFlushing = true
+    }
+
+    private _endFlush(): void {
+        this._pendingFlushes--
+        if (this._pendingFlushes === 0) {
+            this._isFlushing = false
+        }
+    }
+
     private _startTest(payload: { name: string; start: number; uuid?: string }): void {
         this._pushRuntimeMessage({ type: 'allure:test:start', data: payload })
         this._setTestParameters()
+        /**
+         * flush once the new test:start is buffered: a test is only written when the
+         * following test starts, because its own scope has to stay open past its test:end
+         * for "after each" hooks to attach to
+         */
+        this._flushIncrementally()
     }
 
     private _endTest(payload: {
@@ -523,8 +560,13 @@ export default class AllureReporter extends WDIOReporter {
     }
 
     async onRunnerEnd(_runner: RunnerStats): Promise<void> {
-        this._isFlushing = true
+        /**
+         * counted like any other flush, so an incremental flush finishing while we await it
+         * cannot report the reporter as synchronised while this pass is still writing
+         */
+        this._beginFlush()
         try {
+            await this._flushChain
             for (const [cid, state] of this.allureStatesByCid) {
                 await state.processRuntimeMessage()
                 this.allureStatesByCid.delete(cid)
@@ -533,7 +575,7 @@ export default class AllureReporter extends WDIOReporter {
             if (this._options.addConsoleLogs) {
                 process.stdout.write = this._originalStdoutWrite
             }
-            this._isFlushing = false
+            this._endFlush()
         }
         this._allureRuntime.writeEnvironmentInfo()
     }

--- a/packages/wdio-allure-reporter/src/state.ts
+++ b/packages/wdio-allure-reporter/src/state.ts
@@ -35,6 +35,7 @@ export class AllureReportState {
     private _currentTestUuid?: string
     private _currentTestName?: string
     messages: WDIORuntimeMessage[] = []
+    private _processedIndex = 0
     private _pendingHookMessages: WDIORuntimeMessage[] = []
     private _isCapturingPendingHook: boolean = false
 
@@ -341,10 +342,20 @@ export class AllureReportState {
         this.messages.push(message)
     }
 
-    async processRuntimeMessage(): Promise<void> {
-        for (let i = 0; i < this.messages.length; i++) {
+    /**
+     * Consume every message that has not been consumed yet.
+     *
+     * Pass `final: false` to flush mid-run: messages are applied and completed tests are
+     * written out, but the run is not finalised, so the reporter can keep going. The
+     * cursor makes this safe to call repeatedly - a message is never applied twice, and a
+     * pass that throws leaves the cursor on the message that threw so the next pass
+     * retries it rather than replaying the whole batch.
+     */
+    async processRuntimeMessage(final: boolean = true): Promise<void> {
+        for (let i = this._processedIndex; i < this.messages.length; i++) {
             const message = this.messages[i]
-            const lastMessage = i === this.messages.length - 1
+            const lastMessage = final && i === this.messages.length - 1
+            this._processedIndex = i
 
             switch (message.type) {
             case 'allure:suite:start':
@@ -431,6 +442,12 @@ export class AllureReportState {
             if (this._isRuntimeMessage(message)) {
                 this.allureRuntime.applyRuntimeMessages(target, [message])
             }
+        }
+
+        this._processedIndex = this.messages.length
+
+        if (!final) {
+            return
         }
 
         if (this._currentTestUuid) {

--- a/packages/wdio-allure-reporter/tests/state.test.ts
+++ b/packages/wdio-allure-reporter/tests/state.test.ts
@@ -209,4 +209,28 @@ describe('state', () => {
             expect(parsed.errors).toHaveLength(0)
         })
     })
+
+    describe('incremental flush', () => {
+        it('writes finished tests before the run is finalised and never replays a message', async () => {
+            state.pushRuntimeMessage({ type: 'allure:suite:start', data: { name: 'suite' } })
+            state.pushRuntimeMessage({ type: 'allure:test:start', data: { name: 'first test', start: Date.now() } })
+            state.pushRuntimeMessage({ type: 'allure:test:end', data: { status: 'passed' as any, stop: Date.now() } })
+            state.pushRuntimeMessage({ type: 'allure:test:start', data: { name: 'second test', start: Date.now() } })
+
+            await state.processRuntimeMessage(false)
+            // a second flush with nothing new must be a no-op
+            await state.processRuntimeMessage(false)
+
+            expect(getResults(outputDir).results.map((r: any) => r.name)).toEqual(['first test'])
+
+            state.pushRuntimeMessage({ type: 'allure:test:end', data: { status: 'failed' as any, stop: Date.now() } })
+            state.pushRuntimeMessage({ type: 'allure:suite:end', data: {} })
+
+            await state.processRuntimeMessage()
+
+            const { results } = getResults(outputDir)
+            expect(results.map((r: any) => r.name).sort()).toEqual(['first test', 'second test'])
+            expect(results.filter((r: any) => r.name === 'first test')).toHaveLength(1)
+        })
+    })
 })

--- a/packages/wdio-allure-reporter/tests/suite.test.ts
+++ b/packages/wdio-allure-reporter/tests/suite.test.ts
@@ -1317,3 +1317,65 @@ describe('command reporting', () => {
         expect(consoleAttachments).toHaveLength(0)
     })
 })
+
+describe('Incremental flush', () => {
+    const outputDir = temporaryDirectory()
+
+    beforeEach(() => clean(outputDir))
+
+    const namedTest = (title: string) => Object.assign(testStart(), { uid: title, title, fullTitle: title })
+    const settle = async (reporter: AllureReporter) => {
+        while (!reporter.isSynchronised) {
+            await new Promise((resolve) => setImmediate(resolve))
+        }
+    }
+
+    it('writes a finished test before the runner ends and reports itself unsynchronised while doing so', async () => {
+        const reporter = new AllureReporter({ outputDir })
+
+        reporter.onRunnerStart(runnerStart())
+        reporter.onSuiteStart(suiteStart())
+        reporter.onTestStart(namedTest('first test'))
+        reporter.onTestPass(Object.assign(testPassed(), { uid: 'first test', title: 'first test' }))
+        reporter.onTestStart(namedTest('second test'))
+
+        expect(reporter.isSynchronised).toBe(false)
+        await settle(reporter)
+
+        expect(getResults(outputDir).results.map((r: any) => r.name)).toEqual(['first test'])
+
+        reporter.onTestPass(Object.assign(testPassed(), { uid: 'second test', title: 'second test' }))
+        reporter.onSuiteEnd(suiteEnd())
+        await reporter.onRunnerEnd(runnerEnd())
+
+        const { results } = getResults(outputDir)
+        expect(results.map((r: any) => r.name).sort()).toEqual(['first test', 'second test'])
+    })
+
+    it('produces the same results as a run that is only flushed at the end', async () => {
+        const run = async (dir: string, flushDuringRun: boolean) => {
+            const reporter = new AllureReporter({ outputDir: dir })
+
+            reporter.onRunnerStart(runnerStart())
+            reporter.onSuiteStart(suiteStart())
+            for (const title of ['one', 'two', 'three']) {
+                reporter.onTestStart(namedTest(title))
+                if (flushDuringRun) {
+                    await settle(reporter)
+                }
+                reporter.onTestPass(Object.assign(testPassed(), { uid: title, title }))
+            }
+            reporter.onSuiteEnd(suiteEnd())
+            await reporter.onRunnerEnd(runnerEnd())
+
+            return getResults(dir).results.map((r: any) => r.name).sort()
+        }
+
+        const flushedDir = temporaryDirectory()
+        const endOnlyDir = temporaryDirectory()
+        clean(flushedDir)
+        clean(endOnlyDir)
+
+        expect(await run(flushedDir, true)).toEqual(await run(endOnlyDir, false))
+    })
+})


### PR DESCRIPTION
## Proposed changes

Fixes #15529.

`@wdio/allure-reporter` buffers every runtime message and only calls `AllureReportState.processRuntimeMessage()` once, in `onRunnerEnd`. Nothing reaches the results directory until the whole run is over, so if the runner dies mid-run you lose every result, not just the test that was in flight.

The blocker was that `processRuntimeMessage()` was not safe to call more than once: it always replayed `this.messages` from index 0, and it finalised the run at the end by writing the current test and unwinding the scope stack.

This makes it resumable and lets the reporter flush as the run goes:

- `AllureReportState` keeps a cursor (`_processedIndex`) and starts each pass from it, so a message is never applied twice. The cursor points at the message being handled, so a pass that throws leaves it there and the next pass retries that message instead of replaying the batch.
- `processRuntimeMessage(final = false)` applies buffered messages without the finalisation tail. The default stays `true`, so the runner-end call still finalises the run exactly as it does today.
- `AllureReporter` flushes once a new `allure:test:start` has been buffered. That is the point at which the previous test gets written, because a test's own scope has to stay open past its `test:end` for `"after each"` hooks to attach to it.
- Flushes are chained so they cannot overlap, and `onRunnerEnd` is counted as a flush itself, so an incremental flush completing while `onRunnerEnd` awaits the chain cannot flip `isSynchronised` back to `true` while the final pass is still writing.

The order in which messages are applied is unchanged, and so is the final content of the results directory. The only difference is when the loop runs.

One boundary worth naming: because a test is written when the *next* one starts, a crash costs you the test that was in flight, and a spec with a single test still only produces its result at runner end. Everything before the in-flight test is on disk.

I did not add the `saveAllureResultOnTestEnd` option suggested in the issue. Flushing unconditionally leaves the reporter's output identical to what it produces today, so there is nothing to opt out of.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported

## Further comments

Three tests were added, and the two regression tests both fail if the `src` changes are reverted:

- `tests/state.test.ts`: two mid-run flushes over a suite with one finished and one started test, asserting the finished test is on disk before the run is finalised, that a flush with nothing new is a no-op, and that the finished test is not written twice by the final pass.
- `tests/suite.test.ts`: the same at reporter level, also asserting the reporter reports `isSynchronised === false` while a flush is in flight.
- `tests/suite.test.ts`: an equivalence check that a run flushed per test and a run flushed only at the end produce the same results.

`npx vitest run ./packages/wdio-allure-reporter/tests` passes (200 tests, no type errors) and eslint is clean on the package.

### Reviewers: @webdriverio/project-committers
