### PR TITLE
feat(utils): support conditional worker service activation

### DIFF
--- a/packages/wdio-types/src/Services.ts
+++ b/packages/wdio-types/src/Services.ts
@@ -32,11 +32,27 @@ export interface ServiceOption {
 
 export interface ServiceClass {
     new(options: WebdriverIO.ServiceOption, capabilities: ResolvedTestrunnerCapabilities, config: WebdriverIOOptions): ServiceInstance
+    /**
+     * Runs in a worker before construction. Return false to skip this service for the worker.
+     */
+    shouldRun?(
+        options: WebdriverIO.ServiceOption,
+        capabilities: ResolvedTestrunnerCapabilities,
+        config: WebdriverIOOptions
+    ): boolean | Promise<boolean>
 }
 
 export interface ServicePlugin extends ServiceClass {
     default: ServiceClass
     launcher?: ServiceClass
+    /**
+     * Runs once per package in the launcher. Return false to skip importing the package in workers.
+     * Launcher services are still initialized.
+     */
+    shouldLoad?(
+        config: Omit<TestrunnerOptions, 'capabilities' | keyof HookFunctions>,
+        capabilities: TestrunnerCapabilities
+    ): boolean | Promise<boolean>
 }
 
 export interface ServiceInstance extends HookFunctions {

--- a/packages/wdio-utils/src/initializeServices.ts
+++ b/packages/wdio-utils/src/initializeServices.ts
@@ -98,7 +98,8 @@ export async function initializeLauncherService (
     ignoredWorkerServices: string[];
     launcherServices: Services.ServiceInstance[];
 }> {
-    const ignoredWorkerServices = []
+    const ignoredWorkerServices: string[] = []
+    const workerServiceLoadDecisions = new Map<Services.ServicePlugin, boolean>()
     const launcherServices: Services.ServiceInstance[] = []
     let serviceLabelToBeInitialised = 'unknown'
 
@@ -132,13 +133,26 @@ export async function initializeLauncherService (
             }
 
             /**
+             * Package-wide activation decisions are made once in the launcher, so disabled
+             * packages need not be imported into any workers. Launcher hooks are unaffected.
+             */
+            const servicePlugin = service as Services.ServicePlugin
+            if (serviceName && typeof servicePlugin.shouldLoad === 'function' && !workerServiceLoadDecisions.has(servicePlugin)) {
+                serviceLabelToBeInitialised = `"${serviceName}"`
+                workerServiceLoadDecisions.set(servicePlugin, await servicePlugin.shouldLoad(config, caps) !== false)
+            }
+
+            /**
              * check if service has a default export, if not we can later filter it out so the
              * service module is not even loaded in the worker process
              */
             if (
                 serviceName &&
-                typeof (service as { default: Function }).default !== 'function' &&
-                typeof service !== 'function'
+                (
+                    (typeof servicePlugin.default !== 'function' && typeof service !== 'function') ||
+                    workerServiceLoadDecisions.get(servicePlugin) === false
+                ) &&
+                !ignoredWorkerServices.includes(serviceName)
             ) {
                 ignoredWorkerServices.push(serviceName)
             }
@@ -183,7 +197,10 @@ export async function initializeWorkerService (
 
             const Service = (service as Services.ServicePlugin).default || service as Services.ServiceClass
             if (typeof Service === 'function') {
-                serviceLabelToBeInitialised = serviceName || Service.constructor?.name || Service.toString()
+                serviceLabelToBeInitialised = serviceName || Service.name || Service.toString()
+                if (typeof Service.shouldRun === 'function' && await Service.shouldRun(serviceConfig, caps, config) === false) {
+                    continue
+                }
                 initializedServices.push(new Service(serviceConfig, caps, config))
                 continue
             }

--- a/packages/wdio-utils/tests/initializeServices.test.ts
+++ b/packages/wdio-utils/tests/initializeServices.test.ts
@@ -217,3 +217,272 @@ describe('initializeWorkerService', () => {
         )).rejects.toThrow(/Failed to initialise service borked: Error: ups/)
     })
 })
