### PR TITLE
fix(wdio-utils): track dialog listener lifecycle

### DIFF
--- a/packages/wdio-utils/src/monad.ts
+++ b/packages/wdio-utils/src/monad.ts
@@ -61,25 +61,111 @@ export default function WebDriver(options: object, modifier?: Function, properti
 
     const mittInstance = mitt()
 
+    type EventHandler = (event: unknown) => void
+    const dialogListeners: Array<{ listener: EventHandler, registered: EventHandler }> = []
+
+    const emitDialogListenerTransition = (previousCount: number) => {
+        if (previousCount === 0 && dialogListeners.length > 0) {
+            mittInstance.emit('_dialogListenerRegistered')
+        } else if (previousCount > 0 && dialogListeners.length === 0) {
+            mittInstance.emit('_dialogListenerRemoved')
+        }
+    }
+
+    const addDialogListener = (listener: EventHandler, registered = listener) => {
+        const previousCount = dialogListeners.length
+        mittInstance.on('dialog', registered)
+        dialogListeners.push({ listener, registered })
+        emitDialogListenerTransition(previousCount)
+    }
+
+    const removeDialogListener = (listener?: EventHandler, registered?: EventHandler) => {
+        const previousCount = dialogListeners.length
+        let index = -1
+
+        for (let i = dialogListeners.length - 1; i >= 0; i--) {
+            const entry = dialogListeners[i]
+            if (registered ? entry.registered === registered : entry.listener === listener) {
+                index = i
+                break
+            }
+        }
+
+        if (index === -1) {
+            return
+        }
+
+        const [entry] = dialogListeners.splice(index, 1)
+        mittInstance.off('dialog', entry.registered)
+        emitDialogListenerTransition(previousCount)
+    }
+
+    const removeAllDialogListeners = () => {
+        const previousCount = dialogListeners.length
+        mittInstance.off('dialog')
+        dialogListeners.length = 0
+        emitDialogListenerTransition(previousCount)
+    }
+
     // Create EventEmitter-compatible interface
     const eventHandler = {
-        on: mittInstance.on.bind(mittInstance),
-        off: mittInstance.off.bind(mittInstance),
-        emit: mittInstance.emit.bind(mittInstance),
-        once: (type: string, handler: Function) => {
-            const onceWrapper = (...args: unknown[]) => {
-                mittInstance.off(type, onceWrapper)
-                handler(...args)
+        on: (type: string, handler: EventHandler) => {
+            if (type === 'dialog') {
+                addDialogListener(handler)
+            } else {
+                mittInstance.on(type, handler)
             }
-            mittInstance.on(type, onceWrapper)
         },
-        removeListener: mittInstance.off.bind(mittInstance),
+        off: (type: string, handler?: EventHandler) => {
+            if (type === 'dialog') {
+                if (handler) {
+                    removeDialogListener(handler)
+                } else {
+                    removeAllDialogListeners()
+                }
+            } else {
+                mittInstance.off(type, handler)
+            }
+        },
+        emit: mittInstance.emit.bind(mittInstance),
+        once: (type: string, handler: EventHandler) => {
+            const onceWrapper = (event: unknown) => {
+                if (type === 'dialog') {
+                    removeDialogListener(handler, onceWrapper)
+                } else {
+                    mittInstance.off(type, onceWrapper)
+                }
+                handler(event)
+            }
+
+            if (type === 'dialog') {
+                addDialogListener(handler, onceWrapper)
+            } else {
+                mittInstance.on(type, onceWrapper)
+            }
+        },
+        removeListener: (type: string, handler?: EventHandler) => {
+            if (type === 'dialog') {
+                if (handler) {
+                    removeDialogListener(handler)
+                } else {
+                    removeAllDialogListeners()
+                }
+            } else {
+                mittInstance.off(type, handler)
+            }
+        },
         removeAllListeners: (type?: string) => {
-            if (type) {
+            if (type === 'dialog') {
+                removeAllDialogListeners()
+            } else if (type) {
                 mittInstance.off(type)
             } else {
-                // Clear all event handlers by creating new mitt instance
-                Object.assign(mittInstance, mitt())
+                const previousCount = dialogListeners.length
+                mittInstance.off('dialog')
+                dialogListeners.length = 0
+                emitDialogListenerTransition(previousCount)
+                mittInstance.all.clear()
             }
         }
     }
@@ -301,19 +387,6 @@ export default function WebDriver(options: object, modifier?: Function, properti
      */
     for (const eventCommand of EVENTHANDLER_FUNCTIONS) {
         prototype[eventCommand] = function (...args: [unknown, unknown]) {
-            /**
-             * Emit an event when a dialog listener is registered or unregistered.
-             * This is used in `packages/webdriverio/src/dialog.ts`
-             * to decide whether to propagate a `dialog` event to
-             * the user or automatically accept or dismiss the dialog.
-             */
-            if (eventCommand === 'on' && args[0] === 'dialog') {
-                eventHandler.emit('_dialogListenerRegistered')
-            }
-            if (eventCommand === 'off' && args[0] === 'dialog') {
-                eventHandler.emit('_dialogListenerRemoved')
-            }
-
             // Call the appropriate method based on eventCommand
             switch (eventCommand) {
             case 'on':

--- a/packages/wdio-utils/tests/monad.test.ts
+++ b/packages/wdio-utils/tests/monad.test.ts
@@ -395,6 +395,61 @@ describe('monad', () => {
         expect(client.commandList).toHaveLength(0)
     })
 
+    it('tracks dialog listener state through once and removals', () => {
+        const client = webdriverMonad({}, (browser: any) => browser, { ...prototype })(sessionId)
+        const registered = vi.fn()
+        const removed = vi.fn()
+        const onceListener = vi.fn()
+        const firstListener = vi.fn()
+        const secondListener = vi.fn()
+
+        client.on('_dialogListenerRegistered', registered)
+        client.on('_dialogListenerRemoved', removed)
+
+        client.once('dialog', onceListener)
+        expect(registered, 'once dialog listener registration must disable auto handling').toHaveBeenCalledTimes(1)
+
+        client.on('dialog', firstListener)
+        client.on('dialog', secondListener)
+        expect(registered).toHaveBeenCalledTimes(1)
+
+        const dialog = { message: 'confirmation' }
+        client.emit('dialog', dialog)
+        expect(onceListener).toHaveBeenCalledWith(dialog)
+        expect(onceListener).toHaveBeenCalledTimes(1)
+        expect(removed).not.toHaveBeenCalled()
+
+        client.removeListener('dialog', firstListener)
+        expect(removed).not.toHaveBeenCalled()
+
+        client.off('dialog', secondListener)
+        expect(removed).toHaveBeenCalledTimes(1)
+
+        const removedOnceListener = vi.fn()
+        client.once('dialog', removedOnceListener)
+        expect(registered).toHaveBeenCalledTimes(2)
+        client.removeListener('dialog', removedOnceListener)
+        expect(removed).toHaveBeenCalledTimes(2)
+        client.emit('dialog', dialog)
+        expect(removedOnceListener).not.toHaveBeenCalled()
+
+        client.on('dialog', firstListener)
+        client.on('dialog', secondListener)
+        expect(registered).toHaveBeenCalledTimes(3)
+        client.removeAllListeners('dialog')
+        expect(removed).toHaveBeenCalledTimes(3)
+
+        client.on('dialog', firstListener)
+        expect(registered).toHaveBeenCalledTimes(4)
+        client.removeAllListeners()
+        expect(removed).toHaveBeenCalledTimes(4)
+
+        const ordinaryListener = vi.fn()
+        client.on('result', ordinaryListener)
+        client.emit('result', dialog)
+        expect(ordinaryListener).toHaveBeenCalledWith(dialog)
+    })
+
     describe('given custom command', () => {
         let client: any
         beforeEach(() => {


### PR DESCRIPTION
## Proposed changes

Fixes #15558.

Track the number of registered `dialog` handlers in the WebDriver monad and emit dialog lifecycle events only when the count crosses between zero and non-zero. This keeps automatic dialog handling disabled while any listener remains, and restores it after the last listener is removed or a one-time listener fires.

The regression test covers `once`, `off`, `removeListener`, scoped and global `removeAllListeners`, and multiple concurrent dialog listeners.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

Focused verification: `pnpm exec vitest --config vitest.config.ts --run packages/wdio-utils/tests/monad.test.ts`.

### Reviewers: @webdriverio/project-committers