### PR TITLE
feat: Move select into BETA with env flag still

### DIFF
--- a/e2e/wdio/headless/multiRemoteTest.e2e.ts
+++ b/e2e/wdio/headless/multiRemoteTest.e2e.ts
@@ -86,7 +86,7 @@ describe('multi remote test', () => {
                 await multiRemoteBrowser.url('https://guinea-pig.webdriver.io/')
 
                 const title = multiRemoteBrowser.$('header').$('h1')
-                const browserAHeader = title.unstable_select('browserA')
+                const browserAHeader = title.select('browserA')
 
                 expect(await browserAHeader.instances).toEqual(['browserA'])
                 expect(await browserAHeader.isExisting()).toEqual([true])
@@ -99,7 +99,7 @@ describe('multi remote test', () => {
                 await multiRemoteBrowser.url('https://guinea-pig.webdriver.io/')
 
                 const title = multiRemoteBrowser.$('header').$('h1')
-                const browserAHeader = title.unstable_select('browserA', 'browserC')
+                const browserAHeader = title.select('browserA', 'browserC')
 
                 expect(await browserAHeader.instances).toEqual(['browserA', 'browserC'])
                 expect(await browserAHeader.isExisting()).toEqual([true, true])
@@ -112,7 +112,7 @@ describe('multi remote test', () => {
                 await multiRemoteBrowser.url('https://guinea-pig.webdriver.io/')
 
                 const title = multiRemoteBrowser.$('header').$('h1')
-                const browserAHeader = title.unstable_select('browserA', 'browserC', 'non-existing')
+                const browserAHeader = title.select('browserA', 'browserC', 'non-existing')
 
                 expect(await browserAHeader.instances).toEqual(['browserA', 'browserC'])
                 expect(await browserAHeader.isExisting()).toEqual([true, true])
@@ -126,7 +126,7 @@ describe('multi remote test', () => {
 
                 const title = multiRemoteBrowser.$('header').$('h1')
                 // @ts-expect-error: rejects seems missing...
-                await expect(() => title.unstable_select('non-existing').instances).rejects.toThrow('None of the following requested instances are valid: non-existing')
+                await expect(() => title.select('non-existing').instances).rejects.toThrow('None of the following requested instances are valid: non-existing')
             })
 
             it('should be able to select 1 instance on the multi-remote browser', async () => {
@@ -134,7 +134,7 @@ describe('multi remote test', () => {
                 await browserB.url('about:blank')
 
                 // Select only browserA, so browserB's missing element shouldn't matter
-                const header = await multiRemoteBrowser.unstable_select('browserA').$('header')
+                const header = await multiRemoteBrowser.select('browserA').$('header')
 
                 expect(await header.instances).toEqual(['browserA'])
                 expect(await header.isExisting()).toEqual([true])
@@ -144,7 +144,7 @@ describe('multi remote test', () => {
                 await multiRemoteBrowser.url('https://guinea-pig.webdriver.io/')
                 await browserB.url('about:blank')
 
-                const header = await multiRemoteBrowser.unstable_select('browserA', 'browserB').$('header')
+                const header = await multiRemoteBrowser.select('browserA', 'browserB').$('header')
 
                 expect(await header.instances).toEqual(expect.arrayContaining(['browserA', 'browserB']))
                 expect(await header.isExisting()).toEqual([true, false])
@@ -154,7 +154,7 @@ describe('multi remote test', () => {
                 await multiRemoteBrowser.url('https://guinea-pig.webdriver.io/')
                 await browserB.url('about:blank')
 
-                const header = await multiRemoteBrowser.unstable_select('browserA', 'browserB', 'non-existing').$('header')
+                const header = await multiRemoteBrowser.select('browserA', 'browserB', 'non-existing').$('header')
 
                 expect(await header.instances).toEqual(expect.arrayContaining(['browserA', 'browserB']))
                 expect(await header.isExisting()).toEqual([true, false])
@@ -165,13 +165,13 @@ describe('multi remote test', () => {
                 await browserB.url('about:blank')
 
                 // @ts-expect-error: rejects seems missing...
-                await expect(async () => multiRemoteBrowser.unstable_select('non-existing')).rejects.toThrow('None of the following requested instances are valid: non-existing')
+                await expect(async () => multiRemoteBrowser.select('non-existing')).rejects.toThrow('None of the following requested instances are valid: non-existing')
             })
 
             it('should allow chaining select with 1 browser on element query', async () => {
                 await multiRemoteBrowser.url('https://guinea-pig.webdriver.io/')
 
-                const header = await multiRemoteBrowser.unstable_select('browserA').$('header').$('h1').getText()
+                const header = await multiRemoteBrowser.select('browserA').$('header').$('h1').getText()
 
                 expect(header).toEqual(['WebdriverJS Testpage'])
             })
@@ -179,7 +179,7 @@ describe('multi remote test', () => {
             it('should allow chaining select with 2 browser on element query', async () => {
                 await multiRemoteBrowser.url('https://guinea-pig.webdriver.io/')
 
-                const header = await multiRemoteBrowser.unstable_select('browserA', 'browserC').$('header').$('h1').getText()
+                const header = await multiRemoteBrowser.select('browserA', 'browserC').$('header').$('h1').getText()
 
                 expect(header).toEqual(['WebdriverJS Testpage', 'WebdriverJS Testpage'])
             })
@@ -190,15 +190,15 @@ describe('multi remote test', () => {
                 expect(await browserA.$('header').$('h1').getText()).toEqual('WebdriverJS Testpage')
 
                 // On browser, using select we do keep the selected instance scope, so we can chain $ and get the element from the selected browser
-                const browserChainedText = await multiRemoteBrowser.unstable_select('browserA').$('header').$('h1').getText()
+                const browserChainedText = await multiRemoteBrowser.select('browserA').$('header').$('h1').getText()
                 expect(browserChainedText).toEqual(['WebdriverJS Testpage'])
 
                 // Selecting only for value it works!
-                const elementTextFromChainedSelected = await multiRemoteBrowser.$('header').$('h1').unstable_select('browserA').getText()
+                const elementTextFromChainedSelected = await multiRemoteBrowser.$('header').$('h1').select('browserA').getText()
                 expect(elementTextFromChainedSelected).toEqual(['WebdriverJS Testpage'])
 
                 // However, should we do the same when selecting on a element and chaining $()?
-                const elementTextFromChainedParentSelected = await multiRemoteBrowser.$('header').unstable_select('browserA').$('h1').getText()
+                const elementTextFromChainedParentSelected = await multiRemoteBrowser.$('header').select('browserA').$('h1').getText()
                 expect(elementTextFromChainedParentSelected).toEqual(['WebdriverJS Testpage'])
             })
 
@@ -226,7 +226,7 @@ describe('multi remote test', () => {
                 })
 
                 it('should be able to select 2 instances on the browser', async () => {
-                    const selected = await customMultiRemoteBrowser.unstable_select('browserA', 'browserB')
+                    const selected = await customMultiRemoteBrowser.select('browserA', 'browserB')
 
                     expect(selected.instances).toEqual(['browserA', 'browserB'])
                     expect(selected.getInstance('browserA')).toBeDefined()
@@ -234,7 +234,7 @@ describe('multi remote test', () => {
                 })
 
                 it('should be able to select 2 instances on the element', async () => {
-                    const selected = await customMultiRemoteBrowser.$('h1').unstable_select('browserA', 'browserB')
+                    const selected = await customMultiRemoteBrowser.$('h1').select('browserA', 'browserB')
 
                     expect(selected.instances).toEqual(['browserA', 'browserB'])
                     expect(selected.getInstance('browserA')).toBeDefined()
@@ -243,7 +243,7 @@ describe('multi remote test', () => {
                 })
 
                 it('should be able to chain select', async () => {
-                    const selected = await customMultiRemoteBrowser.$('h1').unstable_select('browserA', 'browserB').unstable_select('browserA')
+                    const selected = await customMultiRemoteBrowser.$('h1').select('browserA', 'browserB').select('browserA')
 
                     expect(selected.instances).toEqual(['browserA'])
                     expect(selected.getInstance('browserA')).toBeDefined()
@@ -289,7 +289,7 @@ describe('multi remote test', () => {
                 })
 
                 it('should preserve custom commands when selecting browser', async () => {
-                    const selectedBrowser = multiRemoteBrowser.unstable_select('browserA', 'browserB')
+                    const selectedBrowser = multiRemoteBrowser.select('browserA', 'browserB')
 
                     // @ts-expect-error custom element command is not part of the default type
                     expect(await selectedBrowser.customCommand()).toEqual(['WebdriverJS Testpage', 'WebdriverJS Testpage'])
@@ -301,7 +301,7 @@ describe('multi remote test', () => {
                     })
 
                     expect(await multiRemoteBrowser.getCookies()).toBe('getCookies (overwritten)')
-                    expect(await multiRemoteBrowser.unstable_select('browserA', 'browserB').getCookies()).toBe('getCookies (overwritten)')
+                    expect(await multiRemoteBrowser.select('browserA', 'browserB').getCookies()).toBe('getCookies (overwritten)')
                 })
 
                 it('preserve overridden elements commands on multiRemoteBrowser', async () => {
@@ -310,14 +310,14 @@ describe('multi remote test', () => {
                     }, true)
 
                     expect(await multiRemoteBrowser.$('header').$('h1').getValue()).toEqual(['getValue (overwritten)', 'getValue (overwritten)', 'getValue (overwritten)'])
-                    expect(await multiRemoteBrowser.unstable_select('browserA', 'browserB').$('header').$('h1').getValue()).toEqual(['getValue (overwritten)', 'getValue (overwritten)'])
-                    expect(await multiRemoteBrowser.$('header').$('h1').unstable_select('browserA', 'browserB').getValue()).toEqual(['getValue (overwritten)', 'getValue (overwritten)'])
+                    expect(await multiRemoteBrowser.select('browserA', 'browserB').$('header').$('h1').getValue()).toEqual(['getValue (overwritten)', 'getValue (overwritten)'])
+                    expect(await multiRemoteBrowser.$('header').$('h1').select('browserA', 'browserB').getValue()).toEqual(['getValue (overwritten)', 'getValue (overwritten)'])
                 })
 
                 it('should preserve custom commands when selecting element', async () => {
 
-                    const selectedHeaderOnBrowser = await multiRemoteBrowser.unstable_select('browserA', 'browserB').$('header').$('h1')
-                    const selectedHeaderOnElement = await multiRemoteBrowser.$('header').$('h1').unstable_select('browserA', 'browserB')
+                    const selectedHeaderOnBrowser = await multiRemoteBrowser.select('browserA', 'browserB').$('header').$('h1')
+                    const selectedHeaderOnElement = await multiRemoteBrowser.$('header').$('h1').select('browserA', 'browserB')
 
                     // @ts-expect-error custom element command is not part of the default type
                     expect(await selectedHeaderOnBrowser.customElementCommand()).toEqual(['WebdriverJS Testpage', 'WebdriverJS Testpage'])
@@ -327,7 +327,7 @@ describe('multi remote test', () => {
 
                 it('should preserved addLocatorStrategy', async () => {
                     multiRemoteBrowser.addLocatorStrategy('staticStrategy', (_selector: any) => ({ elementId: 'static' }) as unknown as HTMLElement)
-                    const selected = multiRemoteBrowser.unstable_select('browserA')
+                    const selected = multiRemoteBrowser.select('browserA')
 
                     expect(multiRemoteBrowser.addLocatorStrategy).toBeDefined()
                     expect(selected.addLocatorStrategy).toBeDefined()
@@ -335,7 +335,7 @@ describe('multi remote test', () => {
 
                 it('should preserve non-command properties when selecting a browser', async () => {
 
-                    const selected = multiRemoteBrowser.unstable_select('browserA', 'browserB')
+                    const selected = multiRemoteBrowser.select('browserA', 'browserB')
 
                     expect(browserA.strategies).toBeInstanceOf(Map)
                     expect(browserA.isW3C).toBe(true)

--- a/packages/wdio-utils/src/shim.ts
+++ b/packages/wdio-utils/src/shim.ts
@@ -10,7 +10,7 @@ let inCommandHook = false
 
 const ELEMENT_QUERY_COMMANDS = [
     '$', '$$', 'custom$', 'custom$$', 'shadow$', 'shadow$$', 'react$',
-    'react$$', 'nextElement', 'previousElement', 'parentElement', 'unstable_select'
+    'react$$', 'nextElement', 'previousElement', 'parentElement', 'select'
 ]
 const ELEMENT_PROPS = [
     'elementId', 'error', 'selector', 'parent', 'index', 'isReactElement',

--- a/packages/webdriverio/src/multiremote.ts
+++ b/packages/webdriverio/src/multiremote.ts
@@ -15,7 +15,7 @@ const overridableCommands = new Set(Object.keys(BrowserCommands))
 type EventEmitter = (args: unknown) => void
 type WrappedClient = {
     options: Options.WebdriverIO,
-    commandList: (keyof (ProtocolCommands & BrowserCommandsType) & 'getInstance' & 'unstable_select')[],
+    commandList: (keyof (ProtocolCommands & BrowserCommandsType) & 'getInstance' & 'select')[],
     __propertiesObject__?: Record<string, PropertyDescriptor>
 }
 
@@ -52,7 +52,7 @@ export default class MultiRemote {
             value: (browserName: string) => this.instances[browserName]
         }
 
-        propertiesObject.unstable_select = {
+        propertiesObject.select = {
             value: function unstableSelect(this: WebdriverIO.MultiRemoteBrowser & WrappedClient, ...instanceNames: string[]) {
                 const newMultiRemote = new MultiRemote()
                 newMultiRemote.instances = instanceNames.reduce((acc, name) => {
@@ -158,7 +158,7 @@ export default class MultiRemote {
             // @ts-expect-error ToDo(Christian): remove eventually
             delete client.sessionId
 
-            client.unstable_select = function unstableSelect(...instanceNames: string[]) {
+            client.select = function select(...instanceNames: string[]) {
                 const selectedResults: unknown[] = []
 
                 const selectedInstances = instanceNames.reduce((acc, name) => {

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -498,11 +498,11 @@ interface MultiRemoteBase extends Omit<InstanceBase, 'sessionId'>, CustomInstanc
     getInstance: (browserName: string) => WebdriverIO.Browser
 
     /**
-     * @experimental select one or multiple browsers always wrapped into a multi-remote to run commands on them.
+     * @experimental (Beta) select one or multiple browsers always wrapped into a multi-remote to run commands on them.
      * Even if only one instance is selected, it will still return a multi-remote browser.
      * Use getInstance to have exclusive access to a single instance.
      */
-    unstable_select: (...browserNames: string[]) => WebdriverIO.MultiRemoteBrowser
+    select: (...browserNames: string[]) => WebdriverIO.MultiRemoteBrowser
 
 }
 interface MultiRemoteElementBase {
@@ -523,11 +523,11 @@ interface MultiRemoteElementBase {
      */
     getInstance: (browserName: string) => WebdriverIO.Element
     /**
-     * @experimental select one or multiple browsers always wrapped into a multi-remote to run commands on them.
+     * @experimental (Beta) select one or multiple browsers always wrapped into a multi-remote to run commands on them.
      * Even if only one instance is selected, it will still return a multi-remote element.
      * Use getInstance to have exclusive access to a single element.
      */
-    unstable_select: (...browserNames: string[]) => WebdriverIO.MultiRemoteElement
+    select: (...browserNames: string[]) => WebdriverIO.MultiRemoteElement
     /**
      * @private
      */

--- a/packages/webdriverio/tests/multiremote.test.ts
+++ b/packages/webdriverio/tests/multiremote.test.ts
@@ -151,7 +151,7 @@ describe('Multi-Remote tests', () => {
             const h1 = await browser.$('#foo')
 
             // narrow to browserA only
-            const selectedH1 = h1.unstable_select('browserA')
+            const selectedH1 = h1.select('browserA')
             expect(selectedH1.instances).toEqual(['browserA'])
 
             // Should preserve the instance scope when chaining $() on a selected element
@@ -159,12 +159,12 @@ describe('Multi-Remote tests', () => {
             expect(child.instances).toEqual(['browserA'])
         })
 
-        test('should throw an error when unstable_select matches nothing', async () => {
+        test('should throw an error when select matches nothing', async () => {
             const browser = await multiremote(caps())
 
             const h1 = await browser.$('#foo')
 
-            expect(() => h1.unstable_select('nonExistentBrowser')).toThrowError('None of the following requested instances are valid: nonExistentBrowser')
+            expect(() => h1.select('nonExistentBrowser')).toThrowError('None of the following requested instances are valid: nonExistentBrowser')
         })
     })
 })

--- a/packages/webdriverio/tests/multiremote.test.ts
+++ b/packages/webdriverio/tests/multiremote.test.ts
@@ -95,6 +95,7 @@ describe('Multi-Remote tests', () => {
     test('should be able to add a command to and element in multiremote', async () => {
         const browser = await multiremote(caps())
 
+        // @ts-expect-error untyped custom command
         browser.addCommand('myCustomElementCommand', async function (this: WebdriverIO.MultiRemoteBrowser) {
         // @ts-expect-error invalid params
             const size = await this.getSize()
@@ -114,6 +115,7 @@ describe('Multi-Remote tests', () => {
     test('should be able to overwrite command to and element in multiremote', async () => {
         const browser = await multiremote(caps())
 
+        // @ts-expect-error untyped custom command
         browser.overwriteCommand('getSize', async function (
             this: WebdriverIO.MultiRemoteBrowser,
             origCmd: any


### PR DESCRIPTION
## Proposed changes

Have multi-remote select in beta instead of unstable for multi-remote support in `expect-wdio`

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
