### PR TITLE
fix(@wdio/utils): settle predicates for arrays containing only holeslement

### DIFF
--- a/packages/wdio-utils/src/pIteration.ts
+++ b/packages/wdio-utils/src/pIteration.ts
@@ -211,6 +211,9 @@ export const some = <T>(array: T[], callback: Function, thisArg?: T) => {
                 .then(check)
                 .catch(reject)
         }
+        if (counter === array.length + 1) {
+            resolve(false)
+        }
     })
 }
 
@@ -263,6 +266,9 @@ export const every = <T>(array: T[], callback: Function, thisArg?: T) => {
                 .then((elem) => callback.call(thisArg || this, elem, i, array))
                 .then(check)
                 .catch(reject)
+        }
+        if (counter === array.length + 1) {
+            resolve(true)
         }
     })
 }

--- a/packages/wdio-utils/tests/pIteration.test.ts
+++ b/packages/wdio-utils/tests/pIteration.test.ts
@@ -7,6 +7,20 @@ import {
 
 const delay = (ms?: number) => new Promise(resolve => setTimeout(() => resolve(ms), ms || 0))
 
+test('some resolves false for an array containing only holes', async () => {
+    const result = await some(new Array(3), () => {
+        throw new Error('callback should not run for a hole')
+    })
+    expect(result).toBe(false)
+}, 1000)
+
+test('every resolves true for an array containing only holes', async () => {
+    const result = await every(new Array(3), () => {
+        throw new Error('callback should not run for a hole')
+    })
+    expect(result).toBe(true)
+}, 1000)
+
 test('forEach, check callbacks are run in parallel', async () => {
     let total = 0
     const parallelCheck: number[] = []


### PR DESCRIPTION
New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
## Proposed changes

`some(new Array(3), callback)` and `every(new Array(3), callback)` never settle. All slots are skipped, so no callback reaches the completion check.

Resolve the result after scheduling when every slot was skipped: `false` for `some`, `true` for `every`. Two regression tests reproduce the hang and verify that callbacks are not invoked for holes.

## Types of changes

- [x] Bugfix

## Validation

The two regressions time out before the fix. All 78 iterator tests and ESLint pass afterward. Scoped TypeScript checking passes for the implementation; the iterator test file reports type errors in unrelated thisArg/reduce tests, so no full typecheck pass is claimed.

Commands: `vitest run packages/wdio-utils/tests/pIteration.test.ts --typecheck.enabled=false` and `eslint packages/wdio-utils/src/pIteration.ts packages/wdio-utils/tests/pIteration.test.ts`.