+
+describe('service activation', () => {
+    describe('shouldLoad', () => {
+        it.each([
+            ['synchronous false', () => false, false],
+            ['asynchronous false', async () => false, false],
+            ['synchronous true', () => true, true],
+            ['asynchronous true', async () => true, true],
+            ['no explicit decision', () => undefined, true]
+        ] as const)('handles %s without disabling the launcher', async (_name, predicate, enabled) => {
+            const shouldLoad = vi.fn(predicate)
+            const launcherConstructor = vi.fn()
+            const workerConstructor = vi.fn()
+            vi.mocked(safeImport).mockResolvedValue({
+                shouldLoad,
+                launcher: class {
+                    constructor (...args: unknown[]) {
+                        launcherConstructor(...args)
+                    }
+                },
+                default: class {
+                    constructor (...args: unknown[]) {
+                        workerConstructor(...args)
+                    }
+                }
+            } as any)
+            const options = { endpoint: 'http://localhost:4444' }
+            const config = { services: [['conditional', options]], baseUrl: 'http://localhost' } as WebdriverIO.Config
+            const caps = [{ browserName: 'chrome' }, { browserName: 'firefox' }]
+
+            const { launcherServices, ignoredWorkerServices } = await initializeLauncherService(config, caps)
+
+            expect(shouldLoad).toHaveBeenCalledExactlyOnceWith(config, caps)
+            expect(launcherServices).toHaveLength(1)
+            expect(launcherConstructor).toHaveBeenCalledExactlyOnceWith(options, caps, config)
+            expect(workerConstructor).not.toHaveBeenCalled()
+            expect(ignoredWorkerServices).toEqual(enabled ? [] : ['conditional'])
+
+            vi.mocked(safeImport).mockClear()
+            const workerServices = await initializeWorkerService(config, caps[0], ignoredWorkerServices)
+            expect(workerServices).toHaveLength(enabled ? 1 : 0)
+            expect(safeImport).toHaveBeenCalledTimes(enabled ? 1 : 0)
+            expect(workerConstructor).toHaveBeenCalledTimes(enabled ? 1 : 0)
+            expect(shouldLoad).toHaveBeenCalledTimes(1)
+        })
+
+        it('uses one package-wide decision for duplicate service entries', async () => {
+            const shouldLoad = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+            const launcherConstructor = vi.fn()
+            vi.mocked(safeImport).mockResolvedValue({
+                shouldLoad,
+                launcher: class {
+                    constructor (...args: unknown[]) {
+                        launcherConstructor(...args)
+                    }
+                },
+                default: class {}
+            } as any)
+            const firstOptions = { name: 'first' }
+            const secondOptions = { name: 'second' }
+            const config = { services: [['conditional', firstOptions], ['conditional', secondOptions]] } as WebdriverIO.Config
+            const caps = [{ browserName: 'chrome' }]
+
+            const { launcherServices, ignoredWorkerServices } = await initializeLauncherService(config, caps)
+
+            expect(shouldLoad).toHaveBeenCalledExactlyOnceWith(config, caps)
+            expect(launcherServices).toHaveLength(2)
+            expect(launcherConstructor).toHaveBeenNthCalledWith(1, firstOptions, caps, config)
+            expect(launcherConstructor).toHaveBeenNthCalledWith(2, secondOptions, caps, config)
+            expect(ignoredWorkerServices).toEqual(['conditional'])
+
+            vi.mocked(safeImport).mockClear()
+            expect(await initializeWorkerService(config, caps[0], ignoredWorkerServices)).toEqual([])
+            expect(safeImport).not.toHaveBeenCalled()
+        })
+
+        it('shares one package decision across aliases of the same imported module', async () => {
+            const shouldLoad = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+            const serviceModule = { default: class {}, shouldLoad }
+            vi.mocked(safeImport).mockResolvedValue(serviceModule as any)
+            const config = { services: ['sauce', '@wdio/sauce-service'] }
+            const caps = [{ browserName: 'chrome' }]
+
+            const { ignoredWorkerServices } = await initializeLauncherService(config, caps)
+
+            expect(shouldLoad).toHaveBeenCalledExactlyOnceWith(config, caps)
+            expect(ignoredWorkerServices).toEqual(['sauce', '@wdio/sauce-service'])
+
+            vi.mocked(safeImport).mockClear()
+            expect(await initializeWorkerService(config, caps[0], ignoredWorkerServices)).toEqual([])
+            expect(safeImport).not.toHaveBeenCalled()
+        })
+
+        it('keeps package decisions independent and reevaluates them for each launcher', async () => {
+            const firstShouldLoad = vi.fn().mockReturnValueOnce(false).mockReturnValueOnce(true)
+            const secondShouldLoad = vi.fn().mockReturnValueOnce(true).mockReturnValueOnce(false)
+            const packages = {
+                first: { default: class {}, shouldLoad: firstShouldLoad },
+                second: { default: class {}, shouldLoad: secondShouldLoad }
+            }
+            vi.mocked(safeImport).mockImplementation(async (name) => packages[name as keyof typeof packages] as any)
+            const config = { services: ['first', 'second'] }
+            const caps = [{ browserName: 'chrome' }]
+
+            const firstLaunch = await initializeLauncherService(config, caps)
+            expect(firstLaunch.ignoredWorkerServices).toEqual(['first'])
+
+            vi.mocked(safeImport).mockClear()
+            const services = await initializeWorkerService(config, caps[0], firstLaunch.ignoredWorkerServices)
+            expect(services).toHaveLength(1)
+            expect(services[0]).toBeInstanceOf(packages.second.default)
+            expect(safeImport).toHaveBeenCalledExactlyOnceWith('second')
+
+            const secondLaunch = await initializeLauncherService(config, caps)
+            expect(secondLaunch.ignoredWorkerServices).toEqual(['second'])
+            expect(firstShouldLoad).toHaveBeenCalledTimes(2)
+            expect(secondShouldLoad).toHaveBeenCalledTimes(2)
+        })
+
+        it.each([false, 'disabled', undefined])('ignores a nonfunction shouldLoad export (%s)', async (shouldLoad) => {
+            vi.mocked(safeImport).mockResolvedValue({ default: class {}, shouldLoad } as any)
+
+            expect(await initializeLauncherService({ services: ['conditional'] }, {})).toEqual({
+                ignoredWorkerServices: [],
+                launcherServices: []
+            })
+        })
+
+        it('leaves worker shouldRun decisions out of launcher initialization', async () => {
+            const shouldRun = vi.fn().mockReturnValue(false)
+            vi.mocked(safeImport).mockResolvedValue({
+                default: class {
+                    static shouldRun = shouldRun
+                },
+                launcher: class {}
+            } as any)
+
+            const result = await initializeLauncherService({ services: ['conditional'] }, {})
+
+            expect(result.launcherServices).toHaveLength(1)
+            expect(result.ignoredWorkerServices).toEqual([])
+            expect(shouldRun).not.toHaveBeenCalled()
+        })
+
+        it.each([
+            ['throws', () => { throw new Error('activation failed') }],
+            ['rejects', async () => { throw new Error('activation failed') }]
+        ] as const)('identifies the package when shouldLoad %s', async (_name, shouldLoad) => {
+            vi.mocked(safeImport).mockResolvedValue({ default: class {}, shouldLoad } as any)
+
+            await expect(initializeLauncherService({ services: ['conditional'] }, {}))
+                .rejects.toThrow(/Failed to initialise launcher service "conditional": Error: activation failed/)
+        })
+    })
+
+    describe.each(['package default', 'CommonJS export', 'custom class'] as const)('shouldRun on a %s', (serviceType) => {
+        it.each([
+            ['synchronous false', () => false, false],
+            ['asynchronous false', async () => false, false],
+            ['synchronous true', () => true, true],
+            ['asynchronous true', async () => true, true],
+            ['no explicit decision', () => undefined, true],
+            ['absent predicate', undefined, true]
+        ] as const)('handles %s before constructing the worker service', async (_name, predicate, enabled) => {
+            const shouldRun = predicate && vi.fn(predicate)
+            const constructor = vi.fn()
+            class ConditionalService {
+                constructor (...args: unknown[]) {
+                    constructor(...args)
+                }
+
+                before () {}
+            }
+            if (shouldRun) {
+                Object.assign(ConditionalService, { shouldRun })
+            }
+            vi.mocked(safeImport).mockResolvedValue(
+                (serviceType === 'package default' ? { default: ConditionalService } : ConditionalService) as any
+            )
+            const service = serviceType === 'custom class' ? ConditionalService : 'conditional'
+            const options = { endpoint: 'http://localhost:4444' }
+            const config = { services: [[service, options]], baseUrl: 'http://localhost' } as WebdriverIO.Config
+            const caps = { browserName: 'firefox' }
+
+            const services = await initializeWorkerService(config, caps)
+
+            expect(services).toHaveLength(enabled ? 1 : 0)
+            if (shouldRun) {
+                expect(shouldRun).toHaveBeenCalledExactlyOnceWith(options, caps, config)
+            }
+            if (enabled) {
+                expect(services[0]).toBeInstanceOf(ConditionalService)
+                expect(constructor).toHaveBeenCalledExactlyOnceWith(options, caps, config)
+            } else {
+                expect(constructor).not.toHaveBeenCalled()
+            }
+            expect(safeImport).toHaveBeenCalledTimes(serviceType === 'custom class' ? 0 : 1)
+        })
+
+        it.each([
+            ['throws', () => { throw new Error('activation failed') }],
+            ['rejects', async () => { throw new Error('activation failed') }]
+        ] as const)('identifies the service when shouldRun %s', async (_name, shouldRun) => {
+            class ConditionalService {
+                static shouldRun = shouldRun
+                before () {}
+            }
+            vi.mocked(safeImport).mockResolvedValue(
+                (serviceType === 'package default' ? { default: ConditionalService } : ConditionalService) as any
+            )
+            const service = serviceType === 'custom class' ? ConditionalService : 'conditional'
+            const config = { services: [service] } as WebdriverIO.Config
+            const label = serviceType === 'custom class' ? 'ConditionalService' : 'conditional'
+
+            await expect(initializeWorkerService(config, {}))
+                .rejects.toThrow(`Failed to initialise service ${label}: Error: activation failed`)
+        })
+    })
+
+    it('evaluates shouldRun separately for each worker capability', async () => {
+        const shouldRun = vi.fn((_options, caps: WebdriverIO.Capabilities) => caps.browserName === 'chrome')
+        const constructor = vi.fn()
+        class ConditionalService {
+            static shouldRun = shouldRun
+            constructor (...args: unknown[]) {
+                constructor(...args)
+            }
+        }
+        vi.mocked(safeImport).mockResolvedValue({ default: ConditionalService } as any)
+        const options = { endpoint: 'http://localhost:4444' }
+        const config = { services: [['conditional', options]] } as WebdriverIO.Config
+        const firefox = { browserName: 'firefox' }
+        const chrome = { browserName: 'chrome' }
+
+        expect(await initializeWorkerService(config, firefox)).toEqual([])
+        expect(await initializeWorkerService(config, chrome)).toHaveLength(1)
+
+        expect(shouldRun).toHaveBeenCalledTimes(2)
+        expect(shouldRun).toHaveBeenNthCalledWith(1, options, firefox, config)
+        expect(shouldRun).toHaveBeenNthCalledWith(2, options, chrome, config)
+        expect(constructor).toHaveBeenCalledExactlyOnceWith(options, chrome, config)
+    })
+
+    it.each([false, 'disabled'])('ignores a nonfunction shouldRun property (%s)', async (shouldRun) => {
+        const Service = Object.assign(class {}, { shouldRun })
+        vi.mocked(safeImport).mockResolvedValue({ default: Service } as any)
+
+        const services = await initializeWorkerService({ services: ['conditional'] }, {})
+
+        expect(services).toHaveLength(1)
+        expect(services[0]).toBeInstanceOf(Service)
+    })
+
+    it('preserves preinitialized service objects without calling activation properties', async () => {
+        const service = { before: vi.fn(), shouldLoad: vi.fn(), shouldRun: vi.fn() }
+        const config = { services: [service] }
+
+        const { launcherServices, ignoredWorkerServices } = await initializeLauncherService(config, {})
+        const workerServices = await initializeWorkerService(config, {}, ignoredWorkerServices)
+
+        expect(launcherServices).toEqual([service])
+        expect(workerServices).toEqual([service])
+        expect(launcherServices[0]).toBe(service)
+        expect(workerServices[0]).toBe(service)
+        expect(service.shouldLoad).not.toHaveBeenCalled()
+        expect(service.shouldRun).not.toHaveBeenCalled()
+        expect(safeImport).not.toHaveBeenCalled()
+    })
+})

