### PR TITLE
fix(wdio-config): apply keyword exclude to grouped specs

### DIFF
--- a/packages/wdio-config/src/node/ConfigParser.ts
+++ b/packages/wdio-config/src/node/ConfigParser.ts
@@ -554,9 +554,7 @@ export default class ConfigParser {
         const filteredSpec = specs.reduce((returnVal: Spec[], currSpec) => {
             if (Array.isArray(currSpec)) {
                 returnVal.push(currSpec.filter(specItem => !excludeList.some(excludeVal => specItem.includes(excludeVal))))
-            }
-            const isSpecExcluded = excludeList.some(excludedVal => currSpec.includes(excludedVal))
-            if (!isSpecExcluded) {
+            } else if (!excludeList.some(excludedVal => currSpec.includes(excludedVal))) {
                 returnVal.push(currSpec)
             }
             return returnVal

--- a/packages/wdio-config/tests/node/configparser.test.ts
+++ b/packages/wdio-config/tests/node/configparser.test.ts
@@ -663,6 +663,15 @@ describe('ConfigParser', () => {
             expect(specs[0]).not.toContain(path.join(__dirname, 'validateConfig.test.ts'))
         })
 
+        it('should exclude files from arrays by keyword without duplicating the group', async () => {
+            const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF_ARRAY)
+            await configParser.initialize({ exclude: ['FileSystemPathService'] })
+
+            const specs = configParser.getSpecs()
+            expect(specs).toHaveLength(1)
+            expect(specs.flat()).not.toContain(path.join(__dirname, 'FileSystemPathService.test.ts'))
+        })
+
         it('should exclude/include capability excludes', async () => {
             const configParser = await ConfigParserForTestWithAllFiles(FIXTURES_CONF)
             await configParser.initialize()


### PR DESCRIPTION
## Proposed changes

`--exclude` with a keyword did not work for grouped specs (`specs: [[...]]`). The excluded file still ran and the group was pushed twice. This fixes the keyword branch of `filterSpecs` so grouped specs are filtered once, matching the path exclude behavior.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

### Reviewers: @webdriverio/project-committers
