### PR TITLE
fix(webdriver): keep new driver PID after reloadSession

### DIFF
--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -211,7 +211,9 @@ export default class WebDriver {
         const driverPid = instance.capabilities['wdio:driverPID']
         instance.sessionId = sessionId
         instance.capabilities = newSessionCapabilities
-        instance.capabilities['wdio:driverPID'] = driverPid
+        if (!driverProcess?.pid) {
+            instance.capabilities['wdio:driverPID'] = driverPid
+        }
         Object.assign(instance.requestedCapabilities, capabilities)
 
         /**

--- a/packages/webdriver/tests/index.test.ts
+++ b/packages/webdriver/tests/index.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import logger, { logMock } from '@wdio/logger'
 import { sessionEnvironmentDetector } from '@wdio/utils'
 import { startWebDriver } from '@wdio/utils'
+import type { Capabilities } from '@wdio/types'
 
 import '../src/browser.js'
 
@@ -357,6 +358,24 @@ describe('WebDriver', () => {
             await WebDriver.reloadSession(session, { browserName: 'chrome' })
             expect(startWebDriver).toHaveBeenCalledOnce()
             expect((session.capabilities as WebdriverIO.Capabilities)['wdio:driverPID']).toBe(1234)
+        })
+
+        it('keeps the PID of the newly spawned driver after reload', async () => {
+            const spawnDriver = (pid: number) => (params: Capabilities.RemoteConfig) => {
+                params.hostname = 'localhost'
+                params.port = 4444
+                return { pid } as any
+            }
+            vi.mocked(startWebDriver)
+                .mockImplementationOnce(spawnDriver(1234))
+                .mockImplementationOnce(spawnDriver(5678))
+            const session = await WebDriver.newSession({
+                path: '/',
+                capabilities: { browserName: 'firefox' }
+            })
+            expect((session.capabilities as WebdriverIO.Capabilities)['wdio:driverPID']).toBe(1234)
+            await WebDriver.reloadSession(session, { browserName: 'chrome' })
+            expect((session.capabilities as WebdriverIO.Capabilities)['wdio:driverPID']).toBe(5678)
         })
 
         it('connects to the new remote', async () => {


### PR DESCRIPTION
## Proposed changes

When `reloadSession` is called with a new `browserName` on a local session, a new driver is spawned and its PID is written to `wdio:driverPID`. The code then restored the previous session's PID over it. The new driver was never killed on `deleteSession` and was left running.

This change restores the previous PID only when no new driver was spawned. A unit test with distinct PIDs for the original and reloaded driver is added.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported

### Reviewers: @webdriverio/project-committers
