### PR TITLE
fix(e2e): stop mistaking a stray mousemove for the result of moveTo()

### DIFF
--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -254,28 +254,44 @@ describe('main suite 1', () => {
             }
         }) as unknown as Promise<Point>
 
+        const getMousePosition = () => browser.execute(
+            () => (window as unknown as { mouseMoveTo: Point }).mouseMoveTo
+        ) as unknown as Promise<Point>
+
         /**
-         * Waiting for "any mousemove" is not enough: a headed browser also emits one
-         * when the page renders under the OS cursor, and that stray event was being
-         * mistaken for the result of our own move, which is what made this test flake
-         * on the Windows CI runner. Wait for the position we actually expect, which no
-         * unrelated event can satisfy.
+         * A measurement has to satisfy two things, and neither alone is enough:
+         *
+         * - a mousemove must have fired *since* `countBefore`, otherwise the pointer
+         *   already sitting on the target would let a `moveTo()` that does nothing
+         *   pass, which is what makes the no-offset case worth asserting at all
+         * - it must report the position we expect, otherwise the mousemove a headed
+         *   browser emits when the page renders under the OS cursor gets mistaken for
+         *   the result of our own move - the race this test used to flake on
          */
-        const waitForMouseAt = async (expected: Point) => {
-            let actual: Point = { x: -1, y: -1 }
-            await browser.waitUntil(
-                async () => {
-                    actual = await browser.execute(
-                        () => (window as unknown as { mouseMoveTo: Point }).mouseMoveTo
-                    ) as unknown as Point
-                    return actual.x === expected.x && actual.y === expected.y
-                },
-                {
-                    timeout: 5000,
-                    timeoutMsg: `expected the mouse at (${expected.x}, ${expected.y}) after moveTo(), last saw (${actual.x}, ${actual.y})`
-                }
-            )
-            return actual
+        const waitForMouseAt = async (expected: Point, countBefore: number) => {
+            let actual: Point | undefined
+            try {
+                await browser.waitUntil(
+                    async () => {
+                        if ((await getMouseMoveCount()) <= countBefore) {
+                            return false
+                        }
+                        actual = await getMousePosition()
+                        return actual.x === expected.x && actual.y === expected.y
+                    },
+                    { timeout: 5000 }
+                )
+            } catch {
+                /**
+                 * build the message here, not in `timeoutMsg`: that is interpolated
+                 * when the options object is created, before any polling has happened
+                 */
+                throw new Error(
+                    `expected a mousemove putting the pointer at (${expected.x}, ${expected.y}) after moveTo(), ` +
+                    (actual ? `last saw (${actual.x}, ${actual.y})` : 'but no mousemove fired at all')
+                )
+            }
+            return actual as Point
         }
 
         beforeEach(async () => {
@@ -296,14 +312,16 @@ describe('main suite 1', () => {
         inputs.forEach((input) => {
             it(`moves to position x,y outside of iframe when passing the arguments ${JSON.stringify(input)}`, async () => {
                 await setupMouseTracking()
+                const countBeforeFirstMove = await getMouseMoveCount()
                 await browser.$('#parent').moveTo()
                 const center = await getInViewCenter()
-                const rectBefore = await waitForMouseAt(center)
+                const rectBefore = await waitForMouseAt(center, countBeforeFirstMove)
+                const countBeforeSecondMove = await getMouseMoveCount()
                 await browser.$('#parent').moveTo(input)
                 const rectAfter = await waitForMouseAt({
                     x: center.x + (input?.xOffset ?? 0),
                     y: center.y + (input?.yOffset ?? 0)
-                })
+                }, countBeforeSecondMove)
                 expect(rectBefore.x + (input && input?.xOffset ? input?.xOffset : 0)).toEqual(rectAfter.x)
                 expect(rectBefore.y + (input && input?.yOffset ? input?.yOffset : 0)).toEqual(rectAfter.y)
             })

--- a/e2e/wdio/headless/test.e2e.ts
+++ b/e2e/wdio/headless/test.e2e.ts
@@ -240,6 +240,44 @@ describe('main suite 1', () => {
             ) as unknown as Promise<{ x: number, y: number }>
         }
 
+        type Point = { x: number, y: number }
+
+        /**
+         * the in-view centre point WebDriver moves the pointer to, in the same
+         * coordinate space that `clientX`/`clientY` are reported in
+         */
+        const getInViewCenter = () => browser.execute(() => {
+            const r = document.querySelector('#parent')!.getBoundingClientRect()
+            return {
+                x: Math.floor(r.width / 2) + Math.floor(r.left),
+                y: Math.floor(r.height / 2) + Math.floor(r.top)
+            }
+        }) as unknown as Promise<Point>
+
+        /**
+         * Waiting for "any mousemove" is not enough: a headed browser also emits one
+         * when the page renders under the OS cursor, and that stray event was being
+         * mistaken for the result of our own move, which is what made this test flake
+         * on the Windows CI runner. Wait for the position we actually expect, which no
+         * unrelated event can satisfy.
+         */
+        const waitForMouseAt = async (expected: Point) => {
+            let actual: Point = { x: -1, y: -1 }
+            await browser.waitUntil(
+                async () => {
+                    actual = await browser.execute(
+                        () => (window as unknown as { mouseMoveTo: Point }).mouseMoveTo
+                    ) as unknown as Point
+                    return actual.x === expected.x && actual.y === expected.y
+                },
+                {
+                    timeout: 5000,
+                    timeoutMsg: `expected the mouse at (${expected.x}, ${expected.y}) after moveTo(), last saw (${actual.x}, ${actual.y})`
+                }
+            )
+            return actual
+        }
+
         beforeEach(async () => {
             await browser.url('https://guinea-pig.webdriver.io/pointer.html')
             await browser.$('#parent').waitForExist()
@@ -256,16 +294,16 @@ describe('main suite 1', () => {
         })
 
         inputs.forEach((input) => {
-            it(`moves to position x,y outside of iframe when passing the arguments ${JSON.stringify(input)}`, async function() {
-                // Unstable test, retry up to 3 times `Expected: 90 Received: 504` with when input = `{"xOffset":10}`
-                this.retries(3)
-
+            it(`moves to position x,y outside of iframe when passing the arguments ${JSON.stringify(input)}`, async () => {
                 await setupMouseTracking()
                 await browser.$('#parent').moveTo()
-                const rectBefore = await waitForMousePosition(0)
-                const countBeforeSecondMove = await getMouseMoveCount()
+                const center = await getInViewCenter()
+                const rectBefore = await waitForMouseAt(center)
                 await browser.$('#parent').moveTo(input)
-                const rectAfter = await waitForMousePosition(countBeforeSecondMove)
+                const rectAfter = await waitForMouseAt({
+                    x: center.x + (input?.xOffset ?? 0),
+                    y: center.y + (input?.yOffset ?? 0)
+                })
                 expect(rectBefore.x + (input && input?.xOffset ? input?.xOffset : 0)).toEqual(rectAfter.x)
                 expect(rectBefore.y + (input && input?.yOffset ? input?.yOffset : 0)).toEqual(rectAfter.y)
             })


### PR DESCRIPTION
## Proposed changes

Fixes a CI test case 

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