--- a/packages/wdio-utils/tests/serviceActivation.test-d.ts
+++ b/packages/wdio-utils/tests/serviceActivation.test-d.ts
@@ -1,0 +1,75 @@
+import { expectTypeOf, test } from 'vitest'
+import type { Capabilities, Options, Services } from '@wdio/types'
+
+type ShouldLoad = NonNullable<Services.ServicePlugin['shouldLoad']>
+type ShouldRun = NonNullable<Services.ServiceClass['shouldRun']>
+
+test('package activation receives launcher config and all capabilities', () => {
+    const shouldLoad: ShouldLoad = (config, capabilities) => {
+        expectTypeOf(config).toEqualTypeOf<Omit<Options.Testrunner, 'capabilities' | keyof Services.HookFunctions>>()
+        expectTypeOf(capabilities).toEqualTypeOf<Capabilities.TestrunnerCapabilities>()
+        return true
+    }
+    const shouldLoadAsync: ShouldLoad = async (config, capabilities) => shouldLoad(config, capabilities)
+
+    class Service {
+        before () {}
+    }
+
+    const syncPlugin = Object.assign(Service, { default: Service, shouldLoad })
+    const asyncPlugin = Object.assign(Service, { default: Service, shouldLoad: shouldLoadAsync })
+
+    expectTypeOf(syncPlugin).toExtend<Services.ServicePlugin>()
+    expectTypeOf(asyncPlugin).toExtend<Services.ServicePlugin>()
+    expectTypeOf<ShouldLoad>().returns.toEqualTypeOf<boolean | Promise<boolean>>()
+})
+
+test('worker activation is compatible with service constructors and typed arguments', () => {
+    const shouldRun: ShouldRun = (options, capabilities, config) => {
+        expectTypeOf(options).toEqualTypeOf<WebdriverIO.ServiceOption>()
+        expectTypeOf(capabilities).toEqualTypeOf<Capabilities.ResolvedTestrunnerCapabilities>()
+        expectTypeOf(config).toEqualTypeOf<Options.WebdriverIO>()
+        return true
+    }
+    const shouldRunAsync: ShouldRun = async (options, capabilities, config) => shouldRun(options, capabilities, config)
+
+    class Service {
+        static shouldRun = shouldRun
+
+        constructor (
+            options: WebdriverIO.ServiceOption,
+            capabilities: Capabilities.ResolvedTestrunnerCapabilities,
+            config: Options.WebdriverIO
+        ) {
+            expectTypeOf(shouldRun).toBeCallableWith(options, capabilities, config)
+        }
+
+        before () {}
+    }
+
+    const asyncService = Object.assign(class { before () {} }, { shouldRun: shouldRunAsync })
+    class LegacyService {
+        before () {}
+    }
+
+    expectTypeOf(Service).toExtend<Services.ServiceClass>()
+    expectTypeOf(asyncService).toExtend<Services.ServiceClass>()
+    expectTypeOf(LegacyService).toExtend<Services.ServiceClass>()
+    expectTypeOf<ShouldRun>().returns.toEqualTypeOf<boolean | Promise<boolean>>()
+})
+
+test('activation predicates require a boolean or a promise of boolean', () => {
+    // @ts-expect-error package activation cannot return a string
+    const invalidShouldLoad: ShouldLoad = () => 'enabled'
+    // @ts-expect-error asynchronous package activation cannot return a number
+    const invalidAsyncShouldLoad: ShouldLoad = async () => 1
+    // @ts-expect-error worker activation cannot return a number
+    const invalidShouldRun: ShouldRun = () => 1
+    // @ts-expect-error asynchronous worker activation cannot return a string
+    const invalidAsyncShouldRun: ShouldRun = async () => 'enabled'
+
+    expectTypeOf(invalidShouldLoad).toEqualTypeOf<ShouldLoad>()
+    expectTypeOf(invalidAsyncShouldLoad).toEqualTypeOf<ShouldLoad>()
+    expectTypeOf(invalidShouldRun).toEqualTypeOf<ShouldRun>()
+    expectTypeOf(invalidAsyncShouldRun).toEqualTypeOf<ShouldRun>()
+})

