### PR TITLE
fix(wdio-utils): preserve sparse array length in async map

### DIFF
--- a/packages/wdio-utils/src/pIteration.ts
+++ b/packages/wdio-utils/src/pIteration.ts
@@ -54,6 +54,7 @@ export const forEachSeries = async <T>(array: T[], callback: Function, thisArg?:
  */
 export const map = async <T>(array: T[], callback: Function, thisArg?: T) => {
     const promiseArray = []
+    promiseArray.length = array.length
     for (let i = 0; i < array.length; i++) {
         if (i in array) {
             promiseArray[i] = Promise.resolve(array[i]).then((currentValue) => {
@@ -73,6 +74,7 @@ export const map = async <T>(array: T[], callback: Function, thisArg?: T) => {
  */
 export const mapSeries = async <T>(array: T[], callback: Function, thisArg?: T) => {
     const result = []
+    result.length = array.length
     for (let i = 0; i < array.length; i++) {
         if (i in array) {
             result[i] = await callback.call(thisArg || this, await array[i], i, array)

--- a/packages/wdio-utils/src/pIteration.ts
+++ b/packages/wdio-utils/src/pIteration.ts
@@ -53,16 +53,19 @@ export const forEachSeries = async <T>(array: T[], callback: Function, thisArg?:
  * @return {Promise} - Returns a Promise with the resultant *Array* as value.
  */
 export const map = async <T>(array: T[], callback: Function, thisArg?: T) => {
+    const result = new Array(array.length)
     const promiseArray = []
-    promiseArray.length = array.length
     for (let i = 0; i < array.length; i++) {
         if (i in array) {
-            promiseArray[i] = Promise.resolve(array[i]).then((currentValue) => {
+            promiseArray.push(Promise.resolve(array[i]).then((currentValue) => {
                 return callback.call(thisArg || this, currentValue, i, array)
-            })
+            }).then((value) => {
+                result[i] = value
+            }))
         }
     }
-    return Promise.all(promiseArray)
+    await Promise.all(promiseArray)
+    return result
 }
 
 /**

--- a/packages/wdio-utils/tests/pIteration.test.ts
+++ b/packages/wdio-utils/tests/pIteration.test.ts
@@ -167,6 +167,36 @@ test('map should skip holes in arrays', async () => {
     expect(count).toBe(4)
 })
 
+test.each(Object.entries({ map, mapSeries }))('%s preserves length and skips holes in sparse arrays', async (_, iterator) => {
+    const input = new Array<number | undefined>(5)
+    input[1] = 2
+    input[2] = undefined
+    const visited: number[] = []
+
+    const result = await iterator(input, async (value: number | undefined, index: number) => {
+        visited.push(index)
+        return value === undefined ? 'explicit undefined' : value * 2
+    })
+
+    expect(result).toHaveLength(5)
+    expect(result[1]).toBe(4)
+    expect(result[2]).toBe('explicit undefined')
+    expect(visited).toEqual([1, 2])
+    expect(input).toHaveLength(5)
+    expect(Object.keys(input)).toEqual(['1', '2'])
+})
+
+test.each(Object.entries({ map, mapSeries }))('%s preserves length of arrays containing only holes', async (_, iterator) => {
+    let count = 0
+    const result = await iterator(new Array(3), async () => {
+        count++
+        return 'unexpected'
+    })
+
+    expect(result).toHaveLength(3)
+    expect(count).toBe(0)
+})
+
 test('find', async () => {
     const foundNum = await find([1, 2, 3], async (num: number, index: number, array: number[]) => {
         await delay()

--- a/packages/wdio-utils/tests/pIteration.test.ts
+++ b/packages/wdio-utils/tests/pIteration.test.ts
@@ -175,12 +175,19 @@ test.each(Object.entries({ map, mapSeries }))('%s preserves length and skips hol
 
     const result = await iterator(input, async (value: number | undefined, index: number) => {
         visited.push(index)
-        return value === undefined ? 'explicit undefined' : value * 2
+        return value === undefined ? undefined : value * 2
     })
 
     expect(result).toHaveLength(5)
     expect(result[1]).toBe(4)
-    expect(result[2]).toBe('explicit undefined')
+    expect(result[2]).toBeUndefined()
+    expect(Object.keys(result)).toEqual(['1', '2'])
+    expect(0 in result).toBe(false)
+    expect(2 in result).toBe(true)
+    expect(4 in result).toBe(false)
+    const resultIndexes: number[] = []
+    result.forEach((_, index) => resultIndexes.push(index))
+    expect(resultIndexes).toEqual([1, 2])
     expect(visited).toEqual([1, 2])
     expect(input).toHaveLength(5)
     expect(Object.keys(input)).toEqual(['1', '2'])
@@ -194,6 +201,7 @@ test.each(Object.entries({ map, mapSeries }))('%s preserves length of arrays con
     })
 
     expect(result).toHaveLength(3)
+    expect(Object.keys(result)).toEqual([])
     expect(count).toBe(0)
 })
 


### PR DESCRIPTION
## Proposed changes

Preserve the input array length in `map()` and `mapSeries()` when mapping sparse arrays. Previously, an array such as 
`[1, , ,]` produced a result of length 1 instead of 3.

Initialize the result arrays with the input length while continuing to skip holes when invoking callbacks. Add regression tests for trailing holes, arrays containing only holes, and explicit `undefined` values.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

All four new regression cases fail before the fix and pass afterward. All 80 iterator tests pass, and ESLint passes for both changed files.

No documentation or public type changes are needed: this restores the documented length-preservation behavior. Backport applicability has not been assessed.

### Reviewers: @webdriverio/project-committers