### PR TITLE
docs: Dialog auto dismis and once

### DIFF
--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -487,10 +487,9 @@ describe('main suite 1', () => {
             await browser.url('https://guinea-pig.webdriver.io')
             const mockedDialog = (dialog: WebdriverIO.Dialog) => {
                 if (dialog.message() === 'expectedDialog' ) {
-                    dialog.dismiss()
-                } else {
-                    throw new Error('Unexpected dialog: ' + dialog.message())
+                    return dialog.dismiss()
                 }
+                throw new Error('Unexpected dialog: ' + dialog.message())
             }
             browser.on('dialog', mockedDialog)
             await browser.execute(() => alert('expectedDialog'))
@@ -520,10 +519,9 @@ describe('main suite 1', () => {
 
             const mockedDialog = (dialog: WebdriverIO.Dialog) => {
                 if (dialog.message() === 'expectedDialog' ) {
-                    dialog.dismiss()
-                } else {
-                    throw new Error('Unexpected dialog: ' + dialog.message())
+                    return dialog.dismiss()
                 }
+                throw new Error('Unexpected dialog: ' + dialog.message())
             }
             browser.once('dialog', mockedDialog)
             await browser.execute(() => alert('expectedDialog'))

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -485,17 +485,21 @@ describe('main suite 1', () => {
 
         it('should continue autoDismiss after handling a dialog manually with `browser.on`', async () => {
             await browser.url('https://guinea-pig.webdriver.io')
+            let dismissalPromise: Promise<void> | undefined
             const mockedDialog = (dialog: WebdriverIO.Dialog) => {
                 if (dialog.message() === 'expectedDialog' ) {
-                    return dialog.dismiss()
+                    dismissalPromise = dialog.dismiss()
+                    return
                 }
                 throw new Error('Unexpected dialog: ' + dialog.message())
             }
             browser.on('dialog', mockedDialog)
             await browser.execute(() => alert('expectedDialog'))
+            await dismissalPromise
             browser.off('dialog', mockedDialog)
 
             await browser.execute(() => alert('autoDismiss'))
+
             /**
              * in case the alert is not automatically accepted
              * the following line would time out
@@ -516,17 +520,20 @@ describe('main suite 1', () => {
 
         it('should continue autoDismiss after handling a dialog manually with `browser.once`', async () => {
             await browser.url('https://guinea-pig.webdriver.io')
-
+            let dismissalPromise: Promise<void> | undefined
             const mockedDialog = (dialog: WebdriverIO.Dialog) => {
                 if (dialog.message() === 'expectedDialog' ) {
-                    return dialog.dismiss()
+                    dismissalPromise = dialog.dismiss()
+                    return
                 }
                 throw new Error('Unexpected dialog: ' + dialog.message())
             }
             browser.once('dialog', mockedDialog)
             await browser.execute(() => alert('expectedDialog'))
+            await dismissalPromise
 
             await browser.execute(() => alert('autoDimiss'))
+
             /**
              * in case the alert is not automatically accepted
              * the following line would time out

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -456,6 +456,10 @@ describe('main suite 1', () => {
     })
 
     describe('dialog handling', () => {
+        afterEach(() => {
+            browser.removeAllListeners('dialog')
+        })
+
         it('should automatically accept alerts', async () => {
             await browser.url('https://guinea-pig.webdriver.io')
 
@@ -481,13 +485,18 @@ describe('main suite 1', () => {
 
         it('should continue autoDismiss after handling a dialog manually with `browser.on`', async () => {
             await browser.url('https://guinea-pig.webdriver.io')
-
-            const mockedDialog = (dialog: WebdriverIO.Dialog) => dialog.dismiss()
+            const mockedDialog = (dialog: WebdriverIO.Dialog) => {
+                if (dialog.message() === 'expectedDialog' ) {
+                    dialog.dismiss()
+                } else {
+                    console.log('Unexpected dialog:', dialog.message())
+                }
+            }
             browser.on('dialog', mockedDialog)
-            await browser.execute(() => alert('234'))
+            await browser.execute(() => alert('expectedDialog'))
             browser.off('dialog', mockedDialog)
 
-            await browser.execute(() => alert('123'))
+            await browser.execute(() => alert('autoDismiss'))
             /**
              * in case the alert is not automatically accepted
              * the following line would time out
@@ -509,11 +518,17 @@ describe('main suite 1', () => {
         it('should continue autoDismiss after handling a dialog manually with `browser.once`', async () => {
             await browser.url('https://guinea-pig.webdriver.io')
 
-            const mockedDialog = (dialog: WebdriverIO.Dialog) => dialog.dismiss()
+            const mockedDialog = (dialog: WebdriverIO.Dialog) => {
+                if (dialog.message() === 'expectedDialog' ) {
+                    dialog.dismiss()
+                } else {
+                    console.log('Unexpected dialog:', dialog.message())
+                }
+            }
             browser.once('dialog', mockedDialog)
-            await browser.execute(() => alert('234'))
+            await browser.execute(() => alert('expectedDialog'))
 
-            await browser.execute(() => alert('123'))
+            await browser.execute(() => alert('autoDimiss'))
             /**
              * in case the alert is not automatically accepted
              * the following line would time out

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -12,7 +12,6 @@ import type { remote } from 'webdriver'
 import type { SameSiteOptions } from '../../../packages/wdio-protocols/build/types.js'
 import logger from '@wdio/logger'
 import { some } from 'expect-webdriverio/api'
-import type { Dialog } from '../../../packages/webdriverio/src/session/dialog.js'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
@@ -483,7 +482,7 @@ describe('main suite 1', () => {
         it('should continue autoDismiss after handling a dialog manually with `browser.on`', async () => {
             await browser.url('https://guinea-pig.webdriver.io')
 
-            const mockedDialog = (dialog: Dialog) => dialog.dismiss()
+            const mockedDialog = (dialog: WebdriverIO.Dialog) => dialog.dismiss()
             browser.on('dialog', mockedDialog)
             await browser.execute(() => alert('234'))
             browser.off('dialog', mockedDialog)
@@ -510,7 +509,7 @@ describe('main suite 1', () => {
         it('should continue autoDismiss after handling a dialog manually with `browser.once`', async () => {
             await browser.url('https://guinea-pig.webdriver.io')
 
-            const mockedDialog = (dialog: Dialog) => dialog.dismiss()
+            const mockedDialog = (dialog: WebdriverIO.Dialog) => dialog.dismiss()
             browser.once('dialog', mockedDialog)
             await browser.execute(() => alert('234'))
 

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -489,7 +489,7 @@ describe('main suite 1', () => {
                 if (dialog.message() === 'expectedDialog' ) {
                     dialog.dismiss()
                 } else {
-                    console.log('Unexpected dialog:', dialog.message())
+                    throw new Error('Unexpected dialog: ' + dialog.message())
                 }
             }
             browser.on('dialog', mockedDialog)
@@ -522,7 +522,7 @@ describe('main suite 1', () => {
                 if (dialog.message() === 'expectedDialog' ) {
                     dialog.dismiss()
                 } else {
-                    console.log('Unexpected dialog:', dialog.message())
+                    throw new Error('Unexpected dialog: ' + dialog.message())
                 }
             }
             browser.once('dialog', mockedDialog)

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -12,6 +12,7 @@ import type { remote } from 'webdriver'
 import type { SameSiteOptions } from '../../../packages/wdio-protocols/build/types.js'
 import logger from '@wdio/logger'
 import { some } from 'expect-webdriverio/api'
+import type { Dialog } from '../../../packages/webdriverio/src/session/dialog.js'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
@@ -468,17 +469,57 @@ describe('main suite 1', () => {
             await browser.$('div').click()
         })
 
-        /**
-         * fails due to https://github.com/GoogleChromeLabs/chromium-bidi/issues/2556
-         */
-        it('should be able to handle dialogs', async () => {
+        it('should be able to handle dialogs manually with `browser.on`', async () => {
             await browser.url('https://guinea-pig.webdriver.io')
+
             browser.execute(() => alert('123'))
             const dialog = await new Promise<WebdriverIO.Dialog>((resolve) => browser.on('dialog', resolve))
 
             expect(dialog.type()).toBe('alert')
             expect(dialog.message()).toBe('123')
             await dialog.dismiss()
+        })
+
+        it('should continue autoDismiss after handling a dialog manually with `browser.on`', async () => {
+            await browser.url('https://guinea-pig.webdriver.io')
+
+            const mockedDialog = (dialog: Dialog) => dialog.dismiss()
+            browser.on('dialog', mockedDialog)
+            await browser.execute(() => alert('234'))
+            browser.off('dialog', mockedDialog)
+
+            await browser.execute(() => alert('123'))
+            /**
+             * in case the alert is not automatically accepted
+             * the following line would time out
+             */
+            await browser.$('div').click()
+        })
+
+        it('should be able to handle dialogs manually with `browser.once`', async () => {
+            await browser.url('https://guinea-pig.webdriver.io')
+
+            browser.execute(() => alert('123'))
+            const dialog = await new Promise<WebdriverIO.Dialog>((resolve) => browser.once('dialog', resolve))
+
+            expect(dialog.type()).toBe('alert')
+            expect(dialog.message()).toBe('123')
+            await dialog.dismiss()
+        })
+
+        it('should continue autoDismiss after handling a dialog manually with `browser.once`', async () => {
+            await browser.url('https://guinea-pig.webdriver.io')
+
+            const mockedDialog = (dialog: Dialog) => dialog.dismiss()
+            browser.once('dialog', mockedDialog)
+            await browser.execute(() => alert('234'))
+
+            await browser.execute(() => alert('123'))
+            /**
+             * in case the alert is not automatically accepted
+             * the following line would time out
+             */
+            await browser.$('div').click()
         })
     })
 

--- a/packages/webdriverio/tests/shadowRoot.test.ts
+++ b/packages/webdriverio/tests/shadowRoot.test.ts
@@ -91,7 +91,7 @@ describe('ShadowRootManager', () => {
 
         const navigationCommittedListener = listeners.get('browsingContext.navigationCommitted')
         expect(navigationCommittedListener).toEqual(expect.any(Function))
-        navigationCommittedListener({ context: 'navigation-context' })
+        navigationCommittedListener?.({ context: 'navigation-context' })
 
         expect(await manager.getShadowElementsByContextId('navigation-context')).toEqual([])
     })

--- a/website/docs/api/Dialog.md
+++ b/website/docs/api/Dialog.md
@@ -21,6 +21,6 @@ await browser.execute(() => alert('Hello Dialog'))
 
 :::note
 
-Dialogs are dismissed automatically, unless there is a `browser.on('dialog')` listener. When listener is present, it must either [`dialog.accept()`](/docs/api/dialog/accept) or [`dialog.dismiss()`](/docs/api/dialog/dismiss) the dialog - otherwise the page will freeze waiting for the dialog, and actions like click will never finish.
+Dialogs are dismissed automatically, unless there is at least one `browser.on('dialog')` or `browser.once('dialog')` listener. When a listener is present, it must either [`dialog.accept()`](/docs/api/dialog/accept) or [`dialog.dismiss()`](/docs/api/dialog/dismiss) the dialog - otherwise the page will freeze waiting for the dialog, and actions like click will never finish.
 
 :::


### PR DESCRIPTION
## Proposed changes

- Adjust documentation following fixes in https://github.com/webdriverio/webdriverio/pull/15562 for https://github.com/webdriverio/webdriverio/issues/15558.
- Added Dialog e2e coverage.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