--- a/website/docs/CustomServices.md
+++ b/website/docs/CustomServices.md
@@ -98,6 +98,51 @@ export default class CustomWorkerService implements Services.ServiceInstance {
 }
 ```
 
+## Conditional Worker Services
+
+A service can decide whether its worker code is needed for a test run or for a particular worker. There are two optional checks:
+
+| Check | Where it runs | Arguments | Effect of returning `false` |
+| --- | --- | --- | --- |
+| Named module export `shouldLoad` | Launcher process, after importing the service module | Configuration, all configured capabilities | The service module is not imported in any worker. Its launcher service still runs. |
+| Static worker service method `shouldRun` | Worker process, before constructing the service | Service options, that worker's capabilities, configuration | The worker service is not constructed, so none of its hooks run in that worker. |
+
+Use `shouldLoad(config, capabilities)` for service modules configured by name or path. This is a package-wide decision: if the same service appears more than once with different options, the result applies to all of those entries. For example, a custom service that requires remote credentials could export:
+
+```js
+// wdio-custom-service/index.js
+import CustomLauncherService from './launcher.js'
+import CustomWorkerService from './service.js'
+
+export function shouldLoad(config, capabilities) {
+    return Boolean(config.user && config.key)
+}
+
+export default CustomWorkerService
+export const launcher = CustomLauncherService
+```
+
+Use `static shouldRun(options, capabilities, config)` to decide separately for each service entry and worker. It also works with custom service classes passed directly in `services`. For example, this service can restrict its hooks to a configured browser:
+
+```js
+// wdio-custom-service/service.js
+export default class CustomWorkerService {
+    static shouldRun(options, capabilities, config) {
+        return !options.browserName || options.browserName === capabilities.browserName
+    }
+
+    before(capabilities, specs, browser) {
+        // Runs only in workers that passed shouldRun.
+    }
+}
+```
+
+With `services: [['custom', { browserName: 'chrome' }]]`, this worker service is constructed only for Chrome capabilities, provided the package's `shouldLoad` check also allows it. The worker must import the service module to call `shouldRun`; returning `false` from this method does not prevent that import or affect the launcher service.
+
+Both checks can return a boolean or a promise of a boolean. WebdriverIO awaits each result, and only `false` disables loading or construction. Services without these checks keep their existing behavior. Already constructed service objects containing hooks are unchanged.
+
+If either check throws or rejects, service initialization fails with an error identifying the service. This differs from errors thrown by service hooks, described below.
+
 ## Service Error Handling
 
 An Error thrown during a service hook will be logged while the runner continues. If a hook in your service is critical to the setup or teardown of the test runner, the `SevereServiceError` exposed from the `webdriverio` package can be used to stop the runner.


### PR DESCRIPTION
## Proposed changes

Fixes #10039.

Services currently have to decide inside their hooks whether they are relevant to a run. Add two optional activation checks so service authors can avoid unnecessary worker imports and construction:

- A named `shouldLoad(config, capabilities)` export runs in the launcher. Returning `false` excludes the module from worker imports while preserving its launcher service. The decision is shared by entries and aliases that resolve to the same module.
- A worker service's static `shouldRun(options, capabilities, config)` method runs before its constructor. Returning `false` skips that instance for the worker's capability. This also supports custom service classes.

Both checks support synchronous or asynchronous decisions. Only explicit `false` disables a service; services without these checks and preconstructed hook objects keep their existing behavior. Predicate errors retain service context, including custom class names. The public types and custom-service guide describe both stages.

## Types of changes

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added proper type definitions for new commands (if appropriate)

## Backport Request

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Validation

- Complete `@wdio/utils` Vitest suite: 15 files, 326 tests passed, including three compile-time cases; no type errors.
- Service initialization suite: 56 tests passed, including 42 new runtime cases. The original implementation fails 32 of these cases; restoring the exact fix passes all 56.
- Repository compiler: affected `@wdio/types` and `@wdio/utils` builds, including declaration generation, passed. Core dependency builds also passed.
- Standalone TypeScript check of `@wdio/types`: passed.
- ESLint on the changed TypeScript files and `git diff --check`: passed.
- Additional temporary ESM/CommonJS fixtures ran through the built package in separate launcher and worker Node processes. They confirmed disabled packages are not imported in workers, launcher constructors still run, and worker-specific decisions select the correct constructors.

Dependencies were restored with the pinned pnpm version and frozen lockfile. No browser, device, or live cloud-service test was run, and existing cloud services are not changed to opt in automatically.

## Further comments

Prepared and tested with OpenAI Codex, including independent code review. Please consider this contribution under the project's contributor compensation program, subject to maintainer review and eligibility.

### Reviewers: @webdriverio/project-committers
