### PR TITLE
fix(webdriverio):reject invalid timeout values

### DIFF
--- a/packages/webdriverio/src/commands/browser/setTimeout.ts
+++ b/packages/webdriverio/src/commands/browser/setTimeout.ts
@@ -46,10 +46,20 @@ export async function setTimeout(
 
     /**
      * If value is not an integer, or it is less than 0 or greater than the maximum safe
-     * integer, return error with error code invalid argument.
+    * integer, return error with error code invalid argument.
      */
-    const timeoutValues = Object.values(timeouts)
-    if (timeoutValues.length && timeoutValues.every(timeout => typeof timeout !== 'number' || timeout < 0 || timeout > Number.MAX_SAFE_INTEGER)) {
+    const timeoutKeys = ['implicit', 'pageLoad', 'script', 'page load'] as const
+    const knownTimeoutValues = Object.entries(timeouts)
+        .filter(([key]) => timeoutKeys.includes(key as typeof timeoutKeys[number]))
+        .map(([, timeout]) => timeout)
+    const timeoutValues = knownTimeoutValues.length > 0
+        ? knownTimeoutValues
+        : Object.values(timeouts)
+    const definedTimeoutValues = timeoutValues.filter(timeout => timeout !== undefined)
+    if (
+        definedTimeoutValues.some(timeout => typeof timeout !== 'number' || timeout < 0 || timeout > Number.MAX_SAFE_INTEGER) ||
+        (timeoutValues.length > 0 && definedTimeoutValues.length === 0)
+    ) {
         throw new Error('Specified timeout values are not valid integer (see https://webdriver.io/docs/api/browser/setTimeout for documentation).')
     }
 

--- a/packages/webdriverio/tests/commands/browser/setTimeout.test.ts
+++ b/packages/webdriverio/tests/commands/browser/setTimeout.test.ts
@@ -56,6 +56,14 @@ describe('setTimeout', () => {
         expect((vi.mocked(fetch).mock.calls[5][0] as any).pathname)
             .toBe('/session/foobar-123/timeouts')
         expect(vi.mocked(fetch).mock.calls[5][1]?.body).toEqual(JSON.stringify({}))
+
+        await browser.setTimeout({ implicit: 1000, script: undefined })
+        expect(vi.mocked(fetch).mock.calls).toHaveLength(7)
+        expect(vi.mocked(fetch).mock.calls[6][1]?.body).toEqual(JSON.stringify({ implicit: 1000 }))
+
+        await browser.setTimeout({ implicit: 1000, custom: 'not-a-timeout' } as any)
+        expect(vi.mocked(fetch).mock.calls).toHaveLength(8)
+        expect(vi.mocked(fetch).mock.calls[7][1]?.body).toEqual(JSON.stringify({ implicit: 1000 }))
     })
 
     it('should throw error on setting invalid timeout', async () => {
@@ -81,6 +89,16 @@ describe('setTimeout', () => {
             .rejects
             .toEqual(invalidTimeoutValueError)
         await expect(browser.setTimeout({ pageLoad: -2000 }))
+            .rejects
+            .toEqual(invalidTimeoutValueError)
+        await expect(browser.setTimeout({ implicit: 1000, script: -1 }))
+            .rejects
+            .toEqual(invalidTimeoutValueError)
+        // @ts-expect-error invalid param mixed with valid timeout
+        await expect(browser.setTimeout({ implicit: 1000, script: '5000' }))
+            .rejects
+            .toEqual(invalidTimeoutValueError)
+        await expect(browser.setTimeout({ implicit: undefined, pageLoad: undefined, script: undefined }))
             .rejects
             .toEqual(invalidTimeoutValueError)
         // @ts-expect-error invalid param


### PR DESCRIPTION
## Proposed changes

- Fixes `browser.setTimeout()` validation so an invalid supported timeout value cannot be hidden by another valid value in the same object.
- Preserves support for explicitly `undefined` optional timeout properties when another valid timeout is supplied.
- Adds regression coverage for mixed valid and invalid timeout values.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

`browser.setTimeout()` previously used `every()` to validate values. That meant validation threw only when *all* supplied values were invalid.

For example, this input previously passed the browser-level validation:

```ts
await browser.setTimeout({
    implicit: 1000,
    script: -1
})