### PR TITLE
feat(@wdio/spec-reporter): add optional slow-test reporting

### DIFF
--- a/packages/wdio-spec-reporter/README.md
+++ b/packages/wdio-spec-reporter/README.md
@@ -179,6 +179,24 @@ Default: `true`
 ]
 ```
 
+### slowThreshold
+Report tests that take longer than this threshold (in milliseconds) to run. Slow tests are printed in an additional
+section of the report, sorted from slowest to fastest. Disabled by default, i.e. no threshold is applied and no
+slow tests section is printed unless this option is set.
+
+Type: `number`
+Default: `undefined`
+
+#### Example
+```js
+[
+  "spec",
+  {
+    slowThreshold: 2000,
+  },
+]
+```
+
 ## Environment Options
 
 There are certain options you can set through environment variables:

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -562,24 +562,28 @@ export default class SpecReporter extends WDIOReporter {
         }
 
         const threshold = this._slowThreshold
-        const slowTests = (this.getOrderedSuites()
-            .flatMap((suite) => this.getEventsToReport(suite)) as TestStats[])
-            /**
-             * only consider runnables that actually completed (i.e. have an `end`
-             * timestamp) - a skipped/pending test never calls `complete()`, so its
-             * `duration` keeps growing until the report is generated and must not
-             * be evaluated against the threshold
-             */
-            .filter((test) => test.type === 'test' && test.end && test.duration > threshold)
-            .sort((a, b) => b.duration - a.duration)
+        const slowTests = this.getOrderedSuites()
+            .flatMap((suite) => (this.getEventsToReport(suite) as TestStats[])
+                /**
+                 * only consider runnables that actually completed (i.e. have an `end`
+                 * timestamp) - a skipped/pending test never calls `complete()`, so its
+                 * `duration` keeps growing until the report is generated and must not
+                 * be evaluated against the threshold
+                 */
+                .filter((test) => test.type === 'test' && test.end && test.duration > threshold)
+                // keep the suite title alongside each test so same-named tests
+                // in different suites don't look identical in the report
+                .map((test) => ({ suiteTitle: suite.title, test }))
+            )
+            .sort((a, b) => b.test.duration - a.test.duration)
 
         if (!slowTests.length) {
             return []
         }
 
         const output = ['', this.setMessageColor(`Slowest tests (> ${prettyMs(threshold)}):`)]
-        for (const test of slowTests) {
-            output.push(`  ${prettyMs(test.duration)} - ${test.title}`)
+        for (const { suiteTitle, test } of slowTests) {
+            output.push(`  ${prettyMs(test.duration)} - ${suiteTitle} ${test.title}`)
         }
         return output
     }

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -564,7 +564,13 @@ export default class SpecReporter extends WDIOReporter {
         const threshold = this._slowThreshold
         const slowTests = (this.getOrderedSuites()
             .flatMap((suite) => this.getEventsToReport(suite)) as TestStats[])
-            .filter((test) => test.type === 'test' && test.duration > threshold)
+            /**
+             * only consider runnables that actually completed (i.e. have an `end`
+             * timestamp) - a skipped/pending test never calls `complete()`, so its
+             * `duration` keeps growing until the report is generated and must not
+             * be evaluated against the threshold
+             */
+            .filter((test) => test.type === 'test' && test.end && test.duration > threshold)
             .sort((a, b) => b.duration - a.duration)
 
         if (!slowTests.length) {

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -54,6 +54,7 @@ export default class SpecReporter extends WDIOReporter {
     private _chalk: ChalkInstance
     private _onlyFailures = false
     private _sauceLabsSharableLinks = true
+    private _slowThreshold?: number
 
     constructor (options: SpecReporterOptions) {
         /**
@@ -65,6 +66,7 @@ export default class SpecReporter extends WDIOReporter {
         this._onlyFailures = options.onlyFailures || false
         this._realtimeReporting = options.realtimeReporting || false
         this._showPreface = options.showPreface !== false
+        this._slowThreshold = options.slowThreshold
         this._sauceLabsSharableLinks = 'sauceLabsSharableLinks' in options
             ? options.sauceLabsSharableLinks as boolean
             : this._sauceLabsSharableLinks
@@ -248,6 +250,7 @@ export default class SpecReporter extends WDIOReporter {
             ...results,
             ...this.getCountDisplay(duration),
             ...this.getFailureDisplay(),
+            ...this.getSlowTestsDisplay(),
             ...(testLinks.length
                 /**
                  * if we have test links add an empty line
@@ -546,6 +549,32 @@ export default class SpecReporter extends WDIOReporter {
             }
         }
 
+        return output
+    }
+
+    /**
+     * Get display for the slowest tests, sorted from slowest to fastest
+     * @return {Array} Slow tests output
+     */
+    getSlowTestsDisplay () {
+        if (!this._slowThreshold) {
+            return []
+        }
+
+        const threshold = this._slowThreshold
+        const slowTests = (this.getOrderedSuites()
+            .flatMap((suite) => this.getEventsToReport(suite)) as TestStats[])
+            .filter((test) => test.type === 'test' && test.duration > threshold)
+            .sort((a, b) => b.duration - a.duration)
+
+        if (!slowTests.length) {
+            return []
+        }
+
+        const output = ['', this.setMessageColor(`Slowest tests (> ${prettyMs(threshold)}):`)]
+        for (const test of slowTests) {
+            output.push(`  ${prettyMs(test.duration)} - ${test.title}`)
+        }
         return output
     }
 

--- a/packages/wdio-spec-reporter/src/types.ts
+++ b/packages/wdio-spec-reporter/src/types.ts
@@ -63,6 +63,13 @@ export interface SpecReporterOptions {
     * @default: `true`
     */
     color?: boolean
+    /**
+     * Print a "Slowest tests" summary listing tests that took longer than this
+     * threshold (in ms) to run, sorted from slowest to fastest.
+     *
+     * @default: undefined (disabled)
+     */
+    slowThreshold?: number
 }
 
 export enum ChalkColors {

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.ts
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.ts
@@ -102,6 +102,7 @@ export const SUITES_WITH_DURATIONS = {
                 title: 'foo',
                 state: 'passed',
                 type: 'test',
+                end: new Date(),
                 duration: 500,
             },
             {
@@ -109,6 +110,7 @@ export const SUITES_WITH_DURATIONS = {
                 title: 'bar',
                 state: 'passed',
                 type: 'test',
+                end: new Date(),
                 duration: 5000,
             },
             {
@@ -116,7 +118,17 @@ export const SUITES_WITH_DURATIONS = {
                 title: 'baz',
                 state: 'passed',
                 type: 'test',
+                end: new Date(),
                 duration: 8000,
+            },
+            {
+                uid: 'pending1',
+                title: 'a never-ending pending test',
+                state: 'pending',
+                type: 'test',
+                // no `end` timestamp: mimics a skipped/pending test whose
+                // duration keeps growing because `complete()` was never called
+                duration: 999999,
             },
         ],
     },

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.ts
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.ts
@@ -132,6 +132,24 @@ export const SUITES_WITH_DURATIONS = {
             },
         ],
     },
+    [suiteIds[1]]: {
+        uid: suiteIds[1],
+        title: suiteIds[1].slice(0, -1),
+        file: '/bar/foo/loo.e2e.js',
+        hooks: [],
+        tests: [
+            {
+                uid: 'baz2',
+                // same title as the slow "baz" test in the first suite, to
+                // prove suite context disambiguates same-named slow tests
+                title: 'baz',
+                state: 'passed',
+                type: 'test',
+                end: new Date(),
+                duration: 6000,
+            },
+        ],
+    },
 }
 Object.values(SUITES_WITH_DURATIONS).forEach((suite) => {
     // @ts-expect-error

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.ts
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.ts
@@ -90,6 +90,42 @@ Object.values(SUITES).forEach((suite) => {
     suite.hooksAndTests = [...suite.tests]
 })
 
+export const SUITES_WITH_DURATIONS = {
+    [suiteIds[0]]: {
+        uid: suiteIds[0],
+        title: suiteIds[0].slice(0, -1),
+        file: '/foo/bar/loo.e2e.js',
+        hooks: [],
+        tests: [
+            {
+                uid: 'foo1',
+                title: 'foo',
+                state: 'passed',
+                type: 'test',
+                duration: 500,
+            },
+            {
+                uid: 'bar1',
+                title: 'bar',
+                state: 'passed',
+                type: 'test',
+                duration: 5000,
+            },
+            {
+                uid: 'baz1',
+                title: 'baz',
+                state: 'passed',
+                type: 'test',
+                duration: 8000,
+            },
+        ],
+    },
+}
+Object.values(SUITES_WITH_DURATIONS).forEach((suite) => {
+    // @ts-expect-error
+    suite.hooksAndTests = [...suite.tests]
+})
+
 export const SUITES_WITH_DATA_TABLE = {
     [suiteIds[0]]: {
         uid: suiteIds[0],

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -616,6 +616,7 @@ exports[`SpecReporter > printReport > with normal setup > should print the slowe
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]    green ✓ baz
+[loremipsum 50 Windows 10 #0-0]    cyan ? a never-ending pending test
 [loremipsum 50 Windows 10 #0-0]
 [loremipsum 50 Windows 10 #0-0] green 4 passing (5s)
 [loremipsum 50 Windows 10 #0-0] red 1 failing

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -618,13 +618,18 @@ exports[`SpecReporter > printReport > with normal setup > should print the slowe
 [loremipsum 50 Windows 10 #0-0]    green ✓ baz
 [loremipsum 50 Windows 10 #0-0]    cyan ? a never-ending pending test
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Bar test
+[loremipsum 50 Windows 10 #0-0]    green ✓ baz
+[loremipsum 50 Windows 10 #0-0]
 [loremipsum 50 Windows 10 #0-0] green 4 passing (5s)
 [loremipsum 50 Windows 10 #0-0] red 1 failing
 [loremipsum 50 Windows 10 #0-0] cyan 1 skipped
 [loremipsum 50 Windows 10 #0-0]
 [loremipsum 50 Windows 10 #0-0] gray Slowest tests (> 1s):
-[loremipsum 50 Windows 10 #0-0]   8s - baz
-[loremipsum 50 Windows 10 #0-0]   5s - bar
+[loremipsum 50 Windows 10 #0-0]   8s - Foo test baz
+[loremipsum 50 Windows 10 #0-0]   6s - Bar test baz
+[loremipsum 50 Windows 10 #0-0]   5s - Foo test bar
 ",
   ],
 ]

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -604,6 +604,31 @@ exports[`SpecReporter > printReport > with normal setup > should print the repor
 ]
 `;
 
+exports[`SpecReporter > printReport > with normal setup > should print the slowest tests when slowThreshold is configured 1`] = `
+[
+  [
+    "------------------------------------------------------------------
+[loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
+[loremipsum 50 Windows 10 #0-0] Session ID: foobar
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
+[loremipsum 50 Windows 10 #0-0] Foo test
+[loremipsum 50 Windows 10 #0-0]    green ✓ foo
+[loremipsum 50 Windows 10 #0-0]    green ✓ bar
+[loremipsum 50 Windows 10 #0-0]    green ✓ baz
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] green 4 passing (5s)
+[loremipsum 50 Windows 10 #0-0] red 1 failing
+[loremipsum 50 Windows 10 #0-0] cyan 1 skipped
+[loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] gray Slowest tests (> 1s):
+[loremipsum 50 Windows 10 #0-0]   8s - baz
+[loremipsum 50 Windows 10 #0-0]   5s - bar
+",
+  ],
+]
+`;
+
 exports[`SpecReporter > showPreface > false 1`] = `[]`;
 
 exports[`SpecReporter > showPreface > true 1`] = `[]`;

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -125,6 +125,13 @@ describe('SpecReporter', () => {
             expect(display.some((line: string) => line.includes('baz'))).toBe(true)
         })
 
+        it('should include the suite title so same-named slow tests in different suites are distinguishable', () => {
+            // both suites have a slow test titled "baz"
+            const display = getReporter(1000).getSlowTestsDisplay()
+            expect(display.some((line: string) => line.includes('Foo test baz'))).toBe(true)
+            expect(display.some((line: string) => line.includes('Bar test baz'))).toBe(true)
+        })
+
         it('should sort slow tests from slowest to fastest', () => {
             const display = getReporter(1000).getSlowTestsDisplay()
             expect(display.findIndex((line: string) => line.includes('baz')))

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -96,30 +96,54 @@ describe('SpecReporter', () => {
     })
 
     describe('getSlowTestsDisplay', () => {
-        it('should return an empty array when no threshold is configured', () => {
-            const noThresholdReporter = new SpecReporter({}) as any
-            noThresholdReporter['_suiteUids'] = new Set(Object.keys(SUITES_WITH_DURATIONS))
-            noThresholdReporter.suites = SUITES_WITH_DURATIONS
-            expect(noThresholdReporter.getSlowTestsDisplay()).toEqual([])
-        })
-
-        it('should return tests exceeding the threshold, sorted from slowest to fastest', () => {
-            const slowReporter = new SpecReporter({ slowThreshold: 1000 }) as any
+        const getReporter = (slowThreshold?: number) => {
+            const slowReporter = new SpecReporter(slowThreshold === undefined ? {} : { slowThreshold }) as any
             slowReporter['_suiteUids'] = new Set(Object.keys(SUITES_WITH_DURATIONS))
             slowReporter.suites = SUITES_WITH_DURATIONS
-            const display = slowReporter.getSlowTestsDisplay()
+            return slowReporter
+        }
+
+        it('should return an empty array when no threshold is configured', () => {
+            expect(getReporter().getSlowTestsDisplay()).toEqual([])
+        })
+
+        it('should include a completed test whose duration exceeds the threshold', () => {
+            const display = getReporter(1000).getSlowTestsDisplay()
             expect(display.some((line: string) => line.includes('baz'))).toBe(true)
             expect(display.some((line: string) => line.includes('bar'))).toBe(true)
+        })
+
+        it('should not include a completed test whose duration is below the threshold', () => {
+            const display = getReporter(1000).getSlowTestsDisplay()
             expect(display.some((line: string) => line.includes('foo'))).toBe(false)
+        })
+
+        it('should not include a completed test whose duration exactly equals the threshold', () => {
+            // "bar" has a duration of exactly 5000ms
+            const display = getReporter(5000).getSlowTestsDisplay()
+            expect(display.some((line: string) => line.includes('bar'))).toBe(false)
+            expect(display.some((line: string) => line.includes('baz'))).toBe(true)
+        })
+
+        it('should sort slow tests from slowest to fastest', () => {
+            const display = getReporter(1000).getSlowTestsDisplay()
             expect(display.findIndex((line: string) => line.includes('baz')))
                 .toBeLessThan(display.findIndex((line: string) => line.includes('bar')))
         })
 
         it('should return an empty array when no test exceeds the threshold', () => {
-            const slowReporter = new SpecReporter({ slowThreshold: 100000 }) as any
-            slowReporter['_suiteUids'] = new Set(Object.keys(SUITES_WITH_DURATIONS))
-            slowReporter.suites = SUITES_WITH_DURATIONS
-            expect(slowReporter.getSlowTestsDisplay()).toEqual([])
+            expect(getReporter(100000).getSlowTestsDisplay()).toEqual([])
+        })
+
+        // regression test for a reported bug: TestStats.skip() never calls
+        // complete(), so a skipped/pending test's `duration` getter keeps
+        // returning the live elapsed time until the report is generated. A
+        // long-running spec could make that live duration exceed the
+        // threshold even though the test never actually ran.
+        it('should exclude skipped/pending tests even if their unfinished duration exceeds the threshold', () => {
+            // threshold lower than the pending fixture's (unfinished) duration
+            const display = getReporter(1).getSlowTestsDisplay()
+            expect(display.some((line: string) => line.includes('never-ending pending test'))).toBe(false)
         })
     })
 

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -9,7 +9,8 @@ import {
     SUITES_MULTIPLE_ERRORS,
     SUITES_WITH_DOC_STRING,
     SUITES_NO_TESTS_WITH_HOOK_ERROR,
-    SUITES_WITH_RETRIES
+    SUITES_WITH_RETRIES,
+    SUITES_WITH_DURATIONS
 } from './__fixtures__/testdata.js'
 import { State } from '../src/types.js'
 import SpecReporter from '../src/index.js'
@@ -91,6 +92,34 @@ describe('SpecReporter', () => {
                 hooks: [{ error: 1 }, {}, { error: 2 }],
                 hooksAndTests: [{}, { error: 11 }, {}, { type: 'test', title: '33' }, {}, { error: 22 }, {}]
             } as any)).toEqual([{ error: 11 }, { type: 'test', title: '33' }, { error: 22 }])
+        })
+    })
+
+    describe('getSlowTestsDisplay', () => {
+        it('should return an empty array when no threshold is configured', () => {
+            const noThresholdReporter = new SpecReporter({}) as any
+            noThresholdReporter['_suiteUids'] = new Set(Object.keys(SUITES_WITH_DURATIONS))
+            noThresholdReporter.suites = SUITES_WITH_DURATIONS
+            expect(noThresholdReporter.getSlowTestsDisplay()).toEqual([])
+        })
+
+        it('should return tests exceeding the threshold, sorted from slowest to fastest', () => {
+            const slowReporter = new SpecReporter({ slowThreshold: 1000 }) as any
+            slowReporter['_suiteUids'] = new Set(Object.keys(SUITES_WITH_DURATIONS))
+            slowReporter.suites = SUITES_WITH_DURATIONS
+            const display = slowReporter.getSlowTestsDisplay()
+            expect(display.some((line: string) => line.includes('baz'))).toBe(true)
+            expect(display.some((line: string) => line.includes('bar'))).toBe(true)
+            expect(display.some((line: string) => line.includes('foo'))).toBe(false)
+            expect(display.findIndex((line: string) => line.includes('baz')))
+                .toBeLessThan(display.findIndex((line: string) => line.includes('bar')))
+        })
+
+        it('should return an empty array when no test exceeds the threshold', () => {
+            const slowReporter = new SpecReporter({ slowThreshold: 100000 }) as any
+            slowReporter['_suiteUids'] = new Set(Object.keys(SUITES_WITH_DURATIONS))
+            slowReporter.suites = SUITES_WITH_DURATIONS
+            expect(slowReporter.getSlowTestsDisplay()).toEqual([])
         })
     })
 
@@ -183,6 +212,15 @@ describe('SpecReporter', () => {
             })
 
             it('should print the report to the console', () => {
+                const runner = getRunnerConfig({ hostname: 'localhost' })
+                printReporter.printReport(runner)
+                expect(printReporter.write.mock.calls).toMatchSnapshot()
+            })
+
+            it('should print the slowest tests when slowThreshold is configured', () => {
+                printReporter['_slowThreshold'] = 1000
+                printReporter['_suiteUids'] = new Set(Object.keys(SUITES_WITH_DURATIONS))
+                printReporter.suites = SUITES_WITH_DURATIONS
                 const runner = getRunnerConfig({ hostname: 'localhost' })
                 printReporter.printReport(runner)
                 expect(printReporter.write.mock.calls).toMatchSnapshot()

--- a/website/i18n/ptBR/code.json
+++ b/website/i18n/ptBR/code.json
@@ -1,0 +1,580 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "Ocorreu algo inesperado.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Tente novamente.",
+    "description": "The label of the button to try again when the page crashed"
+  },
+  "theme.NotFound.title": {
+    "message": "Página não encontrada",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "Não conseguimos encontrar o que você estava procurando.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Entre em contato com o proprietário do site que o vinculou ao URL original e informe que o link está quebrado.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.admonition.note": {
+    "message": "observação",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "dica",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.danger": {
+    "message": "perigo",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "informação",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.caution": {
+    "message": "cuidado",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Role de volta ao topo",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Arquivo",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Arquivo",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Navegação na página da lista de blogs",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Entradas mais recentes",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Entradas mais antigas",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Navegação na página de postagem do blog",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Postagem mais recente",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Postagem mais antiga",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.post.plurals": {
+    "message": "Uma postagem|{count} postagens",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} marcado com \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "Ver todas as tags",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Página inicial",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Breadcrumbs",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription": {
+    "message": "{count} itens",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Alternar entre o modo escuro e claro (atual {mode})",
+    "description": "The ARIA label for the navbar color mode toggle"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "Tema escuro",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "Tema claro",
+    "description": "The name for the light color mode"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Navegação nas páginas de documentos",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Anterior",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Próximo",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "Um documento marcado|{count} documentos marcados",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} com \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Versão: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "Esta é uma documentação não lançada para {siteTitle} {versionLabel} versão.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "Esta é a documentação para {siteTitle} {versionLabel}, que não é mais mantido ativamente.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "Para obter documentação atualizada, consulte o {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "versão mais recente",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Editar esta página",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Link direto para o título",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " na {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " por {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Última atualização{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versões",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Fechar",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Tags:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Navegação de postagens recentes do blog",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copiado",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copiar código para área de transferência",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copiar",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Alternar quebra de linha",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
+    "message": "Alternar a categoria da barra lateral recolhível '{label}'",
+    "description": "The ARIA label to toggle the collapsible sidebar category"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "Nesta página",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Ler mais",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Read more about {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "Tempo de leitura|{readingTime} minutos de leitura",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Linguagens",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Recolher barra lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Recolher barra lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Fechar barra de navegação",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Voltar ao menu principal",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Alternar barra de navegação",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expandir barra lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expandir barra lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "Visualizar todos os {count} resultados"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "Um documento encontrado|{count} documentos encontrados",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "Resultados da pesquisa por \"{query}\"",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "Pesquise a documentação",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "Digite sua pesquisa aqui",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "Procurar",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.algoliaLabel": {
+    "message": "Pesquisa por Algolia",
+    "description": "The ARIA label for Algolia mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "Nenhum resultado foi encontrado.",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "Buscando novos resultados...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.SearchBar.label": {
+    "message": "Procurar",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "Limpe a pesquisa",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "Cancelar",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "Pesquisas recentes",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "Nenhuma pesquisa recente",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "Salvar pesquisa",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "Remover pesquisa do histórico",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "Pesquisas favoritas",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "Remover pesquisa favorita",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "Erro ao carregar resultados",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "Talvez você queira verificar sua conexão de rede.",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "para selecionar",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Digite a chave",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "navegar",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "Seta para cima",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "Seta para baixo",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "fechar",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Tecla de escape",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "Procurar por",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "Nenhum resultado por",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "Tente pesquisar",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "Acredita que esta consulta deve retornar resultados?",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "Deixe-nos saber.",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "Pesquisar documentos",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
+  },
+  "theme.IdealImageMessage.loading": {
+    "message": "Carregando...",
+    "description": "When the full-scale image is loading"
+  },
+  "theme.IdealImageMessage.load": {
+    "message": "Clique para carregar{sizeMessage}",
+    "description": "To prompt users to load the full image. sizeMessage is a parenthesized size figure."
+  },
+  "theme.IdealImageMessage.offline": {
+    "message": "Seu navegador está offline. Imagem não carregada.",
+    "description": "When the user is viewing an offline document"
+  },
+  "theme.IdealImageMessage.404error": {
+    "message": "404. Imagem não encontrada",
+    "description": "When the image is not found"
+  },
+  "theme.IdealImageMessage.error": {
+    "message": "Error. Clique para recarregar",
+    "description": "When the image fails to load for unknown error"
+  },
+  "theme.PwaReloadPopup.info": {
+    "message": "Nova versão disponível",
+    "description": "The text for PWA reload popup"
+  },
+  "theme.PwaReloadPopup.refreshButtonText": {
+    "message": "Recarregar",
+    "description": "The text for PWA reload button"
+  },
+  "theme.PwaReloadPopup.closeButtonAriaLabel": {
+    "message": "Fechar",
+    "description": "The ARIA label for close button of PWA reload popup"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Pular para o conteúdo principal",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Tags",
+    "description": "The title of the tag list page"
+  },
+  "WebdriverIO allows you to test in actual browser or mobile devices used by your users.": {
+    "message": "O WebdriverIO permite que você teste em navegadores reais ou dispositivos móveis usados ​​por seus usuários."
+  },
+  "Use WebdriverIO for full e2e or unit and component testing in the browser.": {
+    "message": "Use o WebdriverIO para testes completos de e2e ou de unidade e componentes no navegador."
+  },
+  "WebdriverIO automatically waits for elements to appear before interacting with them.": {
+    "message": "O WebdriverIO aguarda automaticamente que os elementos apareçam antes de interagir com eles."
+  },
+  "Get Started": {
+    "message": "Comece aqui"
+  },
+  "Why WebdriverIO?": {
+    "message": "Por que o WebdriverIO?"
+  },
+  "View on GitHub": {
+    "message": "Ver no GitHub"
+  },
+  "Watch on YouTube": {
+    "message": "Assista no YouTube"
+  },
+  "Easy setup for web component testing with:": {
+    "message": "Configuração fácil para teste de componentes da web com:"
+  },
+  "homepage.hightlight.createProject": {
+    "message": "Comece a usar o WebdriverIO em segundos"
+  },
+  "The WebdriverIO testrunner comes with a command line interface that provides a powerful configuration utility and helps you to create your test setup in less than a minute. It let's you pick from available test framework integrations and easily allows to add all supported reporter and service plugins!": {
+    "message": "O WebdriverIO testrunner vem com uma interface de linha de comando que fornece um utilitário de configuração poderoso e ajuda você a criar sua configuração de teste em menos de um minuto. Ele permite que você escolha entre as integrações de framework de teste disponíveis e permite adicionar facilmente todos os plugins de reporter e service suportados!"
+  },
+  "With just one simple command you can set up a complete test suite:": {
+    "message": "Com apenas um comando simples você pode configurar um conjunto de testes completo:"
+  },
+  "homepage.hightlight.watch": {
+    "message": "Assista a palestras sobre WebdriverIO"
+  },
+  "homepage.hightlight.lighthouse": {
+    "message": "Google Lighthouse Integration"
+  },
+  "Integration to developer tools such as:": {
+    "message": "Integração com ferramentas de desenvolvedor como:"
+  },
+  "until October 2023": {
+    "message": "até outubro de 2023"
+  },
+  "since February 2022": {
+    "message": "desde fevereiro de 2022"
+  },
+  "since January 2021": {
+    "message": "desde janeiro de 2021"
+  },
+  "since December 2019": {
+    "message": "desde dezembro de 2019"
+  },
+  "versions.description": {
+    "message": "Página de versões do Docusaurus 2 listando todas as versões documentadas do site"
+  },
+  "WebdriverIO documentation versions": {
+    "message": "Versões da documentação do WebdriverIO"
+  },
+  "The project team releases new major versions roughly on a yearly cadence. LTS release status is \"long-term support\", which typically guarantees that critical bugs will be fixed for a total of 12 months until a new major release is made.": {
+    "message": "A equipe do projeto lança novas versões principais aproximadamente em uma cadência anual. O status de lançamento do LTS é \"long-term support\", o que normalmente garante que bugs críticos serão corrigidos por um total de 12 meses até que uma nova versão importante seja feita."
+  },
+  "Current version (Stable)": {
+    "message": "Versão atual (Stable)"
+  },
+  "Here you can find the documentation for current released version.": {
+    "message": "Aqui você pode encontrar a documentação da versão lançada atualmente."
+  },
+  "Documentation": {
+    "message": "Documentação"
+  },
+  "Release Notes": {
+    "message": "Notas de versão"
+  },
+  "Past versions": {
+    "message": "Versões anteriores"
+  },
+  "Here you can find documentation for previous versions of Docusaurus.": {
+    "message": "Aqui você pode encontrar documentação para versões anteriores do Docusaurus."
+  },
+  "homepage.createBrowserAnimation": {
+    "message": "Criar demonstração do WebdriverIO"
+  },
+  "homepage.highlight.getStartedOnYouTube": {
+    "message": "Comece a aprender mais sobre o WebdriverIO e como começar {youtubeLink}."
+  },
+  "homepage.highlight.getStartedOnYouTube.label;": {
+    "message": "no YouTube",
+    "description": "The label for the link to my YouTube"
+  },
+  "homepage.highlight.conferenceTalk": {
+    "message": "A comunidade em torno do WebdriverIO está falando ativamente em vários grupos de usuários ou conferências sobre tópicos específicos em torno de testes automatizados com o WebdriverIO. Confira esta palestra em {youtubeLink} por {videoAuthor} no {conferenceLink}."
+  },
+  "homepage.highlight.conferenceTalk.label": {
+    "message": "Meus recursos favoritos do WebdriverIO",
+    "description": "The conference talk title"
+  },
+  "homepage.highlight.youtubeChannels": {
+    "message": "Há também muitos canais do YouTube com tutoriais úteis de membros da comunidade, como {channelOne}, {channelTwo} ou {channelThree}."
+  },
+  "homepage.highlight.devtools": {
+    "message": "O WebdriverIO não apenas executa a automação com base no protocolo WebDriver, mas também aproveita as APIs nativas do navegador para permitir integrações com ferramentas populares para desenvolvedores, como {devtoolsLink} ou {lighthouseLink}. Com o {devtoolsServiceLink} plugin você tem acesso a comandos para validar se seu aplicativo é um aplicativo PWA válido, bem como a comandos para capturar métricas de desempenho do frontend, como `speedIndex` e outros."
+  },
+  "homepage.features.crossBrowser": {
+    "message": "Suporte entre navegadores por meio de automação {webdriverLink} e {bidiLink}."
+  },
+  "homepage.features.mobile": {
+    "message": "Execute o WebdriverIO em dispositivos móveis reais, TVs inteligentes ou outros dispositivos IoT por meio de {appiumLink}."
+  },
+  "homepage.features.support": {
+    "message": "Executando um {supportChannelLink} com mais de 8 mil membros e um rico ecossistema de plugins mantidos pela comunidade."
+  },
+  "homepage.tagline": {
+    "message": "Estrutura de teste de automação de navegador e dispositivos móveis de última geração para Node.js"
+  },
+  "homepage.componentTesting.para1": {
+    "message": "WebdriverIO é um {allInOne} framework para o desenvolvimento do seu aplicativo web. Ele permite que você execute testes de componentes pequenos e leves, bem como execute cenários de teste e2e no navegador ou em um dispositivo móvel. Isso garante que você faça o teste em um ambiente {usedBy}."
+  },
+  "features.realEnvironments": {
+    "message": "Teste em ambientes reais"
+  },
+  "features.versatile": {
+    "message": "Versátil e rico em recursos"
+  },
+  "features.autoWait": {
+    "message": "Espera automática"
+  },
+  "features.standards": {
+    "message": "Baseado em Padrões da Web"
+  },
+  "features.mobileSupport": {
+    "message": "Suporte móvel nativo"
+  },
+  "features.community": {
+    "message": "Comunidade Comprometida"
+  },
+  "homepage.componentTesting.heading": {
+    "message": "Testes E2E e Unitários/Componentes em um navegador real!"
+  },
+  "homepage.componentTesting.para2": {
+    "message": "Ele vem com estratégias de seleção inteligente que simplificam a interação, por exemplo, com {reactComponents} ou executar consultas de seletor profundas com árvores shadow DOM aninhadas. Como as interações acontecem por meio de um protocolo de automação padronizado, é garantido que elas se comportam nativamente e não são apenas emuladas por JavaScript."
+  },
+  "Who is using WebdriverIO?": {
+    "message": "Quem está usando o WebdriverIO?"
+  },
+  "all in one": {
+    "message": "tudo em um"
+  },
+  "used by your users": {
+    "message": "usado por seus usuários"
+  }
+}

--- a/website/i18n/ptBR/docusaurus-plugin-content-blog/options.json
+++ b/website/i18n/ptBR/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Blog",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "Blog",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "Postagens recentes",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/website/i18n/ptBR/docusaurus-plugin-content-docs-community/current.json
+++ b/website/i18n/ptBR/docusaurus-plugin-content-docs-community/current.json
@@ -1,0 +1,6 @@
+{
+  "version.label": {
+    "message": "Próximo",
+    "description": "The label for version current"
+  }
+}

--- a/website/i18n/ptBR/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/ptBR/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,74 @@
+{
+  "version.label": {
+    "message": "Próximo",
+    "description": "The label for version current"
+  },
+  "sidebar.docs.category.Getting Started": {
+    "message": "Começando",
+    "description": "The label for category Getting Started in sidebar docs"
+  },
+  "sidebar.docs.category.Core Concepts": {
+    "message": "Conceitos Básicos",
+    "description": "The label for category Core Concepts in sidebar docs"
+  },
+  "sidebar.docs.category.Configuration": {
+    "message": "Configuração",
+    "description": "The label for category Configuration in sidebar docs"
+  },
+  "sidebar.docs.category.Guides": {
+    "message": "Guias",
+    "description": "The label for category Guides in sidebar docs"
+  },
+  "sidebar.docs.category.Testrunner": {
+    "message": "Testrunner",
+    "description": "The label for category Testrunner in sidebar docs"
+  },
+  "sidebar.docs.category.Component Testing": {
+    "message": "Teste de Componente",
+    "description": "The label for category Component Testing in sidebar docs"
+  },
+  "sidebar.docs.category.Framework Setup": {
+    "message": "Configuração do Framework",
+    "description": "The label for category Framework Setup in sidebar docs"
+  },
+  "sidebar.docs.category.Migrate": {
+    "message": "Migrar",
+    "description": "The label for category Migrate in sidebar docs"
+  },
+  "sidebar.docs.category.Integration": {
+    "message": "Integração",
+    "description": "The label for category Integration in sidebar docs"
+  },
+  "sidebar.docs.category.Reporter": {
+    "message": "Reporter",
+    "description": "The label for category Reporter in sidebar docs"
+  },
+  "sidebar.docs.category.Services": {
+    "message": "Serviços",
+    "description": "The label for category Services in sidebar docs"
+  },
+  "sidebar.api.category.Protocols": {
+    "message": "Protocolos",
+    "description": "The label for category Protocols in sidebar api"
+  },
+  "sidebar.api.category.browser": {
+    "message": "navegador",
+    "description": "The label for category browser in sidebar api"
+  },
+  "sidebar.api.category.element": {
+    "message": "elemento",
+    "description": "The label for category element in sidebar api"
+  },
+  "sidebar.api.category.mock": {
+    "message": "mock",
+    "description": "The label for category mock in sidebar api"
+  },
+  "sidebar.flowcharts.category.Flowcharts": {
+    "message": "Fluxogramas",
+    "description": "The label for category Flowcharts in sidebar flowcharts"
+  },
+  "sidebar.docs.category.Web Extension Testing": {
+    "message": "Teste de extensão da web",
+    "description": "The label for category Web Extension Testing in sidebar docs"
+  }
+}

--- a/website/i18n/ptBR/docusaurus-theme-classic/footer.json
+++ b/website/i18n/ptBR/docusaurus-theme-classic/footer.json
@@ -1,0 +1,66 @@
+{
+  "link.title.Docs": {
+    "message": "Documentos",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Community": {
+    "message": "Comunidade",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.title.More": {
+    "message": "Mais",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Getting Started": {
+    "message": "Vamos começar!",
+    "description": "The label of footer link with label=Getting Started linking to docs/gettingstarted"
+  },
+  "link.item.label.API Reference": {
+    "message": "Referência da API",
+    "description": "The label of footer link with label=API Reference linking to docs/api"
+  },
+  "link.item.label.Contribute": {
+    "message": "Contribuir",
+    "description": "The label of footer link with label=Contribute linking to docs/contribute/"
+  },
+  "link.item.label.Help": {
+    "message": "Ajuda",
+    "description": "The label of footer link with label=Help linking to community/support"
+  },
+  "link.item.label.Stack Overflow": {
+    "message": "Stack Overflow",
+    "description": "The label of footer link with label=Stack Overflow linking to https://stackoverflow.com/questions/tagged/webdriver-io"
+  },
+  "link.item.label.Support Chat": {
+    "message": "Suporte Chat",
+    "description": "The label of footer link with label=Support Chat linking to https://discord.webdriver.io"
+  },
+  "link.item.label.Slack": {
+    "message": "Slack",
+    "description": "The label of footer link with label=Slack linking to https://seleniumhq.slack.com/join/shared_invite/zt-f7jwg1n7-RVw4v4sMA7Zjufira_~EVw#/"
+  },
+  "link.item.label.Twitter": {
+    "message": "Twitter",
+    "description": "The label of footer link with label=Twitter linking to https://twitter.com/webdriverio"
+  },
+  "link.item.label.Tidelift Subscription": {
+    "message": "Assinatura Tidelift",
+    "description": "The label of footer link with label=Tidelift Subscription linking to /docs/enterprise/"
+  },
+  "link.item.label.Donate to WebdriverIO": {
+    "message": "Doe para o WebdriverIO",
+    "description": "The label of footer link with label=Donate to WebdriverIO linking to https://opencollective.com/webdriverio"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "The label of footer link with label=Blog linking to blog"
+  },
+  "copyright": {
+    "message": "Copyright © 2024 OpenJS Foundation",
+    "description": "The footer copyright"
+  },
+  "link.item.label.YouTube": {
+    "message": "YouTube",
+    "description": "The label of footer link with label=YouTube linking to https://youtube.com/@webdriverio"
+  }
+}

--- a/website/i18n/ptBR/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/ptBR/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,26 @@
+{
+  "item.label.Docs": {
+    "message": "Documentação",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.API": {
+    "message": "API",
+    "description": "Navbar item with label API"
+  },
+  "item.label.Blog": {
+    "message": "Blog",
+    "description": "Navbar item with label Blog"
+  },
+  "item.label.Contribute": {
+    "message": "Contribuir",
+    "description": "Navbar item with label Contribute"
+  },
+  "item.label.Community": {
+    "message": "Comunidade",
+    "description": "Navbar item with label Community"
+  },
+  "item.label.v8": {
+    "message": "v8",
+    "description": "Navbar item with label v8"
+  }
+}


### PR DESCRIPTION
## Proposed changes

Add optional slow-test reporting to the `@wdio/spec-reporter`.

WebdriverIO already records the execution time of every test through `TestStats`, which inherits duration tracking from `RunnableStats`. The spec reporter currently uses this test information to render suites and failures, but does not expose tests whose execution time exceeds a configurable threshold.

This change adds a `slowThreshold` reporter option. When configured, the spec reporter identifies tests in the current spec whose recorded duration exceeds the threshold, sorts them from slowest to fastest, and prints them in an additional section of the spec report.

```js
reporters: [
    ['spec', {
        slowThreshold: 2000
    }]
]
```

The implementation reuses the existing `TestStats.duration` values and the reporter's current suite/event traversal. No new timing infrastructure, runner events, framework integrations, IPC aggregation, or public WebdriverIO configuration is required.

Because each spec reporter instance runs within its worker, slow tests are reported for the current spec file rather than aggregated across workers. Cross-spec aggregation would require structured result collection in the main process and is intentionally outside the scope of this change.

When `slowThreshold` is not configured, the existing reporter output and behavior remain unchanged.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my feature works
- [x] I have added the necessary documentation
- [x] I have added proper type definitions for the new reporter option

## Backport Request

- [x] This feature is for the current `main` version and doesn't need to be back-ported

## Validation

- Tests with a duration below the configured threshold are not reported.
- Tests with a duration equal to the configured threshold are not reported.
- Tests whose duration exceeds the configured threshold are reported.
- Slow tests are sorted from slowest to fastest.
- Tests from all suites within the current spec report are considered.
- Runs without `slowThreshold` preserve the existing reporter output and behavior.
- Unit tests cover threshold filtering, exact-threshold behavior, ordering, and empty results.
- Reporter output tests cover the slow-test section.
- Type checking and the relevant package test suites pass.

## Further comments

AI disclosure: Claude Code (Anthropic) assisted with the investigation, implementation, and local validation for this GitHub account. Maintainer review is pending.

Could a TSC member confirm whether this contribution qualifies under the [non-project-member contribution expense policy](https://github.com/webdriverio/webdriverio/blob/main/GOVERNANCE.md#expenses-from-non-project-members), and the approved amount and claim requirements if accepted?

### Reviewers: @webdriverio/project-committers
