### PR TITLE
fix(webdriverio): retain detached-first shadow hosts

### DIFF
--- a/e2e/standalone/detached-shadow-root.test.ts
+++ b/e2e/standalone/detached-shadow-root.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from 'vitest'
+import { remote } from 'webdriverio'
+
+const cases = [
+    { mode: 'open', initiallyConnected: false },
+    { mode: 'closed', initiallyConnected: false },
+    { mode: 'open', initiallyConnected: true },
+    { mode: 'closed', initiallyConnected: true }
+] as const
+
+test.each(cases)('serializes $mode shadow host once (initiallyConnected: $initiallyConnected)', async (options) => {
+    const browser = await remote({
+        capabilities: {
+            browserName: 'chrome',
+            'goog:chromeOptions': { args: ['--headless=new'] }
+        }
+    })
+
+    try {
+        await browser.url('data:text/html,<main>Detached shadow host</main>')
+        await browser.execute(({ mode, initiallyConnected }) => {
+            const host = document.createElement('div') as HTMLDivElement & { testShadowRoot: ShadowRoot }
+            host.id = 'detached-shadow-host'
+            host.innerHTML = '<span>Light content</span>'
+            if (initiallyConnected) {
+                document.body.append(host)
+            }
+            host.testShadowRoot = host.attachShadow({ mode })
+            host.testShadowRoot.innerHTML = '<p>Shadow content</p>'
+            if (!initiallyConnected) {
+                document.body.append(host)
+            }
+        }, options)
+
+        const snapshot = await browser.$('#detached-shadow-host').getHTML({ prettify: false })
+        expect(snapshot.match(/shadowrootmode=/g)).toHaveLength(1)
+        expect(snapshot).toContain(`shadowrootmode="${options.mode}"`)
+        expect(snapshot.match(/<p>Shadow content<\/p>/g)).toHaveLength(1)
+        expect(snapshot).toContain('<span>Light content</span>')
+        expect(await browser.execute(() => {
+            const host = document.querySelector('#detached-shadow-host') as HTMLDivElement & { testShadowRoot: ShadowRoot }
+            return { connected: host.isConnected, light: host.innerHTML, shadow: host.testShadowRoot.innerHTML }
+        })).toEqual({ connected: true, light: '<span>Light content</span>', shadow: '<p>Shadow content</p>' })
+    } finally {
+        await browser.deleteSession()
+    }
+})
+
+test.each(['open', 'closed'] as const)('keeps a detached %s host when another host registers the document root', async (mode) => {
+    const browser = await remote({
+        capabilities: { browserName: 'chrome', 'goog:chromeOptions': { args: ['--headless=new'] } }
+    })
+    try {
+        await browser.url('data:text/html,<main id="area"></main>')
+        await browser.execute((mode) => {
+            const first = document.createElement('div') as HTMLDivElement & { testShadowRoot: ShadowRoot }
+            first.id = 'first-host'
+            first.testShadowRoot = first.attachShadow({ mode })
+            first.testShadowRoot.innerHTML = '<p>Shadow A</p>'
+            document.querySelector('#area')!.append(first)
+        }, mode)
+        await browser.execute(() => {
+            const second = document.createElement('div') as HTMLDivElement & { testShadowRoot: ShadowRoot }
+            second.id = 'second-host'
+            document.querySelector('#area')!.append(second)
+            second.testShadowRoot = second.attachShadow({ mode: 'open' })
+            second.testShadowRoot.innerHTML = '<p>Shadow B</p>'
+        })
+
+        const snapshot = await browser.$('#area').getHTML({ prettify: false })
+        expect(snapshot.match(/shadowrootmode=/g)).toHaveLength(2)
+        expect(snapshot.match(/<p>Shadow A<\/p>/g)).toHaveLength(1)
+        expect(snapshot.match(/<p>Shadow B<\/p>/g)).toHaveLength(1)
+        expect(await browser.execute(() => Array.from(document.querySelectorAll('#area > div')).map((node) => {
+            const host = node as HTMLDivElement & { testShadowRoot: ShadowRoot }
+            return { connected: host.isConnected, content: host.testShadowRoot.innerHTML }
+        }))).toEqual([
+            { connected: true, content: '<p>Shadow A</p>' },
+            { connected: true, content: '<p>Shadow B</p>' }
+        ])
+    } finally {
+        await browser.deleteSession()
+    }
+})

--- a/packages/webdriverio/src/session/shadowRoot.ts
+++ b/packages/webdriverio/src/session/shadowRoot.ts
@@ -172,13 +172,20 @@ export class ShadowRootManager extends SessionManager {
                     throw new Error(`Expected "sharedId" parameter from object ${rootElem}`)
                 }
 
-                /**
-                 * only overwrite if `root.sharedId` is different, otherwise it's another shadow component
-                 * within the same context/document
-                 */
                 const tree = this.#shadowRoots.get(logEntry.source.context)
                 if (tree?.element !== rootElem.sharedId) {
-                    this.#shadowRoots.set(logEntry.source.context, new ShadowRootTree(rootElem.sharedId))
+                    const documentTree = new ShadowRootTree(rootElem.sharedId)
+                    // A detached host may have been the initial root. Preserve its hosts
+                    // when the document element confirms this is still the same document.
+                    if (
+                        tree && documentElement?.type === 'node' && documentElement.sharedId &&
+                        this.#documentElements.get(logEntry.source.context)?.sharedId === documentElement.sharedId
+                    ) {
+                        for (const host of tree.shadowRoot ? [tree] : tree.children) {
+                            documentTree.addShadowElement(host)
+                        }
+                    }
+                    this.#shadowRoots.set(logEntry.source.context, documentTree)
                 }
             }
 
