### PR TITLE
fix(webdriverio): recover owning window after nested frame destruction

### DIFF
--- a/packages/webdriverio/src/session/context.ts
+++ b/packages/webdriverio/src/session/context.ts
@@ -207,11 +207,10 @@ export class ContextManager extends SessionManager {
      */
     async #getTopLevelContext(contextId: string) {
         const { contexts } = await this.#browser.browsingContextGetTree({})
-        let context = this.findContext(contextId, contexts, 'byContextId')
-        while (context?.parent) {
-            context = this.findContext(context.parent, contexts, 'byContextId')
-        }
-        return context?.context
+        // Child entries in getTree omit parent, so find the root containing the context.
+        return contexts.find((context) =>
+            this.findContext(contextId, [context], 'byContextId')
+        )?.context
     }
 
     #onCommandResultBidiAndClassic(event: { command: string, result: unknown, body: unknown }) {

--- a/packages/webdriverio/tests/session/context.test.ts
+++ b/packages/webdriverio/tests/session/context.test.ts
@@ -192,17 +192,20 @@ describe('ContextManager', () => {
         expect(manager.getCurrentWindowHandle()).toBeUndefined()
     })
 
-    it('switches to the top-level context when a nested child frame is destroyed (regression test)', async () => {
+    it('switches to the top-level context when a nested child frame is destroyed and child nodes omit parent', async () => {
         const wid = process.env.WDIO_UNIT_TESTS
         delete process.env.WDIO_UNIT_TESTS
         const stub = createBrowserStub({ isBidi: true } as any)
         const browser = stub.browser
         ;(browser as any).browsingContextGetTree.mockResolvedValue({
             contexts: [{
+                context: 'other-window', parent: null, children: [], url: '',
+                clientWindow: 'window-2', originalOpener: null, userContext: 'default'
+            }, {
                 context: 'context-1', parent: null, url: '', clientWindow: 'window-1',
                 originalOpener: null, userContext: 'default',
                 children: [{
-                    context: 'frame-parent', parent: 'context-1', url: '', clientWindow: 'window-1',
+                    context: 'frame-parent', url: '', clientWindow: 'window-1',
                     originalOpener: null, userContext: 'default', children: null
                 }]
             }]


### PR DESCRIPTION
## Proposed changes

When the current iframe is removed from inside another iframe, context recovery calls `switchToWindow()` with the surviving parent iframe ID. Chrome rejects that command with `no such window`. This still reproduces on the `main` baseline (`ba488fa`, v9.31.7), following the recovery work in #15477; it is related to the destroyed-frame scenario in #15570.

BiDi `browsingContext.getTree` deliberately omits `parent` on child entries. Find the top-level tree containing the surviving parent instead of following absent `parent` fields. The regression fixture now reflects the real response and includes an unrelated window before the owning window.

CI follow-up: the affected window/frame tests use a local HTTP fixture with Lighthouse enabled and preserve URL/title, handle and nested-frame checks. The branch is reconciled with upstream main, which includes EdgeDriver 6.3.1, and uses its exact valid lockfile. Frozen installation, the full build and full lint checks pass; 1,606 WebdriverIO/utils tests and both navigation cases pass on the final tree.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate; no public API changes)
- [x] I have added proper type definitions for new commands (if appropriate; no new commands)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported

## Validation

- Corrected regression test fails before the fix: expected the owning window, received `frame-parent`.
- All WebdriverIO package tests: **1,248 passed, 1 skipped** across **181 files**; no type errors reported by the runner.
- ESLint on both changed files and `git diff --check` pass.
- WebdriverIO package compilation passes.
- Real headless Chrome **153.0.8010.12**: removing a nested iframe causes `switchToWindow(iframe-id)` / `no such window` before the fix; after the fix it targets the owning top-level window and `browser.execute()` returns the top-level document content. This used synthetic local `data:` / `srcdoc` pages, without external services.
- The complete published tree at `752bf31` was fetched back and matches the tested local tree.

The [BiDi serialization algorithm](https://w3c.github.io/webdriver-bidi/#get-the-navigable-info) serializes child entries with `include parent id` set to false, matching the observed Chrome response.

## Further comments

AI disclosure: OpenAI Codex performed the investigation, implementation, and local validation for this GitHub account. Maintainer review is pending.

Could a TSC member confirm whether this contribution qualifies under the [non-project-member contribution expense policy](https://github.com/webdriverio/webdriverio/blob/main/GOVERNANCE.md#expenses-from-non-project-members), and the approved amount and claim requirements if accepted?

### Reviewers: @webdriverio/project-committers