### PR TITLE
fix(wdio-sumologic-reporter): Throw on http status different than ok

### DIFF
--- a/packages/wdio-sumologic-reporter/src/index.ts
+++ b/packages/wdio-sumologic-reporter/src/index.ts
@@ -180,6 +180,10 @@ export default class SumoLogicReporter extends WDIOReporter {
                 body: JSON.stringify(logLines)
             })
 
+            if (!resp.ok) {
+                throw new Error(`Sumo Logic responded with ${resp.status}`)
+            }
+
             this._retryDelay = 0
             this._nextRetryAt = 0
 

--- a/packages/wdio-sumologic-reporter/tests/reporter.test.ts
+++ b/packages/wdio-sumologic-reporter/tests/reporter.test.ts
@@ -17,7 +17,8 @@ describe('wdio-sumologic-reporter', () => {
     let reporter: SumoLogicReporter
 
     beforeEach(() => {
-        vi.mocked(fetch).mockClear()
+        vi.mocked(fetch).mockReset()
+        vi.mocked(fetch).mockResolvedValue({ ok: true, status: 200 } as Response)
         vi.mocked(logger('').error).mockClear()
         reporter = new SumoLogicReporter({})
     })
@@ -87,6 +88,10 @@ describe('wdio-sumologic-reporter', () => {
     it('should sync', async () => {
         reporter['_options'].sourceAddress = 'http://localhost:1234'
         reporter.onRunnerStart('onRunnerStart' as any)
+        vi.mocked(fetch).mockResolvedValue({
+            ok: true,
+            status: 200
+        } as Response)
         await reporter.sync()
 
         expect(vi.mocked(fetch).mock.calls).toHaveLength(1)
@@ -98,8 +103,32 @@ describe('wdio-sumologic-reporter', () => {
         expect(reporter['_unsynced']).toHaveLength(0)
     })
 
+    it.each([400, 429, 500])('should retain logs and schedule a retry for HTTP %i',
+        async (status) => {
+            reporter['_options'].sourceAddress = 'http://localhost:1234'
+            reporter.onRunnerStart('onRunnerStart' as any)
+
+            vi.mocked(fetch).mockResolvedValue({
+                ok: false,
+                status,
+                statusText: 'Request failed'
+            } as Response)
+
+            await reporter.sync()
+
+            expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1)
+            expect(reporter['_unsynced']).toHaveLength(1)
+            expect(reporter['_retryDelay']).toBe(100)
+
+            await reporter.sync()
+            expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1)
+
+        }
+    )
+
     it('should log if it fails syncing', async () => {
         vi.mocked(logger('').error).mockClear()
+        vi.mocked(fetch).mockRejectedValue(new Error('network error'))
 
         reporter['_options'].sourceAddress = 'http://localhost:1234/sumoerror'
         reporter.onRunnerStart('onRunnerStart' as any)
@@ -132,7 +161,7 @@ describe('wdio-sumologic-reporter', () => {
             }
         }
 
-        vi.mocked(fetch).mockResolvedValue({ status: 200 } as Response)
+        vi.mocked(fetch).mockResolvedValue({ ok: true, status: 200 } as Response)
         vi.setSystemTime(3499)
         await reporter.sync()
         expect(vi.mocked(fetch)).toHaveBeenCalledTimes(6)
@@ -160,6 +189,7 @@ describe('wdio-sumologic-reporter', () => {
         reporter = new SumoLogicReporter({ sourceAddress: 'http://localhost:1234' })
         reporter.onRunnerStart('onRunnerStart' as any)
         reporter.onRunnerEnd('onRunnerStart' as any)
+
         expect(clearInterval).toBeCalledTimes(0)
         await reporter.sync()
         expect(clearInterval).toBeCalledTimes(0)


### PR DESCRIPTION
## Proposed changes

Treat non-2xx responses from the Sumo Logic collector as failed syncs.

The reporter now keeps the pending log batch and uses the existing retry backoff instead of removing logs after HTTP errors. Added tests for HTTP 400, 429, and 500 responses.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments
This change does not introduce status-specific handling for permanent client errors such as `400`, `401`, `403`, or `404`.

All non-2xx responses currently use the existing retry backoff so that pending test logs are not discarded. A separate policy for disabling the reporter or failing fast on configuration/authentication errors is intentionally out of scope for this bugfix.

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