@@ -208,6 +215,13 @@ export class ShadowRootManager extends SessionManager {
                 shadowElem.value.shadowRoot.sharedId,
                 shadowElem.value.shadowRoot.value.mode
             )
+            // A detached initial host is its own root. Update that entry instead of
+            // adding the same element as its own descendant in the snapshot tree.
+            if (tree.element === newTree.element) {
+                tree.shadowRoot = newTree.shadowRoot
+                tree.mode = newTree.mode
+                return
+            }
             if (rootElem.sharedId) {
                 tree.addShadowElement(rootElem.sharedId, newTree)
             } else {

--- a/packages/webdriverio/tests/shadowRoot.test.ts
+++ b/packages/webdriverio/tests/shadowRoot.test.ts
@@ -154,6 +154,57 @@ describe('ShadowRootManager', () => {
         expect(browser.scriptAddPreloadScript).toBeCalledTimes(0)
     })
 
+    it.each(['open', 'closed'])('registers a detached initial host once with a %s shadow root', async (mode) => {
+        const browser = { ...defaultBrowser } as any
+        const manager = getShadowRootManager(browser)
+        manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: 'detached-host', value: {
+                    localName: 'div',
+                    shadowRoot: { sharedId: 'host-shadow', value: { nodeType: 11, mode } }
+                } },
+                { type: 'node', sharedId: 'detached-host' },
+                { type: 'boolean', value: false },
+                { type: 'node', sharedId: 'document-element' }
+            ],
+            source: { context: 'detached-context' }
+        } as any)
+
+        expect(await manager.getShadowElementPairsByContextId('detached-context', 'detached-host'))
+            .toEqual([['detached-host', 'host-shadow']])
+        expect(manager.getShadowRootModeById('detached-context', 'detached-host')).toBe(mode)
+    })
+
+    it('preserves detached hosts when a later event identifies the same document root', async () => {
+        const manager = getShadowRootManager({ ...defaultBrowser } as any)
+        const register = (host: string, root: string, isDocument: boolean) => manager.handleLogEntry({
+            level: 'debug',
+            args: [
+                { type: 'string', value: '[WDIO]' },
+                { type: 'string', value: 'newShadowRoot' },
+                { type: 'node', sharedId: host, value: {
+                    localName: 'div',
+                    shadowRoot: { sharedId: `${host}-shadow`, value: { nodeType: 11, mode: 'open' } }
+                } },
+                { type: 'node', sharedId: root },
+                { type: 'boolean', value: isDocument },
+                { type: 'node', sharedId: 'same-document-element' }
+            ],
+            source: { context: 'same-document-context' }
+        } as any)
+        register('first-host', 'first-host', false)
+        register('second-host', 'document-root', true)
+
+        const pairs = await manager.getShadowElementPairsByContextId('same-document-context')
+        expect(pairs.filter(([, shadow]) => shadow)).toEqual([
+            ['first-host', 'first-host-shadow'],
+            ['second-host', 'second-host-shadow']
+        ])
+    })
+
     it('should capture shadow root elements', async () => {
         const browser = { ...defaultBrowser } as any
         const manager = getShadowRootManager(browser)


### PR DESCRIPTION
## Proposed changes

If the first shadow host in a context calls `attachShadow()` before being inserted into the document, the tracker can register its element ID as both the initial root and that root's child. `getHTML()` then recursively reconstructs the same host and fails with `RangeError: Maximum call stack size exceeded`.

Keep the host's shadow ID and mode on its existing entry. When a later connected host identifies the real document root, reattach the previously tracked hosts if the document-element identity confirms this is still the same document. This preserves the first shadow instead of discarding it during root normalization; document changes still purge stale state. No serializer, preload-event, or public API changes are needed.

The scope is limited to the shadow-host tracking fix, its tracker unit tests, and its standalone Chrome regression tests. General CI stability changes are tracked separately in #15603.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate; no public API change)
- [x] I have added proper type definitions for new commands (if appropriate; no new command)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported

## Validation

- Baseline main (`ba488fa`, v9.31.7), real Chrome/BiDi: the detached-first reproduction fails with the stack-overflow error before this patch and returns the actual shadow content afterward.
- Tracker regressions expose duplicate registration and loss of the first shadow when the document root is identified; all **33 tracker tests** pass with the fix, including existing document-change cleanup tests.
- **Six real Chrome end-to-end cases pass**: open/closed roots; hosts connected before `attachShadow` or inserted afterward; and a detached-first host followed by a second connected host. Snapshots contain each expected shadow template and its actual content exactly once, and host/shadow contents remain intact.
- Full WebdriverIO package suite: **1,257 passed, 1 skipped**, across **181 files**; no type errors reported by the runner.
- Package build (including declarations), targeted ESLint, and `git diff --check` pass.

Focused end-to-end command from the repository root:

```sh
pnpm exec vitest run --config e2e/vitest.config.ts e2e/standalone/detached-shadow-root.test.ts
```

## Further comments

AI disclosure: OpenAI Codex performed the investigation, implementation, and local validation for this GitHub account. Maintainer review is pending.

Could a TSC member confirm whether this contribution qualifies under the [non-project-member contribution expense policy](https://github.com/webdriverio/webdriverio/blob/main/GOVERNANCE.md#expenses-from-non-project-members), and the approved amount and claim requirements if accepted?

### Reviewers: @webdriverio/project-committers