### PR TITLE
ci: Increase setTimeout delay since exact millisecond is not guarantee

### DIFF
--- a/packages/wdio-runner/tests/reporter.test.ts
+++ b/packages/wdio-runner/tests/reporter.test.ts
@@ -315,7 +315,7 @@ describe('BaseReporter', () => {
         await reporter.initReporters()
 
         // @ts-ignore test reporter param
-        setTimeout(() => (reporter['_reporters'][0].inSync = true), 112)
+        setTimeout(() => (reporter['_reporters'][0].inSync = true), 500)
         await expect(reporter.waitForSync())
             .rejects.toEqual(new Error('Some reporters are still unsynced: CustomReporter'))
     })


### PR DESCRIPTION
## Proposed changes

Fix below instability
```
 FAIL  packages/wdio-runner/tests/reporter.test.ts > BaseReporter > it should fail if waitForSync times out
AssertionError: promise resolved "true" instead of rejecting

- Expected:
Error {
  "message": "rejected promise",
}

+ Received:
true

 ❯ packages/wdio-runner/tests/reporter.test.ts:319:44
    317|         // @ts-ignore test reporter param

    318|         setTimeout(() => (reporter['_reporters'][0].inSync = true), 11…
 Test Files  1 failed | 351 passed (352)
    319|         await expect(reporter.waitForSync())
      Tests  1 failed | 3955 passed | 7 skipped (3963)
       |                                            ^
Type Errors  no errors
   Start at  15:13:21
    320|             .rejects.toEqual(new Error('Some reporters are still unsyn…
    321|     })
```
[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
